### PR TITLE
Backbone factory overhaul: UNet support, centralized resolution, mp.spawn fix

### DIFF
--- a/CONFIG_REFACTOR_PLAN.md
+++ b/CONFIG_REFACTOR_PLAN.md
@@ -1325,3 +1325,50 @@ python test_smil_regressor_ground_truth.py \
 **Change**: `config.py` default SMAL_FILE changed from `SMILy_STICK.pkl` to `SMIL_OmniAnt.pkl` (the latest textured ant model).
 
 **Rationale**: OmniAnt is the maintained, feature-complete model for ant experiments. STICK remains available as a commented-out option for historical use.
+
+---
+
+## Implementation Status (as of 2026-03-24)
+
+### Phase Completion
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Phase 1: Create New Config System | **Complete** | All dataclasses, JSON loading, validation, and examples implemented. |
+| Phase 2: Update Training Scripts | **Complete** | Both `train_smil_regressor.py` and `train_multiview_regressor.py` use `load_config()`. Config exported at training start. |
+| Phase 3: Integration Testing | **Mostly complete** | `test_config_system.py` (445 lines) and `test_curriculum_sync.py` (82 lines) cover precedence, merging, and curriculum. Manual multi-view training validated. |
+| Phase 4: Deprecation & Cleanup | **Not started** | `training_config.py` still exists without deprecation warning. Inline `MultiViewTrainingConfig` class not yet removed from `train_multiview_regressor.py`. |
+
+### Additions Beyond Original Plan
+
+The following were not in the original plan but emerged from practical training needs:
+
+1. **UNet backbone family** — `backbone_factory.py` now supports `unet_efficientnet_b0`, `unet_efficientnet_b3`, `unet_resnet34`, `unet_mobilenet_v3` with encoder-decoder architecture, skip connections, and spatial feature extraction via `forward_with_spatial()`.
+
+2. **Memory optimization fields** — `TrainingHyperparameters` gained:
+   - `use_mixed_precision` (FP16 forward pass, FP32 weight updates)
+   - `backbone_chunk_size` (process backbone images in smaller batches to reduce peak VRAM)
+   - `gradient_accumulation_steps` (simulate larger effective batch sizes)
+
+3. **Three-tier joint control**:
+   - `joint_importance` — per-joint loss upweighting for important joints
+   - `ignored_joint_locations` — loss-level exclusion (joints stay in data but are not supervised)
+   - `ignored_joints` — data-preprocessing-level exclusion (joints removed entirely)
+
+4. **`mesh_scaling` section** — `allow_mesh_scaling`, `init_mesh_scale`, `use_log_scale` for global mesh scale prediction.
+
+5. **`multi_dataset` section** — Multi-dataset training with per-dataset weighting, label availability, and split strategy.
+
+6. **6 example configs** (plan had 2): `singleview_baseline.json`, `multiview_baseline.json`, `multiview_sticks.json`, `multiview_sticks_UNET.json`, `multiview_sticks_UNET_continue.json`, `multiview_mouse_UNET_long.json`.
+
+7. **`input_resolution` auto-detection** — `ModelConfig.get_input_resolution()` and `BackboneFactory.get_default_input_resolution()` centralize resolution lookup (224 for ViT, 512 for CNN/UNet).
+
+8. **`hidden_dim` auto-adjustment** — `ModelConfig.get_adjusted_hidden_dim()` picks a sensible decoder dimension per backbone family when not explicitly set.
+
+### Deviations from Plan
+
+1. **`smal_model` vs `legacy`** — The plan used `legacy` as the config section name for SMAL model overrides; implementation uses `smal_model` with automatic aliasing for clarity.
+
+2. **`to_multiview_legacy_dict()` bridge** — Rather than fully removing the flat-dict config pattern from `train_multiview_regressor.py`, a bridge method converts the dataclass config to the legacy dict format. This keeps the training loop code simpler at the cost of an extra conversion step.
+
+3. **Phase 4 deferred** — `training_config.py` deprecation was deprioritized in favour of backbone factory work and training stability fixes.

--- a/hpc_files/download_backbone_weights.py
+++ b/hpc_files/download_backbone_weights.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Pre-download backbone weights for offline use on HPC clusters.
+
+Run this script on a login node (with internet access) before submitting
+SLURM jobs.  It downloads and caches all pretrained weights used by
+BackboneFactory so that compute nodes can load them without network access.
+
+Usage:
+    # Download all backbone weights (default)
+    python download_backbone_weights.py
+
+    # Download only specific backbones
+    python download_backbone_weights.py --backbones resnet152 unet_efficientnet_b3
+
+    # List available backbones
+    python download_backbone_weights.py --list
+"""
+
+import argparse
+import sys
+import os
+
+# ── Backbone registry ──────────────────────────────────────────────────────
+# Maps backbone_factory.py names → (library, model_id) so we know how to
+# trigger the right download path.
+
+TORCHVISION_BACKBONES = {
+    "resnet50": "ResNet50_Weights.DEFAULT",
+    "resnet101": "ResNet101_Weights.DEFAULT",
+    "resnet152": "ResNet152_Weights.DEFAULT",
+}
+
+TIMM_BACKBONES = {
+    # ViT
+    "vit_base_patch16_224": "vit_base_patch16_224",
+    "vit_large_patch16_224": "vit_large_patch16_224",
+    # UNet encoder models
+    "unet_efficientnet_b0": "efficientnet_b0",
+    "unet_efficientnet_b3": "efficientnet_b3",
+    "unet_resnet34": "resnet34",
+    "unet_mobilenet_v3": "mobilenetv3_large_100",
+}
+
+ALL_BACKBONES = list(TORCHVISION_BACKBONES.keys()) + list(TIMM_BACKBONES.keys())
+
+
+def download_torchvision_backbone(name: str) -> None:
+    """Download a torchvision ResNet model to the default torch hub cache."""
+    import torchvision.models as models
+
+    print(f"  Loading torchvision model: {name} ...")
+    if name == "resnet50":
+        models.resnet50(weights=models.ResNet50_Weights.DEFAULT)
+    elif name == "resnet101":
+        models.resnet101(weights=models.ResNet101_Weights.DEFAULT)
+    elif name == "resnet152":
+        models.resnet152(weights=models.ResNet152_Weights.DEFAULT)
+    else:
+        raise ValueError(f"Unknown torchvision backbone: {name}")
+
+
+def download_timm_backbone(name: str, timm_model_id: str) -> None:
+    """Download a timm model to the default HuggingFace / timm cache."""
+    import timm
+
+    print(f"  Loading timm model: {timm_model_id} (for backbone '{name}') ...")
+    timm.create_model(timm_model_id, pretrained=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pre-download backbone weights for offline HPC use.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--backbones",
+        nargs="+",
+        choices=ALL_BACKBONES,
+        default=None,
+        metavar="NAME",
+        help=f"Backbone(s) to download. Default: all. Choices: {ALL_BACKBONES}",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available backbones and exit.",
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        print("Available backbones:")
+        print("\n  torchvision (ResNet):")
+        for name in TORCHVISION_BACKBONES:
+            print(f"    - {name}")
+        print("\n  timm (ViT):")
+        for name in TIMM_BACKBONES:
+            if name.startswith("vit"):
+                print(f"    - {name}")
+        print("\n  timm (UNet encoders):")
+        for name in TIMM_BACKBONES:
+            if name.startswith("unet_"):
+                print(f"    - {name}")
+        sys.exit(0)
+
+    selected = args.backbones if args.backbones else ALL_BACKBONES
+    total = len(selected)
+
+    print(f"Downloading {total} backbone weight(s) ...\n")
+
+    # Show cache locations
+    torch_hub = os.environ.get("TORCH_HOME", os.path.join(os.path.expanduser("~"), ".cache", "torch"))
+    hf_cache = os.environ.get("HF_HOME", os.path.join(os.path.expanduser("~"), ".cache", "huggingface"))
+    print(f"  Torch cache dir : {torch_hub}")
+    print(f"  HuggingFace cache dir: {hf_cache}")
+    print()
+
+    successes = 0
+    failures = []
+
+    for idx, name in enumerate(selected, 1):
+        progress = f"[{idx}/{total}]"
+        print(f"{progress} Downloading '{name}' ...")
+
+        try:
+            if name in TORCHVISION_BACKBONES:
+                download_torchvision_backbone(name)
+            elif name in TIMM_BACKBONES:
+                download_timm_backbone(name, TIMM_BACKBONES[name])
+            else:
+                print(f"  ERROR: Unknown backbone '{name}' — skipping.")
+                failures.append(name)
+                continue
+
+            print(f"{progress} '{name}' — done.\n")
+            successes += 1
+
+        except Exception as e:
+            print(f"{progress} '{name}' — FAILED: {e}\n")
+            failures.append(name)
+
+    # ── Summary ─────────────────────────────────────────────────────────────
+    print("=" * 60)
+    print(f"Downloaded {successes}/{total} backbone(s) successfully.")
+    if failures:
+        print(f"Failed: {failures}")
+        sys.exit(1)
+    else:
+        print("All weights cached. You can now run jobs without internet.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sleap_data_loader.py
+++ b/sleap_data_loader.py
@@ -1152,12 +1152,20 @@ class SLEAPDataLoader:
     def _extract_keypoint_names_from_slp(self, slp_file: Path) -> List[str]:
         """
         Extract keypoint names from a .slp file's metadata.
-        
+
+        SLEAP .slp files store two node lists:
+        - Top-level ``metadata['nodes']``: ordered by node **ID**, each entry has a ``name``.
+        - ``metadata['skeletons'][0]['nodes']``: ordered by skeleton **position**,
+          each entry has an ``id`` that references the top-level list.
+
+        ``pred_points`` in the .slp file are stored in skeleton position order,
+        so this method must return names in that same order.
+
         Args:
             slp_file: Path to the .slp file
-            
+
         Returns:
-            List of keypoint names, or empty list if extraction fails
+            List of keypoint names in skeleton position order, or empty list if extraction fails
         """
         with h5py.File(slp_file, 'r') as f:
             if 'metadata' in f:
@@ -1167,15 +1175,35 @@ class SLEAPDataLoader:
                     if isinstance(metadata_json, bytes):
                         metadata_json = metadata_json.decode('utf-8')
                     metadata = json.loads(metadata_json)
-                    
-                    # Extract node names from skeleton definition
-                    if 'nodes' in metadata:
-                        node_names = [node.get('name', f'node_{i}') 
-                                     for i, node in enumerate(metadata['nodes'])]
-                        print(f"Loaded {len(node_names)} keypoint names from .slp metadata")
+
+                    top_nodes = metadata.get('nodes', [])
+                    skeletons = metadata.get('skeletons', [])
+
+                    # Build an id→name lookup from the top-level nodes list
+                    id_to_name = {}
+                    for i, node in enumerate(top_nodes):
+                        name = node.get('name', f'node_{i}')
+                        id_to_name[i] = name
+
+                    # Resolve skeleton position order → name via node IDs
+                    if skeletons and 'nodes' in skeletons[0] and id_to_name:
+                        skel_nodes = skeletons[0]['nodes']
+                        node_names = []
+                        for skel_node in skel_nodes:
+                            nid = skel_node.get('id', None) if isinstance(skel_node, dict) else None
+                            if nid is not None and nid in id_to_name:
+                                node_names.append(id_to_name[nid])
+                            else:
+                                node_names.append(f'node_{len(node_names)}')
+                        print(f"Loaded {len(node_names)} keypoint names from .slp metadata (skeleton position order)")
                         return node_names
-        
-        return []
+
+                    # Fallback: no skeleton info, use top-level nodes in ID order
+                    if top_nodes:
+                        node_names = [node.get('name', f'node_{i}')
+                                     for i, node in enumerate(top_nodes)]
+                        print(f"Loaded {len(node_names)} keypoint names from .slp metadata (ID order, no skeleton)")
+                        return node_names
             
     def get_skeleton_structure(self) -> Tuple[List[Tuple[int, int]], List[Tuple[str, str]]]:
         """

--- a/smal_fitter/neuralSMIL/DECODER_ISSUES.md
+++ b/smal_fitter/neuralSMIL/DECODER_ISSUES.md
@@ -71,20 +71,42 @@ produced the failure.
 and inf values are clamped, but the computational graph is preserved so gradients
 still flow through non-NaN elements.
 
-### 5. No Multi-View Geometric Consistency for Camera Heads — FIXED
+### 5. No Multi-View Geometric Consistency for Camera Heads — IMPLEMENTED, DISABLED
 
 **Files:** `multiview_smil_regressor.py` (`_triangulate_joints_dlt`,
 `_compute_multiview_losses`)
 
-**Resolution:** Implemented a differentiable **triangulation consistency loss**
-that triangulates GT 2D keypoints using predicted cameras (via DLT with normal
-equations and Tikhonov damping) and compares the result against detached body
-model 3D predictions. Gradients flow through the differentiable triangulation
-into the camera heads. The loss ramps up via curriculum as direct camera
-supervision is phased out.
+**Implementation:** A differentiable **triangulation consistency loss** was
+implemented. It triangulates GT 2D keypoints using predicted cameras (via DLT
+with normal equations and Tikhonov damping) and compares the result against
+detached body model 3D predictions. Gradients flow through the differentiable
+triangulation into the camera heads.
 
 See [docs/triangulation_consistency_loss.md](docs/triangulation_consistency_loss.md)
-for full details. Validated with 12 synthetic tests in `tests/test_triangulation_consistency.py`.
+for full details. Validated with 12 synthetic tests in
+`tests/test_triangulation_consistency.py`.
+
+**Status: Disabled (`triangulation_consistency: 0.0` in all configs).**
+
+In practice the loss is **redundant with `keypoint_2d`**: both encode the same
+geometric constraint (GT 2D ↔ predicted cameras ↔ predicted 3D) — they differ
+only in functional form (DLT pseudo-inverse vs. forward projection). When one
+is satisfied, the other is too.
+
+It becomes **actively harmful when GT 2D labels are noisy** (e.g. from a 2D
+pose estimator). 3D GT is typically cleaner because multi-view triangulation
+averages out per-view noise. The `keypoint_3d` loss anchors the body model to
+that cleaner signal, but `triangulation_consistency` re-triangulates the noisy
+2D with still-learning cameras — injecting 2D noise directly into camera
+supervision.
+
+When **GT camera calibration is available** (`use_gt_camera_init: true`) with
+direct camera supervision (`cam_rot`, `cam_trans`, `fov` losses), the system is
+already geometrically consistent by construction. Any consistency loss is a
+no-op at best.
+
+**Leave at 0.0** unless all of: (1) clean 2D keypoints, (2) no GT camera
+calibration, and (3) no 3D keypoints. Even then, its value is marginal.
 
 ---
 
@@ -212,7 +234,7 @@ single-iteration baseline. The decoder fixes (#10 global feature injection,
 2. ~~**#2 (single-token cross-attention)**~~ — FIXED (V-token context).
 3. ~~**#3 (mean-pool bottleneck)**~~ — FIXED (resolved by #2).
 4. ~~**#4 (NaN clamping)**~~ — FIXED. `torch.nan_to_num`.
-5. ~~**#5 (geometric consistency)**~~ — FIXED. Triangulation consistency loss.
+5. ~~**#5 (geometric consistency)**~~ — IMPLEMENTED, DISABLED (redundant with `keypoint_2d`).
 6. ~~**#6 (curriculum complexity)**~~ — FIXED. Simplified schedule.
 7. ~~**#7 (batch size)**~~ — FIXED. Larger batches now feasible.
 8. **#8 (`global_rot` weight)** — BY DESIGN.

--- a/smal_fitter/neuralSMIL/README.md
+++ b/smal_fitter/neuralSMIL/README.md
@@ -263,6 +263,11 @@ Multi-view training uses SLEAP-exported HDF5 files containing synchronized frame
 - GT camera parameters (rotation, translation, FOV) per view
 - 3D keypoint ground truth
 
+**Important: Undistortion requirement.** All input images and 2D keypoints must be undistorted before training. PyTorch3D's `FoVPerspectiveCameras` uses an ideal pinhole model and does not support lens distortion (e.g. barrel distortion). To ensure consistency:
+- Images are undistorted during preprocessing using the camera's intrinsic matrix (K) and distortion coefficients via `cv2.undistort()`.
+- 2D keypoints (from `reprojections.h5`) are produced by projecting triangulated 3D points through the ideal pinhole model (`P = K @ [R|t]`, no distortion), so they are natively in undistorted pixel space.
+- The renderer's 2D projections and the ground truth 2D keypoints are thus in the same coordinate system, ensuring correct reprojection loss computation.
+
 ### Optimized Single-View HDF5 Format
 
 ```

--- a/smal_fitter/neuralSMIL/backbone_factory.py
+++ b/smal_fitter/neuralSMIL/backbone_factory.py
@@ -216,7 +216,11 @@ class ViTBackbone(BackboneInterface):
     def get_feature_dim(self) -> int:
         """Get ViT feature dimension."""
         return self.feature_dim
-    
+
+    def get_spatial_dim(self) -> int:
+        """Spatial feature dimension for patch tokens (same as feature_dim for ViT)."""
+        return self.feature_dim
+
     def freeze_weights(self) -> None:
         """Freeze ViT parameters."""
         for param in self.backbone.parameters():
@@ -236,15 +240,225 @@ class ViTBackbone(BackboneInterface):
         return list(self.backbone.parameters())
 
 
+class UNetDecodeBlock(nn.Module):
+    """Single UNet decoder block: bilinear upsample + skip-connection concat + double conv."""
+
+    def __init__(self, in_channels: int, skip_channels: int, out_channels: int):
+        super().__init__()
+        self.conv = nn.Sequential(
+            nn.Conv2d(in_channels + skip_channels, out_channels, 3, padding=1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_channels, out_channels, 3, padding=1, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor, skip: Optional[torch.Tensor] = None) -> torch.Tensor:
+        x = torch.nn.functional.interpolate(x, scale_factor=2, mode='bilinear', align_corners=False)
+        if skip is not None:
+            x = torch.cat([x, skip], dim=1)
+        return self.conv(x)
+
+
+class _UNetModule(nn.Module):
+    """Inner nn.Module combining encoder + decoder for BackboneInterface compatibility.
+
+    Storing both as a single nn.Module ensures that BackboneInterface.to(),
+    .parameters(), .eval(), and .train() all propagate to the whole UNet.
+    """
+
+    def __init__(self, encoder: nn.Module, decode_blocks: list, gap: nn.Module):
+        super().__init__()
+        self.encoder = encoder
+        self.decode_blocks = nn.ModuleList(decode_blocks)
+        self.gap = gap  # AdaptiveAvgPool2d(1) for bottleneck global features
+
+
+class UNetBackbone(BackboneInterface):
+    """
+    UNet backbone for high-resolution spatial feature extraction.
+
+    Uses a pretrained timm encoder (EfficientNet, ResNet, MobileNet…) with a
+    lightweight skip-connection decoder. Provides:
+      - ``forward(x)``               → global avg-pooled bottleneck: (B, feature_dim)
+      - ``forward_with_spatial(x)``  → (global_features, spatial_features)
+            global_features: (B, feature_dim)
+            spatial_features: (B, H*W, spatial_dim) — flattened decoder feature map
+
+    The decoder is always kept trainable even when the encoder is frozen.
+    This follows SLEAP's strategy: the pretrained encoder extracts semantic
+    features; the randomly-initialised decoder learns to recover spatial detail
+    for joint localisation.
+    """
+
+    # Maps registered backbone_name → timm encoder model name
+    _ENCODER_MAP: Dict[str, str] = {
+        'unet_efficientnet_b0': 'efficientnet_b0',
+        'unet_efficientnet_b3': 'efficientnet_b3',
+        'unet_resnet34': 'resnet34',
+        'unet_mobilenet_v3': 'mobilenetv3_large_100',
+    }
+
+    def __init__(self, model_name: str = 'unet_efficientnet_b3',
+                 pretrained: bool = True, freeze: bool = False,
+                 decoder_channels: Tuple[int, ...] = (256, 128, 64),
+                 spatial_level: int = 1):
+        """
+        Args:
+            model_name: Full UNet backbone name, e.g. 'unet_efficientnet_b3'.
+            pretrained: Whether to use ImageNet-pretrained encoder weights.
+            freeze: Whether to freeze encoder weights (decoder is always trained).
+            decoder_channels: Output channels for each decoder block (coarse→fine).
+                              Length determines how many upsampling steps are taken.
+            spatial_level: Which decoder block's output to expose as spatial context.
+                0 = coarsest (fewest tokens, deepest semantics)
+                len(decoder_channels)-1 = finest (most tokens)
+                Default 1 gives a good balance: ~784 tokens at 512×512 input.
+        """
+        super().__init__()
+
+        if not TIMM_AVAILABLE:
+            raise ImportError(
+                "timm library is required for UNet backbones. Install with: pip install timm"
+            )
+
+        encoder_name = self._ENCODER_MAP.get(model_name)
+        if encoder_name is None:
+            raise ValueError(
+                f"Unknown UNet backbone '{model_name}'. "
+                f"Supported: {list(self._ENCODER_MAP.keys())}"
+            )
+
+        self.model_name = model_name
+        self.freeze_weights_flag = freeze
+        self.spatial_level = spatial_level
+        self._decoder_channels = tuple(decoder_channels)
+
+        # ── Encoder ──────────────────────────────────────────────────────────
+        # features_only=True returns a list of feature maps at each stride,
+        # from finest (stride 2) to coarsest (stride 32).
+        encoder = timm.create_model(encoder_name, pretrained=pretrained, features_only=True)
+
+        # Probe encoder to discover per-stage channel counts dynamically.
+        with torch.no_grad():
+            _dummy = torch.zeros(1, 3, 64, 64)
+            _dummy_feats = encoder(_dummy)
+        enc_channels = [f.shape[1] for f in _dummy_feats]  # e.g. [24, 32, 48, 136, 384]
+
+        # Global feature dimension = bottleneck channels (deepest encoder stage)
+        self.feature_dim = enc_channels[-1]
+        self._spatial_dim = int(decoder_channels[spatial_level])
+
+        # ── Decoder ──────────────────────────────────────────────────────────
+        # Build one decode block per entry in decoder_channels.
+        # decode_blocks[0] takes the bottleneck and concat-skip from enc_channels[-2],
+        # decode_blocks[1] takes that output and concat-skip from enc_channels[-3], …
+        decode_blocks = []
+        prev_ch = self.feature_dim
+        n_blocks = len(decoder_channels)
+        for i in range(n_blocks):
+            skip_idx = -(i + 2)
+            skip_ch = enc_channels[skip_idx] if abs(skip_idx) <= len(enc_channels) else 0
+            out_ch = int(decoder_channels[i])
+            decode_blocks.append(UNetDecodeBlock(prev_ch, skip_ch, out_ch))
+            prev_ch = out_ch
+
+        # ── Combined module (for BackboneInterface compatibility) ─────────────
+        self.backbone = _UNetModule(encoder, decode_blocks, nn.AdaptiveAvgPool2d(1))
+
+        if freeze:
+            self.freeze_weights()
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    def _encode_decode(self, x: torch.Tensor) -> Tuple[torch.Tensor, list]:
+        """Run full encoder + decoder forward.
+
+        Returns:
+            bottleneck: feature map from the deepest encoder stage (B, C, H, W)
+            decoder_outputs: list of feature maps from each decode block (coarse→fine)
+        """
+        enc_feats = self.backbone.encoder(x)  # list: [fine … coarse]
+        bottleneck = enc_feats[-1]
+
+        current = bottleneck
+        decoder_outputs = []
+        for i, block in enumerate(self.backbone.decode_blocks):
+            skip_idx = -(i + 2)
+            skip = enc_feats[skip_idx] if abs(skip_idx) <= len(enc_feats) else None
+            current = block(current, skip)
+            decoder_outputs.append(current)
+
+        return bottleneck, decoder_outputs
+
+    # ── BackboneInterface ─────────────────────────────────────────────────────
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return global avg-pooled bottleneck features: (B, feature_dim)."""
+        bottleneck, _ = self._encode_decode(x)
+        return self.backbone.gap(bottleneck).view(x.shape[0], -1)
+
+    def forward_with_spatial(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Return global features and spatial decoder features.
+
+        Returns:
+            global_features: (B, feature_dim)  — avg-pooled bottleneck
+            spatial_features: (B, H*W, spatial_dim) — chosen decoder level, flattened
+        """
+        bottleneck, decoder_outputs = self._encode_decode(x)
+        global_features = self.backbone.gap(bottleneck).view(x.shape[0], -1)
+
+        spatial_map = decoder_outputs[self.spatial_level]  # (B, C, H, W)
+        B, C, H, W = spatial_map.shape
+        # Permute to (B, H, W, C) then reshape to (B, H*W, C) for attention
+        spatial_features = spatial_map.permute(0, 2, 3, 1).reshape(B, H * W, C)
+
+        return global_features, spatial_features
+
+    def get_feature_dim(self) -> int:
+        """Bottleneck feature dimension (used as global feature for decoder head)."""
+        return self.feature_dim
+
+    def get_spatial_dim(self) -> int:
+        """Spatial feature dimension at the chosen decoder level (= context_dim)."""
+        return self._spatial_dim
+
+    def freeze_weights(self) -> None:
+        """Freeze encoder only; decoder remains trainable."""
+        for param in self.backbone.encoder.parameters():
+            param.requires_grad = False
+        self.freeze_weights_flag = True
+
+    def unfreeze_weights(self) -> None:
+        """Unfreeze encoder weights."""
+        for param in self.backbone.encoder.parameters():
+            param.requires_grad = True
+        self.freeze_weights_flag = False
+
+    def get_trainable_parameters(self) -> list:
+        """Decoder is always trainable; encoder is trainable only when not frozen."""
+        params = list(self.backbone.decode_blocks.parameters())
+        if not self.freeze_weights_flag:
+            params += list(self.backbone.encoder.parameters())
+        return params
+
+
 class BackboneFactory:
     """Factory class for creating backbone networks."""
-    
+
     SUPPORTED_BACKBONES = {
         'resnet50': ResNetBackbone,
         'resnet101': ResNetBackbone,
         'resnet152': ResNetBackbone,
         'vit_base_patch16_224': ViTBackbone,
         'vit_large_patch16_224': ViTBackbone,
+        # UNet variants: lightweight pretrained encoder + skip-connection decoder
+        'unet_efficientnet_b0': UNetBackbone,   # ~8M enc params, spatial_dim=64
+        'unet_efficientnet_b3': UNetBackbone,   # ~15M enc params, spatial_dim=128
+        'unet_resnet34': UNetBackbone,           # ~25M enc params, spatial_dim=128
+        'unet_mobilenet_v3': UNetBackbone,       # ~6M enc params, spatial_dim=64
     }
     
     @classmethod
@@ -263,20 +477,45 @@ class BackboneFactory:
             available = list(cls.SUPPORTED_BACKBONES.keys())
             raise ValueError(f"Unsupported backbone '{backbone_name}'. Available: {available}")
         
-        # Check if ViT is requested but timm is not available
-        if backbone_name.startswith('vit') and not TIMM_AVAILABLE:
-            raise ImportError(f"Vision Transformer backbone '{backbone_name}' requires timm library. Install with: pip install timm")
+        # Check if ViT or UNet is requested but timm is not available
+        if (backbone_name.startswith('vit') or backbone_name.startswith('unet_')) and not TIMM_AVAILABLE:
+            raise ImportError(f"Backbone '{backbone_name}' requires timm library. Install with: pip install timm")
         
         backbone_class = cls.SUPPORTED_BACKBONES[backbone_name]
-        
+
         # Set default arguments based on backbone type
         if backbone_name.startswith('resnet'):
             kwargs.setdefault('model_name', backbone_name)
         elif backbone_name.startswith('vit'):
             kwargs.setdefault('model_name', backbone_name)
-        
+        elif backbone_name.startswith('unet_'):
+            kwargs.setdefault('model_name', backbone_name)
+            # Apply sensible per-variant decoder defaults (can be overridden by caller)
+            _unet_decoder_defaults: Dict[str, Any] = {
+                'unet_efficientnet_b0': {'decoder_channels': (128, 64, 32)},
+                'unet_efficientnet_b3': {'decoder_channels': (256, 128, 64)},
+                'unet_resnet34':        {'decoder_channels': (256, 128, 64)},
+                'unet_mobilenet_v3':    {'decoder_channels': (128, 64, 32)},
+            }
+            for k, v in _unet_decoder_defaults.get(backbone_name, {}).items():
+                kwargs.setdefault(k, v)
+
         return backbone_class(**kwargs)
     
+    @classmethod
+    def get_default_input_resolution(cls, backbone_name: str) -> int:
+        """Return the recommended input resolution for a given backbone.
+
+        This is the single source of truth for default input resolution.
+        ViT models require a fixed 224×224 input.  CNN-based backbones
+        (ResNet, UNet) are fully convolutional and default to 512×512,
+        but callers may override this via configuration.
+        """
+        if backbone_name.startswith('vit'):
+            return 224
+        # ResNet and UNet are fully convolutional → 512 by default
+        return 512
+
     @classmethod
     def get_backbone_info(cls, backbone_name: str) -> Dict[str, Any]:
         """
@@ -297,12 +536,15 @@ class BackboneFactory:
             'class': cls.SUPPORTED_BACKBONES[backbone_name].__name__,
         }
         
+        # Default input resolution from the centralized helper
+        default_res = cls.get_default_input_resolution(backbone_name)
+
         # Add specific information based on backbone type
         if backbone_name.startswith('resnet'):
             info.update({
                 'type': 'CNN',
                 'feature_dim': 2048,
-                'input_size': 224,
+                'input_size': default_res,
                 'memory_usage': 'Medium',
             })
         elif backbone_name.startswith('vit'):
@@ -310,16 +552,29 @@ class BackboneFactory:
                 info.update({
                     'type': 'Transformer',
                     'feature_dim': 768,
-                    'input_size': 224,
+                    'input_size': default_res,
                     'memory_usage': 'Medium',
                 })
             elif 'large' in backbone_name:
                 info.update({
                     'type': 'Transformer',
                     'feature_dim': 1024,
-                    'input_size': 224,
+                    'input_size': default_res,
                     'memory_usage': 'High',
                 })
+        elif backbone_name.startswith('unet_'):
+            _unet_info: Dict[str, Any] = {
+                'unet_efficientnet_b0': {'feature_dim': 320, 'spatial_dim': 64,  'memory_usage': 'Low'},
+                'unet_efficientnet_b3': {'feature_dim': 384, 'spatial_dim': 128, 'memory_usage': 'Low'},
+                'unet_resnet34':        {'feature_dim': 512, 'spatial_dim': 128, 'memory_usage': 'Low'},
+                'unet_mobilenet_v3':    {'feature_dim': 960, 'spatial_dim': 64,  'memory_usage': 'Low'},
+            }
+            info.update({
+                'type': 'UNet (CNN encoder + decoder)',
+                'input_size': f'{default_res} (fully convolutional, configurable)',
+                'has_spatial_features': True,
+                **_unet_info.get(backbone_name, {}),
+            })
         
         return info
     

--- a/smal_fitter/neuralSMIL/backbone_factory.py
+++ b/smal_fitter/neuralSMIL/backbone_factory.py
@@ -22,63 +22,47 @@ except ImportError:
     timm = None
 
 
-class BackboneInterface(ABC):
-    """Abstract interface for backbone networks."""
-    
+class BackboneInterface(nn.Module, ABC):
+    """Abstract interface for backbone networks.
+
+    Inherits from nn.Module so that backbone parameters are properly
+    registered when assigned as attributes of parent modules (e.g.
+    SMILImageRegressor.backbone), making them visible to
+    model.parameters(), optimizers, and checkpoint saving.
+    """
+
     @abstractmethod
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through the backbone.
-        
+
         Args:
             x: Input tensor of shape (batch_size, 3, height, width)
-            
+
         Returns:
             Feature tensor of shape (batch_size, feature_dim)
         """
         pass
-    
+
     @abstractmethod
     def get_feature_dim(self) -> int:
         """Get the output feature dimension."""
         pass
-    
+
     @abstractmethod
     def freeze_weights(self) -> None:
         """Freeze all backbone parameters."""
         pass
-    
+
     @abstractmethod
     def unfreeze_weights(self) -> None:
         """Unfreeze all backbone parameters."""
         pass
-    
+
     @abstractmethod
     def get_trainable_parameters(self) -> list:
         """Get list of trainable parameter groups."""
         pass
-    
-    def to(self, device):
-        """Move backbone to device."""
-        self.backbone = self.backbone.to(device)
-        return self
-    
-    def parameters(self):
-        """Get backbone parameters."""
-        return self.backbone.parameters()
-    
-    def eval(self):
-        """Set backbone to evaluation mode."""
-        self.backbone.eval()
-        return self
-    
-    def train(self, mode=True):
-        """Set backbone to training mode."""
-        self.backbone.train(mode)
-        return self
-    
-    def __call__(self, x):
-        """Make backbone callable."""
-        return self.forward(x)
+
 
 
 class ResNetBackbone(BackboneInterface):

--- a/smal_fitter/neuralSMIL/benchmark_model.py
+++ b/smal_fitter/neuralSMIL/benchmark_model.py
@@ -387,7 +387,8 @@ def _create_singleview_model(
     apply_smal_file_override(smal_file, shape_family=shape_family)
 
     backbone_name = model_config["backbone_name"]
-    input_resolution = 224 if backbone_name.startswith("vit") else 512
+    from backbone_factory import BackboneFactory
+    input_resolution = BackboneFactory.get_default_input_resolution(backbone_name)
 
     log_fn(f"Singleview model config:")
     log_fn(f"  backbone: {backbone_name}")
@@ -906,10 +907,8 @@ def _run_multiview_benchmark(
 
     # Create model (mirror training script)
     backbone_name = config_from_ckpt["backbone_name"]
-    if backbone_name.startswith("vit"):
-        input_resolution = 224
-    else:
-        input_resolution = 512
+    from backbone_factory import BackboneFactory
+    input_resolution = BackboneFactory.get_default_input_resolution(backbone_name)
     log_fn(f"\nUsing input resolution: {input_resolution}x{input_resolution} (backbone: {backbone_name})")
 
     allow_mesh_scaling = config_from_ckpt.get("allow_mesh_scaling", False)

--- a/smal_fitter/neuralSMIL/benchmark_model.py
+++ b/smal_fitter/neuralSMIL/benchmark_model.py
@@ -856,6 +856,21 @@ def _run_multiview_benchmark(
         max_views = config_from_ckpt.get("max_views", dataset_max_views)
         log_fn(f"Using max_views={max_views} from checkpoint config or dataset")
 
+    # Infer hidden_dim from state_dict to avoid architecture mismatch when config is stale
+    if 'transformer_head.pos_embedding' in state_dict:
+        inferred_hidden_dim = state_dict['transformer_head.pos_embedding'].shape[-1]
+        config_hidden_dim = config_from_ckpt.get("hidden_dim", 1024)
+        if inferred_hidden_dim != config_hidden_dim:
+            log_fn(f"WARNING: config hidden_dim={config_hidden_dim} does not match checkpoint "
+                   f"transformer_head.pos_embedding dim={inferred_hidden_dim}. "
+                   f"Using inferred value.")
+        config_from_ckpt["hidden_dim"] = inferred_hidden_dim
+        # Also update transformer_config so the transformer head is built with the correct dim
+        if "transformer_config" not in config_from_ckpt or not isinstance(config_from_ckpt["transformer_config"], dict):
+            config_from_ckpt["transformer_config"] = {}
+        config_from_ckpt["transformer_config"]["hidden_dim"] = inferred_hidden_dim
+        log_fn(f"Inferred hidden_dim={inferred_hidden_dim} from checkpoint transformer_head.pos_embedding shape")
+
     canonical_camera_order = config_from_ckpt.get("canonical_camera_order", None)
     if canonical_camera_order is None:
         canonical_camera_order = dataset_canonical_camera_order
@@ -939,7 +954,8 @@ def _run_multiview_benchmark(
         input_resolution=input_resolution,
         allow_mesh_scaling=allow_mesh_scaling,
         mesh_scale_init=mesh_scale_init,
-        use_gt_camera_init=use_gt_camera_init
+        use_gt_camera_init=use_gt_camera_init,
+        transformer_config=config_from_ckpt.get("transformer_config", {})
     )
     model = model.to(device)
 

--- a/smal_fitter/neuralSMIL/configs/README.md
+++ b/smal_fitter/neuralSMIL/configs/README.md
@@ -24,6 +24,12 @@ python train_smil_regressor.py --config configs/examples/singleview_baseline.jso
 python train_multiview_regressor.py --config configs/examples/multiview_6cam.json
 ```
 
+### Multi-GPU training
+
+```bash
+python train_multiview_regressor.py --config configs/examples/multiview_mouse_UNET_long.json --num_gpus 2
+```
+
 ### Override from CLI
 
 ```bash
@@ -41,7 +47,300 @@ If you omit `--config`, the scripts fall back to the previous behavior (e.g. `Tr
   - `"smal_file"`: SMAL/SMIL model pickle path. When used, callers should reload `config` so `dd`, `N_POSE`, `N_BETAS`, etc. match that file.
   - `"shape_family"`: integer shape family passed into SMAL/SMIL code (overrides `config.SHAPE_FAMILY` for the run).
 - Curriculum parameters (loss weights and learning rate schedules) use **string keys** for epoch thresholds in JSON (e.g. `"10": 3e-5`). These are converted to integer keys when loaded.
-- See `examples/` for full example configs and `examples/README.md` for a field-by-field guide.
+- See `examples/` for full example configs.
+
+## Top-level JSON sections
+
+### `smal_model` — SMAL/SMIL model overrides (optional)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `smal_file` | string or null | `null` | Path to the SMAL/SMIL model `.pkl` file. Overrides `config.SMAL_FILE` at runtime; derived globals (`dd`, `N_POSE`, `N_BETAS`, joints) are reloaded automatically. |
+| `shape_family` | int or null | `null` | Shape family index passed into SMAL/SMIL code. |
+
+### `dataset` — Data paths and splits
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `data_path` | string | *required* | Path to the HDF5 dataset file. Images and 2D keypoints must be undistorted (see note below). |
+| `train_ratio` | float | `0.85` | Fraction of data used for training. |
+| `val_ratio` | float | `0.05` | Fraction of data used for validation. |
+| `test_ratio` | float | `0.1` | Fraction of data used for testing. |
+| `dataset_fraction` | float | `0.5` | Fraction of training split sampled per epoch (a different random subset is drawn each epoch for diversity). |
+
+**Undistortion:** All input images and 2D keypoints must be in undistorted (ideal pinhole) space. PyTorch3D's `FoVPerspectiveCameras` does not model lens distortion, so raw barrel-distorted images would cause a mismatch between rendered projections and ground truth keypoints. Undistort images with `cv2.undistort()` and use `reprojections.h5` (ideal pinhole projections of triangulated 3D points) as 2D keypoint ground truth.
+
+### `model` — Network architecture
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backbone_name` | string | `"vit_large_patch16_224"` | Feature extraction backbone. See [Supported backbones](#supported-backbones). |
+| `freeze_backbone` | bool | `true` | Freeze pretrained backbone weights (fine-tune only the head). |
+| `hidden_dim` | int | `1024` | Decoder hidden dimension. Auto-adjusted per backbone if not set explicitly (see table below). |
+| `head_type` | string | `"transformer_decoder"` | Prediction head type: `"mlp"` or `"transformer_decoder"`. |
+| `input_resolution` | int or null | `null` | Input image size. `null` = auto-detect from backbone (224 for ViT, 512 for ResNet/UNet). |
+| `use_unity_prior` | bool | `false` | Use legacy Unity quadruped body prior. |
+| `rgb_only` | bool | `false` | Use only RGB channels (ignore alpha/mask channel if present). |
+
+#### Transformer decoder options (used when `head_type = "transformer_decoder"`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `transformer_depth` | int | `6` | Number of transformer decoder layers. |
+| `transformer_heads` | int | `8` | Number of attention heads per layer. |
+| `transformer_dim_head` | int | `64` | Dimension per attention head. |
+| `transformer_mlp_dim` | int | `1024` | Feed-forward network hidden dimension. |
+| `transformer_dropout` | float | `0.1` | Dropout rate in attention and FFN layers. |
+| `transformer_ief_iters` | int | `3` | Number of iterative error feedback (IEF) refinement iterations. |
+| `transformer_trans_scale_factor` | int | `1` | Scale factor applied to predicted `betas_trans`. |
+
+#### Supported backbones
+
+| Backbone name | Type | Feature dim | Default resolution | Spatial dim | Notes |
+|---------------|------|-------------|-------------------|-------------|-------|
+| `resnet50` | CNN | 2048 | 512 | - | Fully convolutional; resolution configurable. |
+| `resnet101` | CNN | 2048 | 512 | - | Fully convolutional; resolution configurable. |
+| `resnet152` | CNN | 2048 | 512 | - | Fully convolutional; resolution configurable. |
+| `vit_base_patch16_224` | ViT | 768 | 224 | 196 patches | Fixed 224px input (patch size 16). |
+| `vit_large_patch16_224` | ViT | 1024 | 224 | 196 patches | Fixed 224px input (patch size 16). |
+| `unet_efficientnet_b0` | UNet | 320 | 512 | 64 | Encoder-decoder with skip connections. |
+| `unet_efficientnet_b3` | UNet | 384 | 512 | 128 | Encoder-decoder with skip connections. |
+| `unet_resnet34` | UNet | 512 | 512 | 128 | Encoder-decoder with skip connections. |
+| `unet_mobilenet_v3` | UNet | 960 | 512 | 64 | Encoder-decoder with skip connections; lightweight. |
+
+**Auto-adjusted `hidden_dim`** (when not set explicitly in JSON):
+
+| Backbone family | hidden_dim |
+|-----------------|-----------|
+| `vit_base_*` | 768 |
+| `vit_large_*` | 1024 |
+| `resnet*` | 2048 |
+| `unet_efficientnet_b0` | 512 |
+| `unet_efficientnet_b3` | 512 |
+| `unet_resnet34` | 512 |
+| `unet_mobilenet_v3` | 256 |
+
+**Choosing a backbone:**
+- **ViT** backbones are small-resolution (224px) but produce rich global features with patch-level spatial tokens. Good for when input images can be downscaled.
+- **ResNet** backbones are fully convolutional and work at arbitrary resolution. No decoder or spatial tokens — the head sees only the global average-pooled feature.
+- **UNet** backbones pair an encoder (EfficientNet, ResNet, MobileNet) with a feature pyramid decoder, producing both a global feature vector and high-resolution spatial feature maps. Best for large input resolutions where spatial detail matters. More VRAM-intensive — consider `backbone_chunk_size` and `use_mixed_precision` for multi-view training with many cameras.
+
+### `optimizer` — Optimizer and learning rate
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `learning_rate` | float | `5e-5` | Base learning rate (epoch 0). |
+| `weight_decay` | float | `1e-4` | AdamW weight decay. |
+| `gradient_clip_norm` | float | `1.0` | Max gradient norm for clipping (0 = disabled). |
+| `optimizer_type` | string | `"adamw"` | Optimizer algorithm. |
+| `lr_schedule` | dict | *(see defaults)* | Epoch-to-LR mapping for learning rate curriculum. Keys are epoch thresholds (strings in JSON), values are learning rates. The highest applicable threshold wins. |
+
+Example:
+```json
+"lr_schedule": {
+  "0": 5e-5,
+  "50": 3e-5,
+  "100": 1e-5,
+  "300": 2e-6
+}
+```
+
+### `loss_curriculum` — Loss weights and progressive training
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `base_weights` | dict | *(see below)* | Initial loss weights applied from epoch 0. |
+| `curriculum_stages` | dict | *(see defaults)* | Epoch-to-weight-update mapping. Each stage partially overrides `base_weights` from that epoch onward. |
+
+#### Available loss terms
+
+| Loss name | Description | Typical range |
+|-----------|-------------|---------------|
+| `global_rot` | Global rotation error | 0.0 |
+| `joint_rot` | Per-joint rotation error | 0.001 |
+| `betas` | Shape parameter error | 0.0005 |
+| `trans` | Translation error | 0.0005 |
+| `fov` | Field-of-view error | 0.001 |
+| `cam_rot` | Camera rotation error (multi-view) | 0.01 |
+| `cam_trans` | Camera translation error (multi-view) | 0.01 |
+| `log_beta_scales` | Per-limb scale parameter error | 0.0005 |
+| `betas_trans` | Per-limb translation parameter error | 0.0005 |
+| `keypoint_2d` | 2D keypoint reprojection error | 0.1 |
+| `keypoint_3d` | 3D keypoint error | 0.25 |
+| `silhouette` | Silhouette overlap loss | 0.0 |
+| `joint_angle_regularization` | Joint angle prior/regularization | 0.001 |
+| `limb_scale_regularization` | Limb scale regularization | 0.01 |
+| `limb_trans_regularization` | Limb translation regularization | 1.0 |
+| `triangulation_consistency` | Cross-view triangulation consistency (multi-view). **Disabled by default — see note below.** | 0.0 |
+| `ief_intermediate` | Intermediate IEF iteration loss | 0.0 |
+
+> **Why `triangulation_consistency` is disabled.**
+> This loss triangulates GT 2D keypoints with the predicted cameras (DLT) and compares the result to the network's own predicted 3D joints (detached). Gradients flow only into the camera heads.
+>
+> In practice this term is **redundant with `keypoint_2d`**: both encode the same geometric constraint (GT 2D, predicted cameras, and predicted 3D must be mutually consistent) — they differ only in functional form (DLT pseudo-inverse vs. forward projection). When one is satisfied, the other is too.
+>
+> It becomes **actively harmful when GT 2D labels are noisy** (e.g. from a 2D pose estimator). The 3D GT is typically cleaner because triangulation across many views averages out per-view noise. The `keypoint_3d` loss anchors the body model to that cleaner signal. But `triangulation_consistency` re-triangulates the noisy 2D with still-learning cameras and pushes the cameras to match the body model — injecting 2D noise directly into camera supervision.
+>
+> When **GT camera calibration is available** (`use_gt_camera_init: true`) with direct camera supervision (`cam_rot`, `cam_trans`, `fov` losses), the system is already geometrically consistent by construction — the 3D GT was produced by the same camera solve. Any consistency loss is a no-op at best.
+>
+> **Leave this at 0.0** unless all of the following hold: (1) you have clean 2D keypoints, (2) no GT camera calibration, and (3) no 3D keypoints. Even then, its value is marginal since it carries no information beyond `keypoint_2d`.
+
+Curriculum stages example:
+```json
+"curriculum_stages": {
+  "10": { "keypoint_2d": 0.1, "joint_angle_regularization": 1e-5 },
+  "50": { "keypoint_3d": 2.0, "limb_scale_regularization": 0.001 },
+  "200": { "fov": 1e-7, "cam_rot": 1e-8, "cam_trans": 1e-8 }
+}
+```
+
+### `training` — Training hyperparameters
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `batch_size` | int | `8` | Samples per GPU per step. |
+| `num_epochs` | int | `1000` | Total training epochs. |
+| `seed` | int | `1234` | Random seed for reproducibility. |
+| `rotation_representation` | string | `"6d"` | Rotation parameterization: `"6d"` (continuous) or `"axis_angle"`. |
+| `num_workers` | int | `8` | DataLoader worker processes. |
+| `pin_memory` | bool | `true` | Pin DataLoader memory for faster GPU transfer. |
+| `prefetch_factor` | int | `4` | Batches prefetched per worker. |
+| `resume_checkpoint` | string or null | `null` | Path to checkpoint `.pth` file to resume from. |
+| `reset_ief_token_embedding` | bool | `false` | Re-initialize IEF token embeddings when resuming (useful when changing `transformer_ief_iters`). |
+| `use_gt_camera_init` | bool | `true` | Use ground-truth camera parameters as initialization base and predict deltas (multi-view). |
+| `use_mixed_precision` | bool | `false` | Enable FP16 mixed precision training via `torch.cuda.amp`. Roughly halves activation memory and speeds up Tensor Core operations. Weight updates remain FP32 for numerical stability. |
+| `backbone_chunk_size` | int or null | `null` | Maximum number of images processed through the backbone in a single forward pass. `null` = process all views at once. Set to a smaller value (e.g. `6`) to reduce peak VRAM when using many views with high-resolution inputs. Mathematically equivalent to unchunked — only affects memory, not results. |
+
+### `scale_trans_beta` — Per-limb scale/translation handling
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | string | `"entangled_with_betas"` | How per-limb scale/translation betas are handled: `"ignore"` (zero out), `"separate"` (predict independently), or `"entangled_with_betas"` (predict jointly with shape betas). |
+
+### `mesh_scaling` — Global mesh scale
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allow_mesh_scaling` | bool | `true` | Allow the model to predict a global mesh scale factor. |
+| `init_mesh_scale` | float | `1.0` | Initial mesh scale value. |
+| `use_log_scale` | bool | `true` | Predict scale in log-space for numerical stability. |
+
+### `joint_importance` — Per-joint loss weighting
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable per-joint importance weighting. |
+| `important_joint_names` | list[string] | `[]` | Joint names to upweight (e.g. `["Nose", "paw_L_tip"]`). Must match joint names in the SMAL model. |
+| `weight_multiplier` | float | `10.0` | Multiplier applied to important joints in 2D/3D keypoint losses. |
+
+### `ignored_joint_locations` — Loss-level joint exclusion
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable joint exclusion from keypoint losses. |
+| `ignored_joint_names` | list[string] | `[]` | Joint names excluded from 2D and 3D keypoint loss computation. Joints remain in the dataset but are not supervised. |
+
+### `ignored_joints` — Data-level joint exclusion
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ignored_joint_names` | list[string] | `[]` | Joints removed entirely during data preprocessing. |
+| `verbose` | bool | `true` | Log which joints are ignored. |
+
+### `multi_dataset` — Multi-dataset training
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable multi-dataset training. |
+| `datasets` | list[object] | `[]` | List of dataset entries (see below). |
+| `validation_split_strategy` | string | `"per_dataset"` | Validation split strategy: `"per_dataset"` or `"combined"`. |
+
+Each dataset entry:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | `""` | Display name. |
+| `path` | string | `""` | Path to HDF5 file. |
+| `type` | string | `"optimized_hdf5"` | Dataset type: `"replicant"`, `"sleap"`, `"optimized_hdf5"`, or `"auto"`. |
+| `weight` | float | `1.0` | Sampling weight relative to other datasets. |
+| `enabled` | bool | `true` | Whether this dataset is active. |
+| `available_labels` | dict | *(all true)* | Which label types are available (e.g. `"keypoint_3d": false` if no 3D annotations). |
+
+### `output` — Checkpoints and visualization
+
+| Field | Type | Default (single-view) | Default (multi-view) | Description |
+|-------|------|-----------------------|----------------------|-------------|
+| `checkpoint_dir` | string | `"checkpoints"` | `"multiview_checkpoints"` | Directory for saved model checkpoints. |
+| `plots_dir` | string | `"plots"` | `"plots"` | Directory for training metric plots. |
+| `visualizations_dir` | string | `"visualizations"` | `"multiview_visualizations"` | Directory for validation visualizations. |
+| `train_visualizations_dir` | string | `"visualizations_train"` | - | Directory for training-set visualizations. |
+| `singleview_visualizations_dir` | string | - | `"multiview_singleview_renders"` | Per-view rendered overlays (multi-view only). |
+| `save_checkpoint_every` | int | `10` | `10` | Save a checkpoint every N epochs. |
+| `generate_visualizations_every` | int | `10` | `10` | Generate visualizations every N epochs. |
+| `plot_history_every` | int | `10` | - | Update training history plots every N epochs. |
+| `num_visualization_samples` | int | `10` | `3` | Number of samples to visualize. |
+
+## Multi-view only fields
+
+These fields are set at the **top level** of the JSON (not inside a section) for multiview configs:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `num_views_to_use` | int or null | `null` | Maximum views per sample. `null` = use all available views in the dataset. |
+| `min_views_per_sample` | int | `2` | Minimum views required per training sample. |
+| `cross_attention_layers` | int | `2` | Number of cross-view attention layers for multi-view feature fusion. |
+| `cross_attention_heads` | int | `8` | Number of attention heads in cross-view attention. |
+| `cross_attention_dropout` | float | `0.1` | Dropout in cross-view attention layers. |
+
+## Memory optimization for multi-view training
+
+When training with many camera views (e.g. 18) at high resolution (e.g. 512px) with a UNet backbone, peak VRAM can exceed GPU capacity. Two options reduce memory usage without affecting training quality:
+
+**`backbone_chunk_size`** (in `training`): Instead of pushing all `batch_size * num_views` images through the backbone at once, process them in chunks. For example, with `batch_size: 2` and 18 views, the backbone normally sees 36 images simultaneously. Setting `backbone_chunk_size: 6` processes 6 at a time, reducing peak backbone VRAM by ~6x.
+
+**`use_mixed_precision`** (in `training`): Uses FP16 for forward pass activations and convolutions via `torch.cuda.amp`, roughly halving activation memory. Weight updates remain in FP32 for stability. Also accelerates training on GPUs with Tensor Cores (e.g. RTX 3090/4090, A100).
+
+Example for a VRAM-constrained setup:
+```json
+"training": {
+  "batch_size": 2,
+  "use_mixed_precision": true,
+  "backbone_chunk_size": 6
+}
+```
+
+## Curriculum keys in JSON
+
+JSON does not allow integer keys. Use **string** keys for epoch-based dicts; they are converted to integers on load:
+
+- **`lr_schedule`**: `"0": 5e-5`, `"10": 3e-5`, ...
+- **`curriculum_stages`**: `"1": { "keypoint_2d": 0.1 }`, `"25": { ... }`, ...
+
+## Example configs
+
+| File | Mode | Description |
+|------|------|-------------|
+| `singleview_baseline.json` | singleview | Full single-view config with ViT backbone, transformer decoder, and loss/LR curriculum. |
+| `multiview_baseline.json` | multiview | Multi-view config with cross-attention and multi-view output directories. |
+| `multiview_sticks.json` | multiview | Stick insect with UNet EfficientNet-B3 backbone, 512px. |
+| `multiview_sticks_UNET.json` | multiview | Stick insect UNet variant. |
+| `multiview_sticks_UNET_continue.json` | multiview | Continuation training from a checkpoint. |
+| `multiview_mouse_UNET_long.json` | multiview | 18-camera mouse with UNet EfficientNet-B3, mixed precision, and backbone chunking for VRAM optimization. |
+
+## Using the examples
+
+```bash
+# Single-view
+python train_smil_regressor.py --config configs/examples/singleview_baseline.json
+
+# Multi-view
+python train_multiview_regressor.py --config configs/examples/multiview_baseline.json --dataset_path /path/to/multiview.h5
+
+# Multi-view with mixed precision (CLI override)
+python train_multiview_regressor.py --config configs/examples/multiview_sticks.json --use_mixed_precision
+```
+
+Copy an example to your project and edit; keep the `mode` field and the structure above so the loader and legacy bridge continue to work.
 
 ## Public API
 
@@ -58,27 +357,15 @@ If you omit `--config`, the scripts fall back to the previous behavior (e.g. `Tr
 
 ## Structure
 
-- **`base_config.py`** — Shared dataclasses: `DatasetConfig`, `ModelConfig`, `OptimizerConfig`, `LossCurriculumConfig`, `ScaleTransBetaConfig`, `MeshScalingConfig`, `OutputConfig`, etc., and `BaseTrainingConfig`.
+- **`base_config.py`** — Shared dataclasses: `DatasetConfig`, `ModelConfig`, `OptimizerConfig`, `LossCurriculumConfig`, `ScaleTransBetaConfig`, `MeshScalingConfig`, `JointImportanceConfig`, `IgnoredJointLocationsConfig`, `IgnoredJointsConfig`, `MultiDatasetConfig`, `OutputConfig`, `TrainingHyperparameters`, `SmalModelConfig`, and `BaseTrainingConfig`.
 - **`singleview_config.py`** — `SingleViewConfig` (minimal extension of base).
-- **`multiview_config.py`** — `MultiViewConfig`, `MultiViewOutputConfig`, and multi-view–specific fields (cross-attention, output dirs).
+- **`multiview_config.py`** — `MultiViewConfig`, `MultiViewOutputConfig`, and multi-view-specific fields (cross-attention, output dirs).
 - **`config_utils.py`** — JSON load/save, deep merge into dataclasses, mode validation.
-- **`examples/`** — Example JSON configs and a short guide.
+- **`examples/`** — Example JSON configs.
 
 ## Backward compatibility
 
 - **Legacy scripts**: `train_smil_regressor.py` and `train_multiview_regressor.py` convert the new config to the dict format expected by their existing `main()` via `to_legacy_dict()` and `to_multiview_legacy_dict()`. No change to the rest of the training loop is required.
 - **`config.py`**: Unchanged; still used for SMAL file paths, shape family, joint counts, and GPU settings by `fitter_3d` and `optimize_to_joints`.
 - **`training_config.py`**: Deprecated; new setups should use this package and JSON configs.
-
-## Validation
-
-Configs can be validated programmatically:
-
-```python
-from configs import SingleViewConfig, load_config
-
-config = load_config(config_file="experiments/baseline.json")
-config.validate()
-```
-
-Validation checks split ratios, head type, scale/trans mode, and (for multi-view) minimum views per sample.
+- **New fields** (`use_mixed_precision`, `backbone_chunk_size`) default to `false`/`null`, so existing configs and scripts work without changes.

--- a/smal_fitter/neuralSMIL/configs/base_config.py
+++ b/smal_fitter/neuralSMIL/configs/base_config.py
@@ -14,7 +14,10 @@ Configuration Precedence (highest to lowest):
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Dict, List, Optional, Tuple, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass  # reserved for future type-only imports
 
 
 @dataclass
@@ -49,6 +52,9 @@ class ModelConfig:
     use_unity_prior: bool = False
     rgb_only: bool = False
 
+    # Input resolution (None = auto-detect from backbone via BackboneFactory)
+    input_resolution: Optional[int] = None
+
     # Transformer decoder configuration
     transformer_depth: int = 6
     transformer_heads: int = 8
@@ -58,12 +64,26 @@ class ModelConfig:
     transformer_ief_iters: int = 3
     transformer_trans_scale_factor: int = 1  # Scale factor for betas_trans
 
+    def get_input_resolution(self) -> int:
+        """Return input resolution, auto-detecting from backbone if not set."""
+        if self.input_resolution is not None:
+            return self.input_resolution
+        from backbone_factory import BackboneFactory
+        return BackboneFactory.get_default_input_resolution(self.backbone_name)
+
     def validate(self):
         if self.head_type not in ('mlp', 'transformer_decoder'):
             raise ValueError(f"Invalid head_type '{self.head_type}', must be 'mlp' or 'transformer_decoder'")
 
     def get_adjusted_hidden_dim(self) -> int:
-        """Return hidden_dim adjusted for backbone architecture."""
+        """Return hidden_dim adjusted for backbone architecture.
+
+        For ViT/ResNet the decoder hidden_dim is matched to the backbone
+        feature_dim to avoid an unnecessary projection.  For UNet backbones the
+        decoder hidden_dim is independent of both the encoder bottleneck and the
+        decoder spatial channels, so a fixed 512 is a reasonable default that
+        keeps the transformer decoder lightweight while still being expressive.
+        """
         if self.backbone_name.startswith('vit'):
             if 'base' in self.backbone_name:
                 return 768
@@ -71,6 +91,14 @@ class ModelConfig:
                 return 1024
         elif self.backbone_name.startswith('resnet'):
             return 2048
+        elif self.backbone_name.startswith('unet_'):
+            _unet_hidden: dict = {
+                'unet_efficientnet_b0': 512,
+                'unet_efficientnet_b3': 512,
+                'unet_resnet34':        512,
+                'unet_mobilenet_v3':    256,
+            }
+            return _unet_hidden.get(self.backbone_name, 512)
         return self.hidden_dim
 
 
@@ -499,6 +527,7 @@ class BaseTrainingConfig:
                 'backbone_name': self.model.backbone_name,
                 'freeze_backbone': self.model.freeze_backbone,
                 'hidden_dim': hidden_dim,
+                'input_resolution': self.model.get_input_resolution(),
                 'rgb_only': self.model.rgb_only,
                 'use_unity_prior': self.model.use_unity_prior,
                 'head_type': self.model.head_type,

--- a/smal_fitter/neuralSMIL/configs/base_config.py
+++ b/smal_fitter/neuralSMIL/configs/base_config.py
@@ -414,6 +414,9 @@ class TrainingHyperparameters:
     resume_checkpoint: Optional[str] = None
     reset_ief_token_embedding: bool = False
     use_gt_camera_init: bool = True
+    use_mixed_precision: bool = False
+    backbone_chunk_size: Optional[int] = None  # Max images through backbone at once (None = all)
+    gradient_accumulation_steps: int = 1  # Accumulate gradients over N mini-batches before stepping
 
 
 @dataclass

--- a/smal_fitter/neuralSMIL/configs/examples/README.md
+++ b/smal_fitter/neuralSMIL/configs/examples/README.md
@@ -15,44 +15,11 @@ The loader uses `mode` to choose the config class and to validate the file.
 
 | File | Mode | Description |
 |------|------|-------------|
-| `singleview_baseline.json` | singleview | Full single-view config with dataset path, ViT backbone, transformer decoder, and full loss/LR curriculum. |
-| `multiview_baseline.json` | multiview | Multi-view config with cross-attention settings and multi-view output directories. |
-
-## Top-level sections
-
-### Shared (both modes)
-
-- **`smal_model`** — Optional overrides for values otherwise sourced from `config.py`:
-  - `smal_file`: path to the SMAL/SMIL model pickle (used by `config.py` to populate `dd`, `N_POSE`, `N_BETAS`, etc.). If set, training/inference should reload `config` so derived fields update.
-  - `shape_family`: integer shape family passed into SMAL/SMIL code (overrides `config.SHAPE_FAMILY` for the run)
-- **`dataset`** — `data_path`, `train_ratio`, `val_ratio`, `test_ratio`, `dataset_fraction`. For multiview, `data_path` is often set at runtime via CLI.
-- **`model`** — `backbone_name`, `freeze_backbone`, `hidden_dim`, `head_type` (`mlp` or `transformer_decoder`), `use_unity_prior`, `rgb_only`, and transformer options (`transformer_depth`, `transformer_heads`, `transformer_dim_head`, `transformer_mlp_dim`, `transformer_dropout`, `transformer_ief_iters`, `transformer_trans_scale_factor`).
-- **`optimizer`** — `learning_rate`, `weight_decay`, `gradient_clip_norm`, `optimizer_type`, and **`lr_schedule`**: a dict mapping epoch (as string) to learning rate, e.g. `"10": 3e-5`, `"100": 1e-5`.
-- **`loss_curriculum`** — **`base_weights`**: dict of loss name → weight (e.g. `global_rot`, `joint_rot`, `keypoint_2d`, `keypoint_3d`, `silhouette`, regularizations). **`curriculum_stages`**: dict mapping epoch (as string) to partial weight updates applied from that epoch onward.
-- **`training`** — `batch_size`, `num_epochs`, `seed`, `rotation_representation` (`6d` or `axis_angle`), `resume_checkpoint`, `num_workers`, `pin_memory`, `prefetch_factor`, `use_gt_camera_init`, `reset_ief_token_embedding`.
-- **`output`** — `checkpoint_dir`, `plots_dir`, `visualizations_dir`, `train_visualizations_dir`, `save_checkpoint_every`, `generate_visualizations_every`, `plot_history_every`, `num_visualization_samples`.
-- **`scale_trans_beta`** — `mode`: `ignore`, `separate`, or `entangled_with_betas`; optional nested options.
-- **`mesh_scaling`** — Optional; `allow_mesh_scaling`, `init_mesh_scale`, `use_log_scale`.
-- **`joint_importance`** — Per-joint importance weighting for keypoint losses: `enabled`, `important_joint_names` (list of joint name strings), `weight_multiplier`.
-- **`ignored_joint_locations`** — Loss-level joint exclusion for 2D/3D keypoint supervision (joints stay in dataset but are not supervised): `enabled`, `ignored_joint_names`.
-- **`ignored_joints`** — Data-preprocessing-level joint exclusion (joints removed from dataset entirely): `ignored_joint_names`, `verbose`.
-- **`multi_dataset`** — Multi-dataset training: `enabled`, `datasets` (list of dataset entries with `name`, `path`, `type`, `weight`, `enabled`, `available_labels`), `validation_split_strategy` (`per_dataset` or `combined`).
-
-### Multi-view only
-
-In **`multiview_baseline.json`** (or any multiview config), you can set at the top level:
-
-- **`num_views_to_use`** — Max views per sample (null = use all).
-- **`min_views_per_sample`** — Minimum views required per sample.
-- **`cross_attention_layers`**, **`cross_attention_heads`**, **`cross_attention_dropout`** — Cross-view attention in the multi-view regressor.
-- **`output`** — Can override with multi-view dirs: `checkpoint_dir`, `visualizations_dir`, `singleview_visualizations_dir`, etc.
-
-## Curriculum keys in JSON
-
-JSON does not allow integer keys. Use **string** keys for epoch-based dicts; they are converted to integers on load:
-
-- **`lr_schedule`**: `"0": 5e-5`, `"10": 3e-5`, …
-- **`curriculum_stages`**: `"1": { "keypoint_2d": 0.1 }`, `"25": { ... }`, …
+| `singleview_baseline.json` | singleview | Full single-view config with ViT backbone, transformer decoder, and loss/LR curriculum. |
+| `multiview_baseline.json` | multiview | Multi-view config with cross-attention and multi-view output directories. |
+| `multiview_sticks.json` | multiview | Stick insect with UNet EfficientNet-B3 backbone, 512px resolution. |
+| `multiview_sticks_UNET.json` | multiview | Stick insect UNet variant. |
+| `multiview_mouse_UNET_long.json` | multiview | 18-camera mouse with UNet EfficientNet-B3, mixed precision, and backbone chunking for VRAM optimization. |
 
 ## Using the examples
 
@@ -62,6 +29,11 @@ python train_smil_regressor.py --config configs/examples/singleview_baseline.jso
 
 # Multi-view (often override dataset path)
 python train_multiview_regressor.py --config configs/examples/multiview_baseline.json --dataset_path /path/to/multiview.h5
+
+# Multi-view with mixed precision (CLI override)
+python train_multiview_regressor.py --config configs/examples/multiview_sticks.json --use_mixed_precision
 ```
 
-Copy an example to your project and edit; keep the `mode` field and the structure above so the loader and legacy bridge continue to work.
+Copy an example to your project and edit; keep the `mode` field so the loader and legacy bridge continue to work.
+
+For a complete field-by-field reference of all config sections, see the parent [README.md](../README.md).

--- a/smal_fitter/neuralSMIL/configs/examples/multiview_baseline.json
+++ b/smal_fitter/neuralSMIL/configs/examples/multiview_baseline.json
@@ -144,6 +144,8 @@
     "pin_memory": true,
     "prefetch_factor": 4,
     "resume_checkpoint": "best_model.pth",
-    "use_gt_camera_init": true
+    "use_gt_camera_init": true,
+    "use_mixed_precision": true,
+    "backbone_chunk_size": 6
   }
 }

--- a/smal_fitter/neuralSMIL/configs/examples/multiview_mouse_UNET_long.json
+++ b/smal_fitter/neuralSMIL/configs/examples/multiview_mouse_UNET_long.json
@@ -3,17 +3,17 @@
 
   "num_views_to_use": null,
   "min_views_per_sample": 2,
-  "cross_attention_layers": 2,
+  "cross_attention_layers": 4,
   "cross_attention_heads": 8,
   "cross_attention_dropout": 0.1,
 
   "smal_model": {
-    "smal_file": "3D_model_prep/SMILy_STICK.pkl",
+    "smal_file": "3D_model_prep/SMILy_Mouse_static_joints_Falkner_conv_repose_hind_legs.pkl",
     "shape_family": null
   },
 
   "dataset": {
-    "data_path": "STICKS_full_512_3D.h5",
+    "data_path": "FALKNER_MOUSE_18_centred_reprojected.h5",
     "train_ratio": 0.85,
     "val_ratio": 0.05,
     "test_ratio": 0.1,
@@ -32,7 +32,7 @@
     "transformer_dim_head": 64,
     "transformer_mlp_dim": 1024,
     "transformer_dropout": 0.1,
-    "transformer_ief_iters": 1,
+    "transformer_ief_iters": 3,
     "transformer_trans_scale_factor": 1
   },
 
@@ -43,11 +43,11 @@
     "optimizer_type": "adamw",
     "lr_schedule": {
       "0": 5e-5,
-      "10": 3e-5,
-      "20": 2e-5,
-      "60": 1e-5,
-      "100": 2e-6,
-      "200": 1e-6
+      "50": 3e-5,
+      "100": 2e-5,
+      "300": 1e-5,
+      "350": 5e-6,
+      "400": 1e-6
     }
   },
 
@@ -69,52 +69,61 @@
       "limb_scale_regularization": 0.01,
       "limb_trans_regularization": 1,
       "triangulation_consistency": 0.0,
-      "ief_intermediate": 0.0
+      "ief_intermediate": 0.1
     },
     "curriculum_stages": {
-      "1": {
-        "joint_angle_regularization": 0.01,
-        "limb_scale_regularization": 0.1,
-        "limb_trans_regularization": 1
-      },
-      "10": {
-        "keypoint_2d": 0.1,
-        "joint_angle_regularization": 1e-5,
-        "limb_scale_regularization": 0.01,
-        "limb_trans_regularization": 1
-      },
       "20": {
+        "keypoint_3d": 0.5,
+        "joint_angle_regularization": 0.0001
+      },
+      "50": {
+        "keypoint_3d": 1,
+        "joint_angle_regularization": 1e-5
+      },
+      "60": {
         "keypoint_3d": 2,
         "joint_angle_regularization": 1e-6,
         "limb_scale_regularization": 0.001,
         "limb_trans_regularization": 0.5
       },
-      "50": {
+      "250": {
         "keypoint_3d": 2,
         "joint_angle_regularization": 1e-6,
-        "limb_scale_regularization": 1e-5,
+        "limb_scale_regularization": 0.001,
         "limb_trans_regularization": 0.5
       },
-      "100": {
+      "300": {
         "keypoint_3d": 2,
-        "joint_angle_regularization": 1e-7,
-        "limb_scale_regularization": 5e-6,
-        "limb_trans_regularization": 0.0001
-      },
-      "150": {
-        "keypoint_3d": 2,
-        "joint_angle_regularization": 1e-7,
-        "limb_scale_regularization": 1e-6,
-        "limb_trans_regularization": 0.0001,
+        "joint_angle_regularization": 5e-7,
+        "limb_scale_regularization": 0.0005,
+        "limb_trans_regularization": 0.5,
         "fov": 1e-7,
         "cam_rot": 1e-8,
         "cam_trans": 1e-8
       },
-      "200": {
+      "350": {
         "keypoint_3d": 2,
-        "joint_angle_regularization": 1e-7,
-        "limb_scale_regularization": 1e-6,
-        "limb_trans_regularization": 0.00001,
+        "joint_angle_regularization": 1e-6,
+        "limb_scale_regularization": 0.0001,
+        "limb_trans_regularization": 0.5,
+        "fov": 1e-7,
+        "cam_rot": 1e-8,
+        "cam_trans": 1e-8
+      },
+      "400": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 4e-7,
+        "limb_scale_regularization": 0.00005,
+        "limb_trans_regularization": 0.5,
+        "fov": 1e-7,
+        "cam_rot": 1e-8,
+        "cam_trans": 1e-8
+      },
+      "500": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 2e-7,
+        "limb_scale_regularization": 0.00001,
+        "limb_trans_regularization": 0.5,
         "fov": 1e-7,
         "cam_rot": 1e-8,
         "cam_trans": 1e-8
@@ -134,7 +143,7 @@
 
   "joint_importance": {
     "enabled": true,
-    "important_joint_names": ["l_1_pt_l", "l_2_pt_l", "l_3_pt_l", "l_1_pt_r", "l_2_pt_r", "l_3_pt_r"],
+    "important_joint_names": ["Nose", "paw_L_tip", "paw_R_tip", "Foot_L_tip", "Foot_R_tip", "Tail_07"],
     "weight_multiplier": 10.0
   },
 
@@ -144,27 +153,28 @@
   },
 
   "output": {
-    "checkpoint_dir": "multiview_checkpoints_STICKS_full_512_3D",
+    "checkpoint_dir": "multiview_checkpoints_MOUSE_Unet_512_EffB3_ief3",
     "plots_dir": "plots",
-    "visualizations_dir": "multiview_visualizations_STICKS_full_512_3D",
-    "singleview_visualizations_dir": "multiview_singleview_renders_STICKS_full_512_3D",
-    "save_checkpoint_every": 10,
+    "visualizations_dir": "multiview_visualizations_MOUSE_Unet_512_EffB3_ief3",
+    "singleview_visualizations_dir": "multiview_singleview_renders_MOUSE_Unet_512_EffB3_ief3",
+    "save_checkpoint_every": 5,
     "generate_visualizations_every": 5,
     "num_visualization_samples": 5
   },
 
   "training": {
-    "batch_size": 3,
-    "num_epochs": 300,
+    "batch_size": 1,
+    "num_epochs": 600,
     "seed": 42,
     "rotation_representation": "6d",
     "num_workers": 16,
     "pin_memory": true,
-    "prefetch_factor": 8,
-    "resume_checkpoint": null,
+    "prefetch_factor": 16,
+    "resume_checkpoint": "multiview_checkpoints_MOUSE_Unet_512_EffB3_ief3/checkpoint_epoch_0019.pth",
     "reset_ief_token_embedding": false,
     "use_gt_camera_init": true,
     "use_mixed_precision": false,
-    "backbone_chunk_size": 6
+    "backbone_chunk_size": 16,
+    "gradient_accumulation_steps": 8
   }
 }

--- a/smal_fitter/neuralSMIL/configs/examples/multiview_sticks_UNET.json
+++ b/smal_fitter/neuralSMIL/configs/examples/multiview_sticks_UNET.json
@@ -13,7 +13,7 @@
   },
 
   "dataset": {
-    "data_path": "Peru_res_512_3D.h5",
+    "data_path": "STICKS_full_512_3D.h5",
     "train_ratio": 0.85,
     "val_ratio": 0.05,
     "test_ratio": 0.1,
@@ -154,7 +154,7 @@
   },
 
   "training": {
-    "batch_size": 4,
+    "batch_size": 3,
     "num_epochs": 300,
     "seed": 42,
     "rotation_representation": "6d",
@@ -163,6 +163,8 @@
     "prefetch_factor": 8,
     "resume_checkpoint": null,
     "reset_ief_token_embedding": false,
-    "use_gt_camera_init": true
+    "use_gt_camera_init": true,
+    "use_mixed_precision": false,
+    "backbone_chunk_size": 6
   }
 }

--- a/smal_fitter/neuralSMIL/configs/examples/multiview_sticks_UNET.json
+++ b/smal_fitter/neuralSMIL/configs/examples/multiview_sticks_UNET.json
@@ -1,0 +1,168 @@
+{
+  "mode": "multiview",
+
+  "num_views_to_use": null,
+  "min_views_per_sample": 2,
+  "cross_attention_layers": 2,
+  "cross_attention_heads": 8,
+  "cross_attention_dropout": 0.1,
+
+  "smal_model": {
+    "smal_file": "3D_model_prep/SMILy_STICK.pkl",
+    "shape_family": null
+  },
+
+  "dataset": {
+    "data_path": "Peru_res_512_3D.h5",
+    "train_ratio": 0.85,
+    "val_ratio": 0.05,
+    "test_ratio": 0.1,
+    "dataset_fraction": 1.0
+  },
+
+  "model": {
+    "backbone_name": "unet_efficientnet_b3",
+    "freeze_backbone": false,
+    "hidden_dim": 1024,
+    "head_type": "transformer_decoder",
+    "use_unity_prior": false,
+    "rgb_only": false,
+    "transformer_depth": 4,
+    "transformer_heads": 8,
+    "transformer_dim_head": 64,
+    "transformer_mlp_dim": 1024,
+    "transformer_dropout": 0.1,
+    "transformer_ief_iters": 1,
+    "transformer_trans_scale_factor": 1
+  },
+
+  "optimizer": {
+    "learning_rate": 5e-5,
+    "weight_decay": 1e-4,
+    "gradient_clip_norm": 1.0,
+    "optimizer_type": "adamw",
+    "lr_schedule": {
+      "0": 5e-5,
+      "10": 3e-5,
+      "20": 2e-5,
+      "60": 1e-5,
+      "100": 2e-6,
+      "200": 1e-6
+    }
+  },
+
+  "loss_curriculum": {
+    "base_weights": {
+      "global_rot": 0.0,
+      "joint_rot": 0.001,
+      "betas": 0.0005,
+      "trans": 0.0005,
+      "fov": 0.001,
+      "cam_rot": 0.01,
+      "cam_trans": 0.01,
+      "log_beta_scales": 0.0005,
+      "betas_trans": 0.0005,
+      "keypoint_2d": 0.1,
+      "keypoint_3d": 0.25,
+      "silhouette": 0.0,
+      "joint_angle_regularization": 0.001,
+      "limb_scale_regularization": 0.01,
+      "limb_trans_regularization": 1,
+      "triangulation_consistency": 0.0,
+      "ief_intermediate": 0.0
+    },
+    "curriculum_stages": {
+      "1": {
+        "joint_angle_regularization": 0.01,
+        "limb_scale_regularization": 0.1,
+        "limb_trans_regularization": 1
+      },
+      "10": {
+        "keypoint_2d": 0.1,
+        "joint_angle_regularization": 1e-5,
+        "limb_scale_regularization": 0.01,
+        "limb_trans_regularization": 1
+      },
+      "20": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-6,
+        "limb_scale_regularization": 0.001,
+        "limb_trans_regularization": 0.5
+      },
+      "50": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-6,
+        "limb_scale_regularization": 1e-5,
+        "limb_trans_regularization": 0.5
+      },
+      "100": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-7,
+        "limb_scale_regularization": 5e-6,
+        "limb_trans_regularization": 0.0001
+      },
+      "150": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-7,
+        "limb_scale_regularization": 1e-6,
+        "limb_trans_regularization": 0.0001,
+        "fov": 1e-7,
+        "cam_rot": 1e-8,
+        "cam_trans": 1e-8
+      },
+      "200": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-7,
+        "limb_scale_regularization": 1e-6,
+        "limb_trans_regularization": 0.00001,
+        "fov": 1e-7,
+        "cam_rot": 1e-8,
+        "cam_trans": 1e-8
+      }
+    }
+  },
+
+  "scale_trans_beta": {
+    "mode": "separate"
+  },
+
+  "mesh_scaling": {
+    "allow_mesh_scaling": true,
+    "init_mesh_scale": 1.0,
+    "use_log_scale": true
+  },
+
+  "joint_importance": {
+    "enabled": true,
+    "important_joint_names": ["l_1_pt_l", "l_2_pt_l", "l_3_pt_l", "l_1_pt_r", "l_2_pt_r", "l_3_pt_r"],
+    "weight_multiplier": 10.0
+  },
+
+  "ignored_joint_locations": {
+    "enabled": true,
+    "ignored_joint_names": []
+  },
+
+  "output": {
+    "checkpoint_dir": "multiview_checkpoints",
+    "plots_dir": "plots",
+    "visualizations_dir": "multiview_visualizations",
+    "singleview_visualizations_dir": "multiview_singleview_renders",
+    "save_checkpoint_every": 10,
+    "generate_visualizations_every": 10,
+    "num_visualization_samples": 5
+  },
+
+  "training": {
+    "batch_size": 4,
+    "num_epochs": 300,
+    "seed": 42,
+    "rotation_representation": "6d",
+    "num_workers": 16,
+    "pin_memory": true,
+    "prefetch_factor": 8,
+    "resume_checkpoint": null,
+    "reset_ief_token_embedding": false,
+    "use_gt_camera_init": true
+  }
+}

--- a/smal_fitter/neuralSMIL/configs/examples/singleview_baseline.json
+++ b/smal_fitter/neuralSMIL/configs/examples/singleview_baseline.json
@@ -134,6 +134,7 @@
     "pin_memory": true,
     "prefetch_factor": 4,
     "resume_checkpoint": "checkpoints/best_model.pth",
-    "use_gt_camera_init": false
+    "use_gt_camera_init": false,
+    "use_mixed_precision": true
   }
 }

--- a/smal_fitter/neuralSMIL/configs/multiview_config.py
+++ b/smal_fitter/neuralSMIL/configs/multiview_config.py
@@ -123,6 +123,9 @@ class MultiViewConfig(BaseTrainingConfig):
             'loss_weights': self.get_loss_weights_for_epoch(0),
             'reset_ief_token_embedding': self.training.reset_ief_token_embedding,
             'use_gt_camera_init': self.training.use_gt_camera_init,
+            'use_mixed_precision': self.training.use_mixed_precision,
+            'backbone_chunk_size': self.training.backbone_chunk_size,
+            'gradient_accumulation_steps': self.training.gradient_accumulation_steps,
 
             # Joint importance / ignored joints / loss curriculum — must be carried
             # through so that DDP worker processes (mp.spawn / torchrun) can re-sync

--- a/smal_fitter/neuralSMIL/dataset_preprocessing.py
+++ b/smal_fitter/neuralSMIL/dataset_preprocessing.py
@@ -79,10 +79,12 @@ class DatasetPreprocessor:
         self.verbose = verbose
         
         # Determine target resolution based on backbone
-        if backbone_name.startswith('vit'):
-            self.target_resolution = 224
-        else:
+        from backbone_factory import BackboneFactory
+        if target_resolution is not None and target_resolution != 224:
+            # Explicit override takes priority
             self.target_resolution = target_resolution
+        else:
+            self.target_resolution = BackboneFactory.get_default_input_resolution(backbone_name)
         
         # Statistics tracking
         self.stats = {

--- a/smal_fitter/neuralSMIL/docs/implementation_history/config_system_refactor_plan.md
+++ b/smal_fitter/neuralSMIL/docs/implementation_history/config_system_refactor_plan.md
@@ -1,3 +1,5 @@
+<!-- Created: 2026-02-17 | Last modified: 2026-03-24 -->
+
 # SMILify Configuration System Refactor Plan
 
 ## Executive Summary

--- a/smal_fitter/neuralSMIL/docs/implementation_history/decoder_architecture_issues.md
+++ b/smal_fitter/neuralSMIL/docs/implementation_history/decoder_architecture_issues.md
@@ -1,3 +1,5 @@
+<!-- Created: 2026-02-26 | Last modified: 2026-03-24 -->
+
 # Multiview Transformer Decoder — Architecture Issues
 
 Identified during deep review of `multiview_baseline.json` config and the
@@ -82,7 +84,7 @@ with normal equations and Tikhonov damping) and compares the result against
 detached body model 3D predictions. Gradients flow through the differentiable
 triangulation into the camera heads.
 
-See [docs/triangulation_consistency_loss.md](docs/triangulation_consistency_loss.md)
+See [triangulation_consistency_loss.md](triangulation_consistency_loss.md)
 for full details. Validated with 12 synthetic tests in
 `tests/test_triangulation_consistency.py`.
 

--- a/smal_fitter/neuralSMIL/docs/implementation_history/multiview_implementation_plan.md
+++ b/smal_fitter/neuralSMIL/docs/implementation_history/multiview_implementation_plan.md
@@ -1,3 +1,5 @@
+<!-- Created: 2026-01-05 | Last modified: 2026-01-14 -->
+
 # Multi-View SLEAP Dataset Implementation Plan
 
 ## Executive Summary

--- a/smal_fitter/neuralSMIL/docs/implementation_history/triangulation_consistency_loss.md
+++ b/smal_fitter/neuralSMIL/docs/implementation_history/triangulation_consistency_loss.md
@@ -1,0 +1,181 @@
+<!-- Created: 2026-02-27 | Last modified: 2026-02-27 -->
+
+# Triangulation Consistency Loss
+
+## Motivation
+
+In the multi-view regressor, each view has its own **camera head** that independently predicts FOV, rotation, and translation. While the 2D keypoint reprojection loss (`keypoint_2d`) and optional direct camera supervision (`cam_rot`, `cam_trans`, `fov`) provide per-view camera learning signals, neither explicitly enforces that the cameras from different views are **geometrically consistent with each other**.
+
+Without an explicit multi-view geometric constraint, the camera heads can drift into configurations where each camera independently explains its own 2D observations well, but the cameras collectively do not agree on a coherent 3D scene. The `triangulation_consistency` loss closes this gap.
+
+## Conceptual Overview
+
+The idea is simple:
+
+1. Take the **ground-truth 2D keypoints** observed in each view.
+2. Use the **predicted camera parameters** from each view to triangulate those 2D observations into 3D.
+3. Compare the triangulated 3D points against the model's **predicted 3D joints** (from the body model).
+
+If the predicted cameras are geometrically consistent, the triangulated 3D points will agree with the body model's 3D prediction. If the cameras are inconsistent, triangulation will produce points that diverge from the body model — and the loss penalises this.
+
+### Gradient flow
+
+The gradient flows through the **triangulation** into the **camera heads** — this is what makes the loss effective. The body model's 3D joint predictions (`joints_3d`) are **detached** and serve as a stable target, since they are already well-supervised by the `keypoint_3d` loss.
+
+```
+GT 2D keypoints ─┐
+                  ├──▶ Differentiable DLT ──▶ triangulated_3d ──┐
+Predicted cameras ┘        (grad flows)                          ├──▶ MSE loss
+                                                                 │
+Predicted 3D joints (detached, no grad) ────────────────────────┘
+```
+
+This design avoids conflicting gradient signals: the body model doesn't get pulled in two directions (by both `keypoint_3d` and `triangulation_consistency`), and the cameras get direct geometric feedback.
+
+## Mathematical Formulation
+
+### DLT (Direct Linear Transform) with w=1 normalisation
+
+Given a 3D point `X = [X, Y, Z, 1]^T` in homogeneous coordinates and a 4x4 projection matrix `P`, the projection into normalised device coordinates (NDC) is:
+
+```
+[u*w, v*w, z*w, w] = [X, Y, Z, 1] @ P      (PyTorch3D row-vector convention)
+```
+
+After perspective divide: `u = (x @ P[:,0]) / (x @ P[:,3])`, `v = (x @ P[:,1]) / (x @ P[:,3])`.
+
+The DLT constraint for each view is:
+
+```
+u * P[:,3] - P[:,0] = 0    (dot product with [X,Y,Z,1])
+v * P[:,3] - P[:,1] = 0
+```
+
+This gives 2 linear equations per view, forming a system `A @ [X, Y, Z, 1]^T = 0` with `A` of shape `(2V, 4)` for `V` views.
+
+**w=1 normalisation:** Rather than solving the homogeneous system via SVD (which has numerically unstable gradients), we fix the homogeneous coordinate to 1 and rewrite:
+
+```
+A[:, :3] @ [X, Y, Z]^T = -A[:, 3]
+```
+
+This is an overdetermined linear system solved via the **normal equations**:
+
+```
+(A_xyz^T @ A_xyz + λI) @ p = A_xyz^T @ (-a_w)
+```
+
+where `λ = 1e-6` is Tikhonov damping that ensures the system is always full-rank, even when some views are masked out (producing zero rows in `A`).
+
+### Why normal equations instead of SVD or lstsq
+
+| Method | Gradient stability | Rank-deficiency handling |
+|--------|-------------------|------------------------|
+| `torch.linalg.svd` | Unstable — backward has `1/(σ_i - σ_j)` terms that explode for near-degenerate systems | Handles naturally but gradients are NaN |
+| `torch.linalg.lstsq` | Moderate — uses LAPACK `gelsd` internally | Fails hard with error when matrix is rank-deficient |
+| **Normal equations + `torch.linalg.solve`** | **Stable** — backward is another linear solve (implicit function theorem) | **Always works** — Tikhonov damping ensures full rank |
+
+### PyTorch3D projection matrix convention
+
+PyTorch3D uses **row-vector convention**: `ndc_homo = world_homo @ P` where `P` is `(4, 4)`. The **columns** of `P` correspond to output dimensions:
+
+- Column 0: `u * w` (x output)
+- Column 1: `v * w` (y output)
+- Column 2: `z * w` (depth output)
+- Column 3: `w` (homogeneous weight)
+
+This is transposed relative to the standard computer vision convention (column-vector, `P @ x`), so the DLT must index **columns** of `P`, not rows.
+
+### NDC coordinate recovery
+
+The forward projection in `_batch_project_joints_to_views` produces normalised [0,1] keypoints via:
+
+```python
+screen = transform_points_screen(joints, image_size=img_size)[:, :, [1, 0]]  # swap x,y
+normalised = screen / img_size
+```
+
+The inverse (used in `_triangulate_joints_dlt`) recovers NDC from normalised keypoints:
+
+```python
+kp_screen = keypoints_2d * img_size      # un-normalise
+kp_screen = kp_screen[..., [1, 0]]       # un-swap (y,x) -> (x,y)
+ndc_xy = 1.0 - kp_screen / (img_size / 2)  # screen -> NDC
+```
+
+Note the sign: PyTorch3D's `ndc_to_screen` maps `screen = (W-1)/2 * (1 - ndc)`, so the inverse is `ndc = 1 - screen / (W/2)`, **not** `screen / (W/2) - 1`.
+
+## Implementation Details
+
+### Files
+
+- **Loss computation:** `multiview_smil_regressor.py`, in `_compute_multiview_losses()`, starting at the `TRIANGULATION CONSISTENCY LOSS` section.
+- **Triangulation solver:** `multiview_smil_regressor.py`, method `_triangulate_joints_dlt()`.
+- **Configuration:** `configs/examples/multiview_sticks.json`, under `loss_curriculum.base_weights.triangulation_consistency` and `loss_curriculum.curriculum_stages`.
+- **Tests:** `tests/test_triangulation_consistency.py` — 12 synthetic tests covering round-trip accuracy, gradient flow, loss computation, and edge cases.
+
+### Loss computation (`_compute_multiview_losses`)
+
+```python
+# 1. Triangulate GT 2D keypoints using predicted cameras (differentiable)
+triangulated, tri_valid = self._triangulate_joints_dlt(
+    target_kps, visibility,
+    predicted_params['fov_per_view'],
+    predicted_params['cam_rot_per_view'],
+    predicted_params['cam_trans_per_view'],
+    ...
+)
+
+# 2. Reject outlier triangulations (no grad — just masking)
+with torch.no_grad():
+    tri_valid = tri_valid & (triangulated.norm(dim=-1) < 50.0)
+
+# 3. Compute MSE against detached body model predictions
+diff_sq = (triangulated - joints_3d.detach()) ** 2
+
+# 4. Mask by validity and joint importance, normalise
+masked_loss = diff_sq * mask_weights.unsqueeze(-1)
+tri_loss = masked_loss.sum() / denom
+```
+
+Key design decisions:
+
+- **`joints_3d.detach()`**: The body model's 3D predictions are the target. No gradient flows into the body model through this loss — it only supervises cameras.
+- **`triangulated` retains grad**: The triangulation is differentiable w.r.t. the predicted camera parameters (via `torch.linalg.solve` backward). Gradients flow: `tri_loss → triangulated → AtA/Atb → projection matrices → camera head parameters`.
+- **Outlier rejection at norm > 50**: Early in training, cameras may be poorly calibrated, producing nonsensical triangulations. These are masked out (the threshold is generous — the actual scene is much smaller).
+- **Joint importance weights**: If configured, important joints (e.g., leg endpoints) receive higher weight in the loss, matching the weighting used by other losses.
+
+### Triangulation solver (`_triangulate_joints_dlt`)
+
+**Input:** GT 2D keypoints `(B, V, J, 2)`, per-joint visibility `(B, V, J)`, predicted camera parameters.
+
+**Output:** Triangulated 3D joints `(B, J, 3)`, valid mask `(B, J)`.
+
+Steps:
+
+1. **Build projection matrices** from predicted FOV, rotation, translation using PyTorch3D's `FoVPerspectiveCameras.get_full_projection_transform()`.
+2. **Convert [0,1]-normalised keypoints to NDC** by inverting the screen-space mapping.
+3. **Construct the DLT constraint matrix** `A` of shape `(B, J, 2V, 4)`: two rows per view per joint, using columns of `P`. Zero out rows for invisible joints. The constraint rows are assembled as `(B, V, J, 2, 4)` then reshaped via `.permute(0, 2, 1, 3, 4).reshape(B, J, V*2, 4)` — the permute is critical to avoid scrambling joints with constraint rows in memory.
+4. **Split** `A` into `A_xyz (B, J, 2V, 3)` and `a_w (B, J, 2V)` for the w=1 formulation.
+5. **Form normal equations**: `AtA = A_xyz^T @ A_xyz + λI`, `Atb = A_xyz^T @ (-a_w)`.
+6. **Solve** via `torch.linalg.solve(AtA, Atb)` → `(B, J, 3)`.
+7. **Valid mask**: joints visible in >= 2 views.
+
+## Configuration
+
+The loss is controlled by the `triangulation_consistency` key in the loss curriculum. It starts at **0.0** (disabled) and ramps up via curriculum stages.
+
+Example curriculum from `multiview_sticks.json`:
+
+| Epoch | Weight | Rationale |
+|-------|--------|-----------|
+| 0     | 0.0    | Cameras still initialising; triangulation would be noise |
+| 30    | 0.001  | Cameras have basic structure; introduce gentle geometric pressure |
+| 45    | 0.005  | Increase as cameras improve |
+| 50    | 0.01   | Moderate enforcement |
+| 60    | 0.05   | Cameras should be reasonably calibrated |
+| 100   | 0.1    | Strong multi-view consistency |
+| 150   | 0.2    | Direct camera supervision (`cam_rot`, `cam_trans`) drops to ~0; triangulation consistency takes over as primary geometric constraint |
+| 200   | 0.5    | Dominant geometric signal for fine-tuning camera heads |
+
+The curriculum is designed so that as direct camera parameter supervision is reduced (the `cam_rot`/`cam_trans` weights drop to `1e-8` by epoch 150), the triangulation consistency loss ramps up to replace it with a purely geometric constraint. This transition encourages the cameras to be self-consistent rather than memorising GT parameters.

--- a/smal_fitter/neuralSMIL/docs/implementation_history/triangulation_consistency_loss.md
+++ b/smal_fitter/neuralSMIL/docs/implementation_history/triangulation_consistency_loss.md
@@ -1,4 +1,4 @@
-<!-- Created: 2026-02-27 | Last modified: 2026-02-27 -->
+<!-- Created: 2026-02-27 | Last modified: 2026-03-24 -->
 
 # Triangulation Consistency Loss
 
@@ -179,3 +179,11 @@ Example curriculum from `multiview_sticks.json`:
 | 200   | 0.5    | Dominant geometric signal for fine-tuning camera heads |
 
 The curriculum is designed so that as direct camera parameter supervision is reduced (the `cam_rot`/`cam_trans` weights drop to `1e-8` by epoch 150), the triangulation consistency loss ramps up to replace it with a purely geometric constraint. This transition encourages the cameras to be self-consistent rather than memorising GT parameters.
+
+## Status: Largely Disabled (March 2026)
+
+In practice this loss is kept at or near zero in current training configs. The primary training datasets use **calibrated cameras with ground-truth 3D keypoints** obtained from multi-view triangulation (SLEAP / Anipose). In this setting the triangulation consistency loss does not provide a meaningful learning signal: the GT 3D points are themselves the output of a solved camera system, so triangulating the GT 2D observations with predicted cameras and comparing against those same GT 3D points creates a circular constraint rather than an independent geometric one.
+
+The loss was originally designed for a scenario where camera parameters are learned from scratch without GT 3D supervision — there, enforcing cross-view geometric agreement through triangulation would provide genuine structure. With calibrated cameras and 3D GT already available, the direct `keypoint_3d`, `cam_rot`, `cam_trans`, and `fov` losses give stronger and more direct supervision.
+
+The implementation and tests are retained for future use cases where cameras must be discovered without calibration data.

--- a/smal_fitter/neuralSMIL/memory_optimization.py
+++ b/smal_fitter/neuralSMIL/memory_optimization.py
@@ -109,7 +109,19 @@ class GradientCheckpointing:
         elif backbone_name.startswith('resnet'):
             # ResNet doesn't typically need gradient checkpointing
             print(f"Gradient checkpointing not needed for {backbone_name}")
-    
+        elif backbone_name.startswith('unet_'):
+            # UNet encoder is a timm model; checkpointing the encoder blocks
+            # can help when the encoder is unfrozen at higher resolutions.
+            if hasattr(model.backbone, 'backbone') and hasattr(model.backbone.backbone, 'encoder'):
+                encoder = model.backbone.backbone.encoder
+                if hasattr(encoder, 'set_grad_checkpointing'):
+                    encoder.set_grad_checkpointing(True)
+                    print(f"Enabled gradient checkpointing for UNet encoder ({backbone_name})")
+                else:
+                    print(f"Gradient checkpointing not supported for UNet encoder ({backbone_name})")
+            else:
+                print(f"Gradient checkpointing not applicable for {backbone_name}")
+
     @staticmethod
     def disable_checkpointing(model: nn.Module, backbone_name: str):
         """Disable gradient checkpointing for the model."""
@@ -118,6 +130,12 @@ class GradientCheckpointing:
                 for block in model.backbone.backbone.blocks:
                     if hasattr(block, 'gradient_checkpointing_disable'):
                         block.gradient_checkpointing_disable()
+            print(f"Disabled gradient checkpointing for {backbone_name}")
+        elif backbone_name.startswith('unet_'):
+            if hasattr(model.backbone, 'backbone') and hasattr(model.backbone.backbone, 'encoder'):
+                encoder = model.backbone.backbone.encoder
+                if hasattr(encoder, 'set_grad_checkpointing'):
+                    encoder.set_grad_checkpointing(False)
             print(f"Disabled gradient checkpointing for {backbone_name}")
 
 
@@ -295,6 +313,14 @@ def recommend_training_config(backbone_name: str, gpu_memory_gb: float = 24.0) -
             config['hidden_dim'] = 768
         elif 'large' in backbone_name:
             config['hidden_dim'] = 1024
+    elif backbone_name.startswith('unet_'):
+        _unet_hidden = {
+            'unet_efficientnet_b0': 512,
+            'unet_efficientnet_b3': 512,
+            'unet_resnet34': 512,
+            'unet_mobilenet_v3': 256,
+        }
+        config['hidden_dim'] = _unet_hidden.get(backbone_name, 512)
     else:
         config['hidden_dim'] = 2048
     

--- a/smal_fitter/neuralSMIL/multiview_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/multiview_smil_regressor.py
@@ -2380,7 +2380,7 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
                     sample_view_mask.append(True)
                 else:
                     # Pad with zeros
-                    dummy_img = torch.zeros(3, 224, 224, dtype=torch.float32, device=self.device)
+                    dummy_img = torch.zeros(3, self.input_resolution, self.input_resolution, dtype=torch.float32, device=self.device)
                     all_images_per_view[v].append(dummy_img)
                     sample_cam_indices.append(0)
                     sample_view_mask.append(False)

--- a/smal_fitter/neuralSMIL/multiview_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/multiview_smil_regressor.py
@@ -368,10 +368,11 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
                  cross_attention_heads: int = 8,
                  cross_attention_dropout: float = 0.1,
                  use_gt_camera_init: bool = False,
+                 backbone_chunk_size: Optional[int] = None,
                  **kwargs):
         """
         Initialize the multi-view SMIL regressor.
-        
+
         Args:
             device: PyTorch device
             data_batch: Batch data for initialization
@@ -383,6 +384,9 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
             cross_attention_layers: Number of cross-attention layers for feature fusion
             cross_attention_heads: Number of attention heads
             cross_attention_dropout: Dropout for attention layers
+            backbone_chunk_size: Max images to process through backbone at once.
+                None = all at once (default). Set to e.g. 6 to reduce peak VRAM
+                when using many views and/or large input resolutions.
             **kwargs: Additional arguments passed to parent SMILImageRegressor
         """
         # Initialize parent single-view regressor
@@ -392,6 +396,7 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
         self.canonical_camera_order = canonical_camera_order or []
         self.num_canonical_cameras = len(self.canonical_camera_order) if self.canonical_camera_order else max_views
         self.use_gt_camera_init = use_gt_camera_init
+        self.backbone_chunk_size = backbone_chunk_size
         
         # Cross-attention feature fusion
         self.view_fusion = MultiViewFeatureFusion(
@@ -456,21 +461,44 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
         batch_size = images_per_view[0].size(0)
         num_views = len(images_per_view)
         
-        # =================== OPTIMIZED: Single backbone pass for all views ===================
+        # =================== Backbone pass for all views ===================
         # Stack all views: List of (B, C, H, W) -> (B, V, C, H, W) -> (B*V, C, H, W)
-        # This gives 5-8x speedup vs sequential backbone calls
         all_images = torch.stack(images_per_view, dim=1)  # (B, V, C, H, W)
         B, V, C, H, W = all_images.shape
         all_images_flat = all_images.view(B * V, C, H, W)  # (B*V, C, H, W)
-        
-        # Single backbone forward pass for all views at once.
-        # For transformer_decoder + any backbone with forward_with_spatial():
-        # also extract per-view spatial tokens for rich cross-attention context.
-        # ViT: (B*V, 196, D) patch tokens.  UNet: (B*V, H*W, C) decoder feature map.
+
+        # Backbone forward pass — optionally chunked to reduce peak VRAM.
+        # When backbone_chunk_size is set, we process images in smaller batches
+        # through the backbone and concatenate results. This is mathematically
+        # equivalent to processing all at once since the backbone is per-image.
+        use_spatial = (self.head_type == 'transformer_decoder'
+                       and hasattr(self.backbone, 'forward_with_spatial'))
+        chunk = self.backbone_chunk_size
+
         patch_tokens = None
-        if self.head_type == 'transformer_decoder' and hasattr(self.backbone, 'forward_with_spatial'):
+        if chunk is not None and chunk < B * V:
+            # Chunked backbone forward to reduce peak VRAM
+            feat_chunks = []
+            patch_chunks = [] if use_spatial else None
+            for i in range(0, B * V, chunk):
+                imgs_chunk = all_images_flat[i:i + chunk]
+                if use_spatial:
+                    f, p = self.backbone.forward_with_spatial(imgs_chunk)
+                    feat_chunks.append(f)
+                    patch_chunks.append(p)
+                else:
+                    feat_chunks.append(self.backbone(imgs_chunk))
+            all_features = torch.cat(feat_chunks, dim=0)
+            if use_spatial:
+                all_patches = torch.cat(patch_chunks, dim=0)
+                _spatial_dim = (
+                    self.backbone.get_spatial_dim()
+                    if hasattr(self.backbone, 'get_spatial_dim')
+                    else self.feature_dim
+                )
+                patch_tokens = all_patches.view(B, V, -1, _spatial_dim)
+        elif use_spatial:
             all_features, all_patches = self.backbone.forward_with_spatial(all_images_flat)
-            # all_features: (B*V, feature_dim), all_patches: (B*V, P, spatial_dim)
             _spatial_dim = (
                 self.backbone.get_spatial_dim()
                 if hasattr(self.backbone, 'get_spatial_dim')

--- a/smal_fitter/neuralSMIL/multiview_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/multiview_smil_regressor.py
@@ -421,8 +421,16 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
 
         # Per-view positional embedding for patch tokens so the decoder's
         # cross-attention knows which view each spatial patch came from.
-        if self.head_type == 'transformer_decoder' and self.backbone_name.startswith('vit'):
-            self.patch_view_embed = nn.Embedding(self.num_canonical_cameras, self.feature_dim).to(device)
+        # Dimension must match the spatial feature channels, which equals
+        # feature_dim for ViT (patch dim == CLS dim) but may differ for
+        # UNet (decoder channels != bottleneck channels).
+        if self.head_type == 'transformer_decoder' and hasattr(self.backbone, 'forward_with_spatial'):
+            _patch_embed_dim = (
+                self.backbone.get_spatial_dim()
+                if hasattr(self.backbone, 'get_spatial_dim')
+                else self.feature_dim
+            )
+            self.patch_view_embed = nn.Embedding(self.num_canonical_cameras, _patch_embed_dim).to(device)
             nn.init.normal_(self.patch_view_embed.weight, mean=0.0, std=0.02)
     
     def forward_multiview(self, images_per_view: List[torch.Tensor], 
@@ -455,14 +463,20 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
         B, V, C, H, W = all_images.shape
         all_images_flat = all_images.view(B * V, C, H, W)  # (B*V, C, H, W)
         
-        # Single backbone forward pass for all views at once
-        # For ViT + transformer_decoder: also extract per-view patch tokens
-        # (B*V, 196, D) for rich spatial cross-attention context.
+        # Single backbone forward pass for all views at once.
+        # For transformer_decoder + any backbone with forward_with_spatial():
+        # also extract per-view spatial tokens for rich cross-attention context.
+        # ViT: (B*V, 196, D) patch tokens.  UNet: (B*V, H*W, C) decoder feature map.
         patch_tokens = None
-        if self.head_type == 'transformer_decoder' and self.backbone_name.startswith('vit'):
+        if self.head_type == 'transformer_decoder' and hasattr(self.backbone, 'forward_with_spatial'):
             all_features, all_patches = self.backbone.forward_with_spatial(all_images_flat)
-            # all_features: (B*V, D) CLS tokens, all_patches: (B*V, 196, D)
-            patch_tokens = all_patches.view(B, V, -1, self.feature_dim)  # (B, V, 196, D)
+            # all_features: (B*V, feature_dim), all_patches: (B*V, P, spatial_dim)
+            _spatial_dim = (
+                self.backbone.get_spatial_dim()
+                if hasattr(self.backbone, 'get_spatial_dim')
+                else self.feature_dim
+            )
+            patch_tokens = all_patches.view(B, V, -1, _spatial_dim)  # (B, V, P, spatial_dim)
         else:
             all_features = self.backbone(all_images_flat)  # (B*V, feature_dim)
 
@@ -2417,9 +2431,11 @@ def create_multiview_regressor(device, batch_size, shape_family, use_unity_prior
         MultiViewSMILImageRegressor instance
     """
     # Create placeholder data batch
-    # Use input_resolution if provided, otherwise default to 224
+    # Derive input_resolution from backbone if not explicitly provided
     # This ensures the renderer is initialized with the correct size
-    input_resolution = kwargs.get('input_resolution', 224)
+    from backbone_factory import BackboneFactory
+    _backbone_name = kwargs.get('backbone_name', 'resnet152')
+    input_resolution = kwargs.get('input_resolution', BackboneFactory.get_default_input_resolution(_backbone_name))
     data_batch = torch.zeros(batch_size, 3, input_resolution, input_resolution, dtype=torch.float32, device=device)
     
     return MultiViewSMILImageRegressor(

--- a/smal_fitter/neuralSMIL/multiview_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/multiview_smil_regressor.py
@@ -2158,7 +2158,7 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
         canonical_joints = canonical_joints.float()
         faces_batch = faces_batch.long()
 
-        _, rendered_joints_raw = self.renderer(verts, canonical_joints, faces_batch)
+        _, rendered_joints_raw = self.renderer(verts, canonical_joints, faces_batch, joints_only=True)
         
         # Normalize rendered joints using the actual renderer image size
         # This ensures consistency between training loss and visualization

--- a/smal_fitter/neuralSMIL/multiview_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/multiview_smil_regressor.py
@@ -654,7 +654,7 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
                     view_emb = self.patch_view_embed(camera_indices)  # (B, V, D)
                     spatial_feats = patch_tokens + view_emb.unsqueeze(2)  # (B, V, P, D)
                     Bp, Vp, P, D = spatial_feats.shape
-                    spatial_feats = spatial_feats.view(Bp, Vp * P, D)  # (B, V*P, D)
+                    spatial_feats = spatial_feats.reshape(Bp, Vp * P, D)  # (B, V*P, D)
                 else:
                     spatial_feats = features  # (B, V, D) — one token per view
             else:

--- a/smal_fitter/neuralSMIL/run_multiview_inference.py
+++ b/smal_fitter/neuralSMIL/run_multiview_inference.py
@@ -29,6 +29,7 @@ socket.getaddrinfo = _getaddrinfo_ipv4_only
 
 import argparse
 import os
+import sys
 import re
 import tempfile
 import pickle
@@ -36,6 +37,10 @@ import shutil
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
 from datetime import timedelta
+
+# Ensure project root and neuralSMIL dir are on sys.path (needed for mp.spawn)
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import numpy as np
 import cv2
@@ -377,7 +382,8 @@ def load_multiview_model_from_checkpoint(checkpoint_path: Path,
     print(f"Model architecture: max_views={max_views}, canonical_camera_order has {len(canonical_camera_order)} cameras")
     print(f"Note: Model can handle samples with fewer views than max_views via view_mask")
 
-    input_resolution = 224 if backbone_name.startswith("vit") else 512
+    from backbone_factory import BackboneFactory
+    input_resolution = BackboneFactory.get_default_input_resolution(backbone_name)
 
     model = create_multiview_regressor(
         device=device,
@@ -455,7 +461,9 @@ def create_multiview_visualization(model: MultiViewSMILImageRegressor,
 
     # Calculate grid dimensions dynamically based on actual num_views (same as training)
     # This allows samples with fewer views than max_views to be visualized correctly
-    img_size = 224
+    # Derive img_size from the model's renderer resolution so visualization is correct
+    # for any backbone (ViT=224, ResNet/UNet=512, etc.)
+    img_size = int(model.renderer.image_size)
     margin = 5
     grid_width = num_views * img_size + (num_views + 1) * margin
     grid_height = 2 * img_size + 3 * margin
@@ -1268,14 +1276,14 @@ def main_inference(
     if world_size > 1:
         sampler = DistributedSampler(dataset, num_replicas=world_size, rank=rank, shuffle=False)
 
-    # Calculate frame dimensions
-    img_size = 224
+    # Calculate frame dimensions — derive from the model's renderer resolution
+    img_size = int(model.renderer.image_size)
     margin = 5
     grid_width = model_max_views * img_size + (model_max_views + 1) * margin
     grid_height = 2 * img_size + 3 * margin
 
     # Determine singleview frame size (use first sample to get actual size)
-    singleview_size = (224, 224)  # Default
+    singleview_size = (img_size, img_size)  # Default, overridden below by test render
     if len(dataset) > 0:
         try:
             test_frame = render_singleview_collage(

--- a/smal_fitter/neuralSMIL/run_multiview_inference.py
+++ b/smal_fitter/neuralSMIL/run_multiview_inference.py
@@ -1215,6 +1215,7 @@ def main_inference(
         print(f"Device: {device}")
         print(f"World size: {world_size}")
         print(f"Dataset: {dataset_path}")
+        print(f"Checkpoint: {args.checkpoint if args.checkpoint else '(auto-detect)'}")
         if args.max_frames is not None:
             print(f"Max frames: {args.max_frames} (testing mode)")
         if args.disable_scaling:
@@ -1226,7 +1227,7 @@ def main_inference(
             print(f"Temporal smoothing: {args.smoothing_window} frames")
         print(f"{'='*60}\n")
     
-    checkpoint_path = _find_default_checkpoint()
+    checkpoint_path = Path(args.checkpoint) if args.checkpoint else _find_default_checkpoint()
     
     # Load dataset
     # Use num_views_to_use=None to use all available views per sample (same as training)
@@ -1499,6 +1500,7 @@ def main():
     parser.add_argument("--master-port", type=str, default=None, help="Master port for distributed processing (default: from MASTER_PORT env var or 12355)")
     parser.add_argument("--smal_file", type=str, default=None, help="Path to SMAL model file to override config.py SMAL_FILE (optional)")
     parser.add_argument("--shape_family", type=int, default=None, help="Shape family to use with --smal_file (optional, defaults to config.SHAPE_FAMILY)")
+    parser.add_argument("--checkpoint", type=str, default=None, help="Path to model checkpoint (.pth) to use for inference (default: auto-detected from multiview_checkpoints/)")
     args = parser.parse_args()
     
     # Get master port from args or environment variable

--- a/smal_fitter/neuralSMIL/run_singleview_inference.py
+++ b/smal_fitter/neuralSMIL/run_singleview_inference.py
@@ -646,7 +646,7 @@ def load_and_preprocess_image(image_path: str, model: SMILImageRegressor, crop_m
         # Preprocess with proper cropping
         target_resolution = model.input_resolution
         preprocessed_image, transform_info = preprocess_frame(
-            image_data, target_resolution, crop_mode, keypoints_2d=keypoints_2d
+            image_data, target_resolution, crop_mode
         )
         
         # Convert to tensor (C, H, W) format

--- a/smal_fitter/neuralSMIL/run_singleview_inference.py
+++ b/smal_fitter/neuralSMIL/run_singleview_inference.py
@@ -460,11 +460,9 @@ def load_model_from_checkpoint(checkpoint_path: str, device: str) -> Tuple[SMILI
         # Create placeholder data for model initialization
         placeholder_data = torch.zeros((batch_size, 3, 512, 512))
         
-        # Determine input resolution based on backbone
-        if model_config['backbone_name'].startswith('vit'):
-            input_resolution = 224
-        else:
-            input_resolution = 512
+        # Determine input resolution from the centralized backbone factory
+        from backbone_factory import BackboneFactory
+        input_resolution = BackboneFactory.get_default_input_resolution(model_config['backbone_name'])
         
         print(f"Creating model with input resolution: {input_resolution}")
         
@@ -843,10 +841,7 @@ def render_prediction_on_frame(model: SMILImageRegressor, predicted_params: Dict
         frame_h, frame_w = original_frame.shape[:2]
         
         # Resize to model's expected input size for rendering
-        if model.backbone_name.startswith('vit'):
-            render_size = 224
-        else:
-            render_size = 512
+        render_size = model.input_resolution
         
         # Prepare image for rendering
         if original_frame.max() > 1.0:
@@ -1007,10 +1002,7 @@ def generate_visualization(model: SMILImageRegressor, predicted_params: Dict[str
             rgb_image = original_image.astype(np.float32)
         
         # Resize to model's expected input size
-        if model.backbone_name.startswith('vit'):
-            target_size = (224, 224)
-        else:
-            target_size = (512, 512)
+        target_size = (model.input_resolution, model.input_resolution)
         
         if rgb_image.shape[:2] != target_size:
             rgb_image = cv2.resize(rgb_image, target_size)
@@ -1260,11 +1252,8 @@ def process_video(model: SMILImageRegressor, video_path: str, output_folder: str
     
     # Determine output video dimensions based on export mode
     if video_export_mode == 'side_by_side':
-        # Determine render size based on model backbone
-        if model.backbone_name.startswith('vit'):
-            render_size = 224
-        else:
-            render_size = 512
+        # Determine render size based on model's input resolution
+        render_size = model.input_resolution
         
         # For side-by-side: input video will be rescaled to match render_size height
         # Output width will be 2 * render_size

--- a/smal_fitter/neuralSMIL/smil_datasets.py
+++ b/smal_fitter/neuralSMIL/smil_datasets.py
@@ -69,10 +69,8 @@ class replicAntSMILDataset(torch.utils.data.Dataset):
         self.original_resolution = self._detect_input_resolution()
         
         # Determine target resolution based on backbone
-        if backbone_name.startswith('vit'):
-            self.target_resolution = 224  # ViT expects 224x224
-        else:
-            self.target_resolution = self.original_resolution  # ResNet can handle original resolution
+        from backbone_factory import BackboneFactory
+        self.target_resolution = BackboneFactory.get_default_input_resolution(backbone_name)
 
     def _detect_input_resolution(self):
         """Detect the input resolution from the batch data file."""

--- a/smal_fitter/neuralSMIL/smil_image_regressor.py
+++ b/smal_fitter/neuralSMIL/smil_image_regressor.py
@@ -280,12 +280,16 @@ class SMILImageRegressor(SMALFitter):
         # Merge with user-provided config
         config = {**default_config, **self.transformer_config}
         
-        # For ViT backbones, we can use spatial features
-        if self.backbone_name.startswith('vit'):
-            context_dim = self.feature_dim  # Same as feature dim for ViT
-        else:
-            # For ResNet, we don't have spatial features, so use global features as context
-            context_dim = self.feature_dim
+        # context_dim = dimension of spatial tokens passed to cross-attention.
+        # For ViT: patch tokens share the same dim as the CLS token (feature_dim).
+        # For UNet: spatial decoder channels differ from bottleneck feature_dim;
+        #   get_spatial_dim() returns the correct value.
+        # For ResNet: no spatial features, context_dim is unused but set consistently.
+        context_dim = (
+            self.backbone.get_spatial_dim()
+            if hasattr(self.backbone, 'get_spatial_dim')
+            else self.feature_dim
+        )
         
         # Create transformer decoder head
         self.transformer_head = build_smil_transformer_decoder_head(
@@ -359,13 +363,8 @@ class SMILImageRegressor(SMALFitter):
             # Assume values are in [0, 255] range
             image_data = image_data.astype(np.float32) / 255.0
         
-        # Resize to appropriate resolution based on backbone type
-        if self.backbone_name.startswith('vit'):
-            # Vision Transformers expect 224x224 input
-            target_size = (224, 224)
-        else:
-            # ResNet can handle higher resolutions
-            target_size = (self.input_resolution, self.input_resolution)
+        # Resize to the model's configured input resolution
+        target_size = (self.input_resolution, self.input_resolution)
         if len(image_data.shape) == 4:
             # Batch of images
             batch_size = image_data.shape[0]
@@ -401,12 +400,7 @@ class SMILImageRegressor(SMALFitter):
             Scaled keypoint coordinates in normalized [0,1] format
         """
         if target_size is None:
-            if self.backbone_name.startswith('vit'):
-                # Vision Transformers expect 224x224 input
-                target_size = (224, 224)
-            else:
-                # ResNet can handle higher resolutions
-                target_size = (self.input_resolution, self.input_resolution)
+            target_size = (self.input_resolution, self.input_resolution)
         
         # Handle different input formats
         if isinstance(original_size, (int, float)):
@@ -483,12 +477,7 @@ class SMILImageRegressor(SMALFitter):
                 image_data = image_data.astype(np.float32) / 255.0
             
             # Resize to appropriate resolution based on backbone type
-            if self.backbone_name.startswith('vit'):
-                # Vision Transformers expect 224x224 input
-                target_size = (224, 224)
-            else:
-                # ResNet can handle higher resolutions
-                target_size = (self.input_resolution, self.input_resolution)
+            target_size = (self.input_resolution, self.input_resolution)
             if image_data.shape[:2] != target_size:
                 image_data = cv2.resize(image_data, target_size)
             
@@ -631,12 +620,13 @@ class SMILImageRegressor(SMALFitter):
     
     def _forward_transformer_decoder(self, images: torch.Tensor, batch_size: int) -> Dict[str, torch.Tensor]:
         """Forward pass for transformer decoder regression head."""
-        # Extract features using backbone
-        if self.backbone_name.startswith('vit'):
-            # For ViT, get both global and spatial features
+        # Extract features using backbone.
+        # Any backbone that implements forward_with_spatial() provides rich spatial
+        # context for the decoder's cross-attention (ViT patch tokens, UNet decoder
+        # feature maps, …).  Fall back to global-only for ResNet.
+        if hasattr(self.backbone, 'forward_with_spatial'):
             global_features, spatial_features = self.backbone.forward_with_spatial(images)
         else:
-            # For ResNet, only global features available
             global_features = self.backbone(images)
             spatial_features = None
         

--- a/smal_fitter/neuralSMIL/train_multiview_regressor.py
+++ b/smal_fitter/neuralSMIL/train_multiview_regressor.py
@@ -2786,20 +2786,20 @@ if __name__ == "__main__":
                             "Optional when using --config with dataset.data_path set. "
                             "CLI value overrides config file.")
     
-    # Model configuration
-    parser.add_argument("--backbone_name", type=str, default='vit_large_patch16_224',
-                       help="Backbone network name")
+    # Model configuration (defaults are None so JSON config values are not overridden)
+    parser.add_argument("--backbone_name", type=str, default=None,
+                       help="Backbone network name (default: from config or vit_large_patch16_224)")
     parser.add_argument("--freeze_backbone", action="store_true",
                        help="Freeze backbone weights")
-    parser.add_argument("--head_type", type=str, default='transformer_decoder',
+    parser.add_argument("--head_type", type=str, default=None,
                        choices=['mlp', 'transformer_decoder'],
-                       help="Type of regression head")
-    parser.add_argument("--hidden_dim", type=int, default=512,
-                       help="Hidden dimension for MLP head")
-    parser.add_argument("--cross_attention_layers", type=int, default=2,
-                       help="Number of cross-attention layers")
-    parser.add_argument("--cross_attention_heads", type=int, default=8,
-                       help="Number of cross-attention heads")
+                       help="Type of regression head (default: from config)")
+    parser.add_argument("--hidden_dim", type=int, default=None,
+                       help="Hidden dimension for MLP head (default: from config)")
+    parser.add_argument("--cross_attention_layers", type=int, default=None,
+                       help="Number of cross-attention layers (default: from config)")
+    parser.add_argument("--cross_attention_heads", type=int, default=None,
+                       help="Number of cross-attention heads (default: from config)")
     
     # Training configuration
     parser.add_argument("--batch_size", type=int, default=None,
@@ -2823,16 +2823,16 @@ if __name__ == "__main__":
                        help="Max views to use per sample (None = all)")
     
     # Output configuration
-    parser.add_argument("--checkpoint_dir", type=str, default='multiview_checkpoints',
-                       help="Checkpoint directory")
-    parser.add_argument("--visualizations_dir", type=str, default='multiview_visualizations',
-                       help="Visualizations directory")
-    parser.add_argument("--save_every_n_epochs", type=int, default=5,
-                       help="Save checkpoint every N epochs")
-    parser.add_argument("--visualize_every_n_epochs", type=int, default=1,
-                       help="Generate visualizations every N epochs (0 to disable)")
-    parser.add_argument("--num_visualization_samples", type=int, default=3,
-                       help="Number of samples to visualize each time")
+    parser.add_argument("--checkpoint_dir", type=str, default=None,
+                       help="Checkpoint directory (default: from config)")
+    parser.add_argument("--visualizations_dir", type=str, default=None,
+                       help="Visualizations directory (default: from config)")
+    parser.add_argument("--save_every_n_epochs", type=int, default=None,
+                       help="Save checkpoint every N epochs (default: from config)")
+    parser.add_argument("--visualize_every_n_epochs", type=int, default=None,
+                       help="Generate visualizations every N epochs, 0 to disable (default: from config)")
+    parser.add_argument("--num_visualization_samples", type=int, default=None,
+                       help="Number of samples to visualize each time (default: from config)")
     
     # Resume training
     parser.add_argument("--resume_checkpoint", type=str, default=None,

--- a/smal_fitter/neuralSMIL/train_multiview_regressor.py
+++ b/smal_fitter/neuralSMIL/train_multiview_regressor.py
@@ -48,8 +48,10 @@ import sys
 import random
 import json
 from tqdm import tqdm
+from contextlib import nullcontext
 from datetime import datetime, timedelta
 import argparse
+import gc
 import imageio
 from typing import Optional
 
@@ -556,67 +558,85 @@ def train_epoch(model: MultiViewSMILImageRegressor,
     total_loss = 0.0
     loss_components_sum = {}
     num_batches = 0
-    
+
+    accum_steps = training_config.get('gradient_accumulation_steps', 1)
+
     progress_bar = tqdm(train_loader, desc=f"Epoch {epoch}", disable=(rank != 0))
-    
+
     for batch_idx, (x_data_batch, y_data_batch) in enumerate(progress_bar):
-        optimizer.zero_grad()
-        
+        # Zero gradients only at the start of each accumulation window
+        if batch_idx % accum_steps == 0:
+            optimizer.zero_grad()
+
+        # Whether this is the last mini-batch in the current accumulation window
+        is_step_batch = ((batch_idx + 1) % accum_steps == 0
+                         or (batch_idx + 1) == len(train_loader))
+
+        # For DDP: suppress gradient all-reduce during accumulation steps.
+        # Sync only happens on the step batch to avoid redundant communication
+        # and incorrect gradient averaging mid-accumulation.
+        maybe_no_sync = (model.no_sync() if (is_distributed and accum_steps > 1
+                         and not is_step_batch) else nullcontext())
+
         try:
-            # Forward pass with mixed precision if enabled
-            if scaler is not None:
-                with torch.cuda.amp.autocast():
+            with maybe_no_sync:
+                # Forward pass with mixed precision if enabled
+                if scaler is not None:
+                    with torch.cuda.amp.autocast():
+                        predicted_params, _, auxiliary_data = base_model.predict_from_multiview_batch(
+                            x_data_batch, y_data_batch
+                        )
+
+                        if predicted_params is None:
+                            continue
+
+                        loss, loss_components = base_model.compute_multiview_batch_loss(
+                            predicted_params, y_data_batch,
+                            loss_weights=loss_weights,
+                            return_components=True
+                        )
+                        # Scale loss by accumulation steps so accumulated gradients
+                        # have the same magnitude as a single large batch
+                        loss = loss / accum_steps
+
+                    # Backward with scaling (gradients accumulate across mini-batches)
+                    scaler.scale(loss).backward()
+
+                    # Only step optimizer at the end of each accumulation window
+                    if is_step_batch:
+                        if training_config.get('gradient_clip_norm', 0) > 0:
+                            scaler.unscale_(optimizer)
+                            torch.nn.utils.clip_grad_norm_(
+                                model.parameters(),
+                                training_config['gradient_clip_norm']
+                            )
+                        scaler.step(optimizer)
+                        scaler.update()
+                else:
+                    # Standard forward/backward
                     predicted_params, _, auxiliary_data = base_model.predict_from_multiview_batch(
                         x_data_batch, y_data_batch
                     )
-                    
+
                     if predicted_params is None:
                         continue
-                    
+
                     loss, loss_components = base_model.compute_multiview_batch_loss(
                         predicted_params, y_data_batch,
                         loss_weights=loss_weights,
                         return_components=True
                     )
-                
-                # Backward with scaling
-                scaler.scale(loss).backward()
-                
-                # Gradient clipping
-                if training_config.get('gradient_clip_norm', 0) > 0:
-                    scaler.unscale_(optimizer)
-                    torch.nn.utils.clip_grad_norm_(
-                        model.parameters(), 
-                        training_config['gradient_clip_norm']
-                    )
-                
-                scaler.step(optimizer)
-                scaler.update()
-            else:
-                # Standard forward/backward
-                predicted_params, _, auxiliary_data = base_model.predict_from_multiview_batch(
-                    x_data_batch, y_data_batch
-                )
-                
-                if predicted_params is None:
-                    continue
-                
-                loss, loss_components = base_model.compute_multiview_batch_loss(
-                    predicted_params, y_data_batch,
-                    loss_weights=loss_weights,
-                    return_components=True
-                )
-                
-                loss.backward()
-                
-                # Gradient clipping
-                if training_config.get('gradient_clip_norm', 0) > 0:
-                    torch.nn.utils.clip_grad_norm_(
-                        model.parameters(),
-                        training_config['gradient_clip_norm']
-                    )
-                
-                optimizer.step()
+                    loss = loss / accum_steps
+
+                    loss.backward()
+
+                    if is_step_batch:
+                        if training_config.get('gradient_clip_norm', 0) > 0:
+                            torch.nn.utils.clip_grad_norm_(
+                                model.parameters(),
+                                training_config['gradient_clip_norm']
+                            )
+                        optimizer.step()
 
             # IEF refinement monitoring: track per-iteration pose delta norms.
             # ief_pose_delta_N = avg L2 distance between iter N and iter N-1 predictions.
@@ -630,19 +650,19 @@ def train_epoch(model: MultiViewSMILImageRegressor,
                     key = f'ief_pose_delta_{i}'
                     loss_components_sum[key] = loss_components_sum.get(key, 0.0) + delta
 
-            # Accumulate metrics
-            total_loss += loss.item()
+            # Accumulate metrics (use un-scaled loss for logging)
+            total_loss += loss.item() * accum_steps
             num_batches += 1
-            
+
             for key, value in loss_components.items():
                 if key not in loss_components_sum:
                     loss_components_sum[key] = 0.0
                 loss_components_sum[key] += value.item() if torch.is_tensor(value) else value
-            
+
             # Update progress bar
             if rank == 0:
                 progress_bar.set_postfix({
-                    'loss': f'{loss.item():.4f}',
+                    'loss': f'{loss.item() * accum_steps:.4f}',
                     'kp2d': f'{loss_components.get("keypoint_2d", torch.tensor(0.0)).item():.4f}'
                 })
             
@@ -654,7 +674,6 @@ def train_epoch(model: MultiViewSMILImageRegressor,
             # Without this, the failed forward pass's GPU tensors stay alive
             # and every subsequent batch also OOMs.
             if isinstance(e, torch.cuda.OutOfMemoryError):
-                import gc
                 gc.collect()
                 torch.cuda.empty_cache()
             continue
@@ -873,8 +892,13 @@ def visualize_multiview_training_progress(model: MultiViewSMILImageRegressor,
                 continue
         
         print(f"Generated {len(collected_samples)} multi-view visualizations for epoch {epoch} in {epoch_dir}")
-        
+
     finally:
+        # Free collected sample data (may hold GPU tensors) before restoring RNG
+        del collected_samples
+        gc.collect()
+        torch.cuda.empty_cache()
+
         # Restore random states
         torch.set_rng_state(torch_rng_state)
         np.random.set_state(numpy_rng_state)
@@ -1392,8 +1416,13 @@ def visualize_singleview_renders(model: MultiViewSMILImageRegressor,
                 torch.cuda.empty_cache()
         
         print(f"Generated single-view renders for {num_rendered} samples (epoch {epoch}) in {epoch_dir}")
-    
+
     finally:
+        # Free collected sample data (may hold GPU tensors) before restoring RNG
+        del collected_samples
+        gc.collect()
+        torch.cuda.empty_cache()
+
         # Restore random states
         torch.set_rng_state(torch_rng_state)
         np.random.set_state(numpy_rng_state)
@@ -1964,10 +1993,13 @@ def render_singleview_for_sample(model: MultiViewSMILImageRegressor,
             print(f"Warning: Failed to render view {view_idx} for sample {sample_idx}: {e}")
             continue
         finally:
-            # Clean up GPU memory after each view to prevent OOM
-            # The SMALFitter creates a renderer with GPU resources that need to be freed
+            # Clean up GPU memory after each view to prevent OOM.
+            # SMALFitter (nn.Module) has circular refs that prevent immediate
+            # deallocation on `del`; gc.collect() breaks the cycles so
+            # empty_cache() can actually return the memory to CUDA.
             if 'temp_fitter' in locals():
                 del temp_fitter
+            gc.collect()
             torch.cuda.empty_cache()
     
     # Generate 3D keypoint visualization if 3D data is available
@@ -2260,14 +2292,39 @@ def load_checkpoint(filepath, model, optimizer=None, scheduler=None, device='cud
     current_model = model.module if hasattr(model, 'module') else model
     current_state = current_model.state_dict()
 
+    # SMALFitter default parameters whose first dim is batch_size.
+    # These are not learned by the neural network — just init values for
+    # the optimization-based fitter.  A batch_size change should not be
+    # treated as an architecture change.
+    _batch_dim_keys = {
+        'global_rotation', 'joint_rotations', 'trans',
+        'log_beta_scales', 'betas_trans',
+    }
+
     filtered_state = {}
     skipped = []
+    resized = []
     for key, param in saved_state.items():
         if key in current_state and param.shape != current_state[key].shape:
-            skipped.append(f"  {key}: checkpoint {param.shape} vs model {current_state[key].shape}")
+            # Check if this is a batch-size-only mismatch on a SMALFitter default
+            cur_shape = current_state[key].shape
+            if (key in _batch_dim_keys
+                    and param.shape[1:] == cur_shape[1:]
+                    and param.shape[0] != cur_shape[0]):
+                # Adapt: take first slice or repeat to match new batch dim
+                new_bs = cur_shape[0]
+                adapted = param[:new_bs] if param.shape[0] >= new_bs else param[0:1].expand(new_bs, *param.shape[1:]).contiguous()
+                filtered_state[key] = adapted
+                resized.append(f"  {key}: {param.shape} -> {adapted.shape} (batch dim adapted)")
+            else:
+                skipped.append(f"  {key}: checkpoint {param.shape} vs model {cur_shape}")
         else:
             filtered_state[key] = param
 
+    if resized:
+        print(f"Adapted {len(resized)} SMALFitter default params to new batch size:")
+        for r in resized:
+            print(r)
     if skipped:
         print(f"Skipped {len(skipped)} mismatched keys (will use fresh init):")
         for s in skipped:
@@ -2525,7 +2582,8 @@ def main(config: dict):
         allow_mesh_scaling=allow_mesh_scaling,
         mesh_scale_init=mesh_scale_init,
         use_gt_camera_init=config.get('use_gt_camera_init', False),
-        transformer_config=config.get('transformer_config', {})
+        transformer_config=config.get('transformer_config', {}),
+        backbone_chunk_size=config.get('backbone_chunk_size', None)
     )
     
     model = model.to(device)
@@ -2543,6 +2601,13 @@ def main(config: dict):
         trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
         print(f"Total parameters: {total_params:,}")
         print(f"Trainable parameters: {trainable_params:,}")
+        if config.get('backbone_chunk_size'):
+            print(f"Backbone chunk size: {config['backbone_chunk_size']} (reduces peak VRAM)")
+        if config.get('use_mixed_precision'):
+            print(f"Mixed precision training: enabled")
+        accum = config.get('gradient_accumulation_steps', 1)
+        if accum > 1:
+            print(f"Gradient accumulation: {accum} steps (effective batch size: {config['batch_size'] * accum})")
     
     # Create optimizer
     optimizer = optim.AdamW(
@@ -2700,9 +2765,12 @@ def main(config: dict):
                 num_samples=config.get('num_visualization_samples', 3),
                 rank=rank
             )
-            
+            # Flush GPU memory between visualization passes
+            gc.collect()
+            torch.cuda.empty_cache()
+
             # Single-view mesh renders (full SMALFitter visualization per view)
-            singleview_dir = config.get('singleview_visualizations_dir', 
+            singleview_dir = config.get('singleview_visualizations_dir',
                                          config['visualizations_dir'].replace('visualizations', 'singleview_renders'))
             visualize_singleview_renders(
                 model=model,
@@ -2716,9 +2784,15 @@ def main(config: dict):
             )
 
             # Free GPU memory fragmented by visualization (SMALFitter instances, renderers, etc.)
-            import gc
             gc.collect()
             torch.cuda.empty_cache()
+
+        # Flush GPU memory on ALL ranks before starting the next epoch.
+        # Rank 0 gets cleanup inside the visualization block, but non-zero ranks
+        # sit at the barrier with stale training tensors (gradients, activations)
+        # still allocated — causing OOM when the next epoch's forward pass spikes usage.
+        gc.collect()
+        torch.cuda.empty_cache()
 
         # Sync all ranks after rank-0-only operations (visualization, checkpointing)
         # so non-zero ranks don't race ahead into the next epoch and deadlock.
@@ -2882,9 +2956,11 @@ if __name__ == "__main__":
     parser.add_argument("--master-port", type=str, default=None,
                        help="Master port for distributed training (default: from MASTER_PORT env var or 12355)")
     
-    # Mixed precision
+    # Mixed precision and memory optimization
     parser.add_argument("--use_mixed_precision", action="store_true",
                        help="Use mixed precision training")
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=None,
+                       help="Accumulate gradients over N mini-batches before optimizer step")
     parser.add_argument("--use_gt_camera_init", action="store_true", default=None,
                        help="Use GT camera params (when available) as base and predict deltas")
     
@@ -2944,6 +3020,9 @@ if __name__ == "__main__":
             if args.reset_ief_token_embedding:
                 cli_overrides['training'] = cli_overrides.get('training', {})
                 cli_overrides['training']['reset_ief_token_embedding'] = True
+            if args.gradient_accumulation_steps is not None:
+                cli_overrides['training'] = cli_overrides.get('training', {})
+                cli_overrides['training']['gradient_accumulation_steps'] = args.gradient_accumulation_steps
 
             new_config = load_config(
                 config_file=args.config,

--- a/smal_fitter/neuralSMIL/train_multiview_regressor.py
+++ b/smal_fitter/neuralSMIL/train_multiview_regressor.py
@@ -969,8 +969,9 @@ def create_multiview_visualization(model: MultiViewSMILImageRegressor,
             import traceback
             traceback.print_exc()
     
-    # Visualization parameters
-    img_size = 224  # Standard visualization size
+    # Visualization parameters — derive from model's actual renderer resolution
+    # so that visualization is correct for any backbone (ViT=224, ResNet/UNet=512, etc.)
+    img_size = int(model.renderer.image_size)
     margin = 5
     
     # Create visualization grid
@@ -2462,13 +2463,14 @@ def main(config: dict):
     # Determine input resolution based on backbone
     # This ensures the renderer is initialized with the correct size
     backbone_name = config['backbone_name']
-    if backbone_name.startswith('vit'):
-        input_resolution = 224  # ViT uses 224x224
-    else:
-        input_resolution = 512  # ResNet typically uses 512x512
-    
+    from backbone_factory import BackboneFactory
+    input_resolution = config.get(
+        'input_resolution',
+        BackboneFactory.get_default_input_resolution(backbone_name)
+    )
+
     if rank == 0:
-        print(f"Using input resolution: {input_resolution}x{input_resolution} (based on backbone: {backbone_name})")
+        print(f"Using input resolution: {input_resolution}x{input_resolution} (backbone: {backbone_name})")
     
     # Get mesh scaling config
     allow_mesh_scaling = config.get('allow_mesh_scaling', False)

--- a/smal_fitter/neuralSMIL/train_multiview_regressor.py
+++ b/smal_fitter/neuralSMIL/train_multiview_regressor.py
@@ -632,6 +632,13 @@ def train_epoch(model: MultiViewSMILImageRegressor,
             print(f"Error in batch {batch_idx}: {e}")
             import traceback
             traceback.print_exc()
+            # Clean up GPU memory after OOM to prevent cascading failures.
+            # Without this, the failed forward pass's GPU tensors stay alive
+            # and every subsequent batch also OOMs.
+            if isinstance(e, torch.cuda.OutOfMemoryError):
+                import gc
+                gc.collect()
+                torch.cuda.empty_cache()
             continue
     
     # Compute averages
@@ -2689,6 +2696,11 @@ def main(config: dict):
                 num_samples=config.get('num_visualization_samples', 3),
                 rank=rank
             )
+
+            # Free GPU memory fragmented by visualization (SMALFitter instances, renderers, etc.)
+            import gc
+            gc.collect()
+            torch.cuda.empty_cache()
 
         # Sync all ranks after rank-0-only operations (visualization, checkpointing)
         # so non-zero ranks don't race ahead into the next epoch and deadlock.

--- a/smal_fitter/neuralSMIL/train_multiview_regressor.py
+++ b/smal_fitter/neuralSMIL/train_multiview_regressor.py
@@ -561,12 +561,19 @@ def train_epoch(model: MultiViewSMILImageRegressor,
 
     accum_steps = training_config.get('gradient_accumulation_steps', 1)
 
+    # Track how many mini-batches in the current accumulation window actually
+    # produced a valid backward pass.  When a batch is skipped (None prediction
+    # or exception), the window has fewer contributors.  We only step the
+    # optimizer if at least one backward occurred.
+    valid_steps_in_window = 0
+
     progress_bar = tqdm(train_loader, desc=f"Epoch {epoch}", disable=(rank != 0))
 
     for batch_idx, (x_data_batch, y_data_batch) in enumerate(progress_bar):
         # Zero gradients only at the start of each accumulation window
         if batch_idx % accum_steps == 0:
             optimizer.zero_grad()
+            valid_steps_in_window = 0
 
         # Whether this is the last mini-batch in the current accumulation window
         is_step_batch = ((batch_idx + 1) % accum_steps == 0
@@ -588,6 +595,9 @@ def train_epoch(model: MultiViewSMILImageRegressor,
                         )
 
                         if predicted_params is None:
+                            if is_step_batch and valid_steps_in_window > 0:
+                                scaler.step(optimizer)
+                                scaler.update()
                             continue
 
                         loss, loss_components = base_model.compute_multiview_batch_loss(
@@ -601,6 +611,7 @@ def train_epoch(model: MultiViewSMILImageRegressor,
 
                     # Backward with scaling (gradients accumulate across mini-batches)
                     scaler.scale(loss).backward()
+                    valid_steps_in_window += 1
 
                     # Only step optimizer at the end of each accumulation window
                     if is_step_batch:
@@ -619,6 +630,8 @@ def train_epoch(model: MultiViewSMILImageRegressor,
                     )
 
                     if predicted_params is None:
+                        if is_step_batch and valid_steps_in_window > 0:
+                            optimizer.step()
                         continue
 
                     loss, loss_components = base_model.compute_multiview_batch_loss(
@@ -629,6 +642,7 @@ def train_epoch(model: MultiViewSMILImageRegressor,
                     loss = loss / accum_steps
 
                     loss.backward()
+                    valid_steps_in_window += 1
 
                     if is_step_batch:
                         if training_config.get('gradient_clip_norm', 0) > 0:
@@ -665,7 +679,7 @@ def train_epoch(model: MultiViewSMILImageRegressor,
                     'loss': f'{loss.item() * accum_steps:.4f}',
                     'kp2d': f'{loss_components.get("keypoint_2d", torch.tensor(0.0)).item():.4f}'
                 })
-            
+
         except Exception as e:
             print(f"Error in batch {batch_idx}: {e}")
             import traceback
@@ -676,6 +690,17 @@ def train_epoch(model: MultiViewSMILImageRegressor,
             if isinstance(e, torch.cuda.OutOfMemoryError):
                 gc.collect()
                 torch.cuda.empty_cache()
+            # If this was the step batch and we had valid backwards in this
+            # window, step the optimizer so accumulated gradients aren't lost.
+            if is_step_batch and valid_steps_in_window > 0:
+                try:
+                    if scaler is not None:
+                        scaler.step(optimizer)
+                        scaler.update()
+                    else:
+                        optimizer.step()
+                except Exception:
+                    pass
             continue
     
     # Compute averages

--- a/smal_fitter/neuralSMIL/train_multiview_regressor.py
+++ b/smal_fitter/neuralSMIL/train_multiview_regressor.py
@@ -117,14 +117,32 @@ def setup_ddp(rank: int, world_size: int, port: str = '12345', local_rank: int =
         print(f"WARNING: MASTER_ADDR '{master_addr}' is not an IPv4 address!")
         print(f"  Attempting to resolve to IPv4...")
         try:
-            # Force IPv4 resolution
             import socket
-            result = socket.getaddrinfo(master_addr, master_port, socket.AF_INET, socket.SOCK_STREAM)
-            if result:
-                master_addr = result[0][4][0]
-                print(f"  Resolved to: {master_addr}")
+            resolved = False
+            # On HPC systems, inter-node communication uses InfiniBand.
+            # Try the InfiniBand hostname first (append 'i' before first dot or at end).
+            dot_idx = master_addr.find('.')
+            if dot_idx > 0:
+                ib_hostname = master_addr[:dot_idx] + 'i' + master_addr[dot_idx:]
             else:
-                print(f"  ERROR: Could not resolve {master_addr} to IPv4!")
+                ib_hostname = master_addr + 'i'
+            try:
+                result = socket.getaddrinfo(ib_hostname, master_port, socket.AF_INET, socket.SOCK_STREAM)
+                if result:
+                    master_addr = result[0][4][0]
+                    print(f"  Resolved InfiniBand hostname '{ib_hostname}' to: {master_addr}")
+                    resolved = True
+            except socket.gaierror:
+                pass  # InfiniBand hostname doesn't exist, fall back to original
+
+            if not resolved:
+                # Fall back to resolving the original hostname
+                result = socket.getaddrinfo(master_addr, master_port, socket.AF_INET, socket.SOCK_STREAM)
+                if result:
+                    master_addr = result[0][4][0]
+                    print(f"  Resolved to: {master_addr}")
+                else:
+                    print(f"  ERROR: Could not resolve {master_addr} to IPv4!")
         except Exception as e:
             print(f"  ERROR resolving hostname: {e}")
     

--- a/smal_fitter/neuralSMIL/train_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/train_smil_regressor.py
@@ -21,6 +21,7 @@ from torch.utils.data.distributed import DistributedSampler
 import numpy as np
 import os
 import sys
+import gc
 import random
 from tqdm import tqdm
 from scipy.spatial.transform import Rotation
@@ -466,6 +467,10 @@ def train_epoch(model, train_loader, optimizer, criterion, device, epoch, loss_w
             print(f"Error processing batch {batch_idx}: {e}")
             import traceback
             traceback.print_exc()
+            # Clean up GPU memory after OOM to prevent cascading failures.
+            if isinstance(e, torch.cuda.OutOfMemoryError):
+                gc.collect()
+                torch.cuda.empty_cache()
             continue
     
     # Average parameter errors over all batches

--- a/smal_fitter/neuralSMIL/train_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/train_smil_regressor.py
@@ -716,11 +716,8 @@ def visualize_training_progress(model, val_loader, device, epoch, model_config, 
                     # Create silhouette tensor
                     sil = torch.FloatTensor(x_data["input_image_mask"])[None, None, ...]
                     
-                    # Convert keypoints to pixel coordinates using backbone image size
-                    if model_config['backbone_name'].startswith('vit'):
-                        target_size = 224
-                    else:
-                        target_size = 512
+                    # Convert keypoints to pixel coordinates using model's actual resolution
+                    target_size = model.input_resolution
                         
                     pixel_coords = y_data["keypoints_2d"].copy()
                     pixel_coords[:, 0] = pixel_coords[:, 0] * target_size  # y coordinates  
@@ -774,11 +771,8 @@ def visualize_training_progress(model, val_loader, device, epoch, model_config, 
             # Set proper target joints and visibility for visualization
             # Convert normalized keypoints back to pixel coordinates for visualization
             if 'keypoints_2d' in y_data and 'keypoint_visibility' in y_data:
-                # Use backbone-specific image size for keypoint conversion
-                if model_config['backbone_name'].startswith('vit'):
-                    target_height, target_width = 224, 224  # ViT uses 224x224
-                else:
-                    target_height, target_width = 512, 512  # ResNet uses 512x512
+                # Use model's actual resolution for keypoint conversion
+                target_height, target_width = model.input_resolution, model.input_resolution
                 
                 # Convert normalized [0,1] coordinates to pixel coordinates
                 keypoints_2d = y_data['keypoints_2d']  # Shape: (num_joints, 2), already in [y_norm, x_norm] format
@@ -1549,16 +1543,13 @@ def main(dataset_name=None, checkpoint_path=None, config_override=None):
         print(f"Using backbone: {model_config['backbone_name']}")
     
     # Determine appropriate input resolution based on backbone
-    if model_config['backbone_name'].startswith('vit'):
-        # Vision Transformers expect 224x224 input
-        input_resolution = 224
-        if not is_distributed or rank == 0:
-            print(f"Using ViT input resolution: {input_resolution}x{input_resolution}")
-    else:
-        # ResNet can handle higher resolutions
-        input_resolution = dataset.get_input_resolution()
-        if not is_distributed or rank == 0:
-            print(f"Using ResNet input resolution: {input_resolution}x{input_resolution}")
+    from backbone_factory import BackboneFactory
+    input_resolution = model_config.get(
+        'input_resolution',
+        BackboneFactory.get_default_input_resolution(model_config['backbone_name'])
+    )
+    if not is_distributed or rank == 0:
+        print(f"Using input resolution: {input_resolution}x{input_resolution} (backbone: {model_config['backbone_name']})")
     
     model = SMILImageRegressor(
         device=device,

--- a/smal_fitter/neuralSMIL/training_config.py
+++ b/smal_fitter/neuralSMIL/training_config.py
@@ -581,23 +581,28 @@ class TrainingConfig:
                 config['model_config']['hidden_dim'] = 768
             elif 'large' in backbone_name:
                 config['model_config']['hidden_dim'] = 1024
+        elif backbone_name.startswith('unet_'):
+            _unet_hidden = {
+                'unet_efficientnet_b0': 512,
+                'unet_efficientnet_b3': 512,
+                'unet_resnet34': 512,
+                'unet_mobilenet_v3': 256,
+            }
+            config['model_config']['hidden_dim'] = _unet_hidden.get(backbone_name, 512)
         elif backbone_name.startswith('resnet'):
             config['model_config']['hidden_dim'] = 2048
-        
+
         # Adjust transformer config based on backbone
         if config['model_config']['head_type'] == 'transformer_decoder':
-            # For ViT backbones, use spatial features
             if backbone_name.startswith('vit'):
-                # ViT provides spatial features, so we can use them as context
+                # ViT provides spatial features via patch tokens
                 pass  # Keep default config
+            elif backbone_name.startswith('unet_'):
+                # UNet provides spatial features via decoder feature maps
+                pass  # context_dim is set dynamically from backbone.get_spatial_dim()
             else:
-                # For ResNet, we don't have spatial features
-                # Adjust context_dim to match feature_dim
-                if 'base' in backbone_name:
-                    config['model_config']['transformer_config']['context_dim'] = 768
-                elif 'large' in backbone_name:
-                    config['model_config']['transformer_config']['context_dim'] = 1024
-                elif backbone_name.startswith('resnet'):
+                # For ResNet, no spatial features — context_dim matches feature_dim
+                if backbone_name.startswith('resnet'):
                     config['model_config']['transformer_config']['context_dim'] = 2048
         
         return config
@@ -746,7 +751,13 @@ class TrainingConfig:
         
         # Print backbone-specific information
         backbone_name = config['model_config']['backbone_name']
-        print(f"  Backbone type: {'Vision Transformer' if backbone_name.startswith('vit') else 'ResNet'}")
+        if backbone_name.startswith('vit'):
+            _btype = 'Vision Transformer'
+        elif backbone_name.startswith('unet_'):
+            _btype = 'UNet (CNN encoder + decoder)'
+        else:
+            _btype = 'ResNet'
+        print(f"  Backbone type: {_btype}")
         print(f"  Feature dimension: {config['model_config']['hidden_dim']}")
         
         # Print head-specific information

--- a/smal_fitter/neuralSMIL/transformer_decoder.py
+++ b/smal_fitter/neuralSMIL/transformer_decoder.py
@@ -333,9 +333,21 @@ class SMILTransformerDecoderHead(nn.Module):
         Returns:
             Dictionary containing predicted SMIL parameters
         """
+        # Force FP32 for the decoder.  The backbone benefits from FP16, but
+        # the IEF loop accumulates residual updates through LayerNorm, attention,
+        # and parameter heads where FP16 precision causes NaN cascades.  The
+        # decoder is small so FP32 has negligible memory impact.
+        with torch.cuda.amp.autocast(enabled=False):
+            features = features.float()
+            if spatial_features is not None:
+                spatial_features = spatial_features.float()
+            return self._forward_impl(features, spatial_features)
+
+    def _forward_impl(self, features: torch.Tensor, spatial_features: Optional[torch.Tensor] = None) -> Dict[str, torch.Tensor]:
+        """Inner forward running in FP32 (called from forward with autocast disabled)."""
         batch_size = features.shape[0]
         device = features.device
-        
+
         # Initialize predictions
         pred_pose = self.init_pose.expand(batch_size, -1).to(device)
         pred_betas = self.init_betas.expand(batch_size, -1).to(device)

--- a/smal_fitter/p3d_renderer.py
+++ b/smal_fitter/p3d_renderer.py
@@ -124,22 +124,26 @@ class Renderer(torch.nn.Module):
         if hasattr(self.color_renderer.shader, 'cameras'):
             self.color_renderer.shader.cameras = self.cameras
 
-    def forward(self, vertices, points, faces, render_texture=False):
+    def forward(self, vertices, points, faces, render_texture=False, joints_only=False):
         # PyTorch3D expects float32 inputs; upstream code can accidentally produce float64
         # (e.g., from SMAL model buffers / numpy defaults). Force here to avoid dtype mismatch.
         vertices = vertices.float()
         points = points.float()
         faces = faces.long()
 
+        screen_size = torch.ones(vertices.shape[0], 2, dtype=torch.float32, device=vertices.device) * self.image_size
+        # fix discussed here: https://github.com/benjiebob/SMALify/issues/30
+        # answer by mshooter
+        proj_points = self.cameras.transform_points_screen(points, image_size=screen_size)[:, :, [1, 0]]
+
+        if joints_only:
+            return None, proj_points
+
         tex = torch.ones_like(vertices) * self.mesh_color  # (1, V, 3)
         textures = Textures(verts_rgb=tex)
 
         mesh = Meshes(verts=vertices, faces=faces, textures=textures)
         sil_images = self.silhouette_renderer(mesh)[..., -1].unsqueeze(1)
-        screen_size = torch.ones(vertices.shape[0], 2, dtype=torch.float32, device=vertices.device) * self.image_size
-        # fix discussed here: https://github.com/benjiebob/SMALify/issues/30
-        # answer by mshooter
-        proj_points = self.cameras.transform_points_screen(points, image_size=screen_size)[:, :, [1, 0]]
 
         if render_texture:
             color_image = self.color_renderer(mesh).permute(0, 3, 1, 2)[:, :3, :, :]

--- a/smal_fitter/sleap_data/preprocess_sleap_dataset.py
+++ b/smal_fitter/sleap_data/preprocess_sleap_dataset.py
@@ -1583,8 +1583,10 @@ Examples:
     parser.add_argument("--target_resolution", type=int, default=224,
                        help="Target image resolution in pixels (default: 224)")
     parser.add_argument("--backbone", dest="backbone_name", default='vit_large_patch16_224',
-                       choices=['vit_large_patch16_224', 'vit_base_patch16_224', 'resnet152'],
-                       help="Backbone network name (default: vit_large_patch16_224)")
+                       help="Backbone network name (default: vit_large_patch16_224). "
+                            "Supported: vit_base_patch16_224, vit_large_patch16_224, "
+                            "resnet50/101/152, unet_efficientnet_b0/b3, unet_resnet34, "
+                            "unet_mobilenet_v3")
     parser.add_argument("--jpeg_quality", type=int, default=95,
                        help="JPEG compression quality 1-100 (default: 95)")
     parser.add_argument("--crop_mode", type=str, default='default',

--- a/smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py
+++ b/smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py
@@ -1710,7 +1710,7 @@ Examples:
                        help="JPEG compression quality 1-100 (default: 95)")
     parser.add_argument("--crop_mode", type=str, default='centred',
                        choices=['default', 'centred', 'bbox_crop'],
-                       help="Image cropping mode (default: default)")
+                       help="Image cropping mode (default: centred)")
     
     # Multi-view specific options
     parser.add_argument("--min_views", type=int, default=2,

--- a/smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py
+++ b/smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py
@@ -161,7 +161,8 @@ class SLEAPMultiViewPreprocessor:
             'views_excluded_processing_error': 0,
             'total_views_attempted': 0,  # Views in available_cameras that we tried to process
             'total_views_included': 0,  # Views successfully included
-            'views_undistorted': 0  # Views that were undistorted
+            'views_undistorted': 0,  # Views that were undistorted
+            'views_reprojected': 0  # Views using reprojected 2D keypoints
         }
         
         # Canonical camera ordering (will be determined from first session)
@@ -244,21 +245,27 @@ class SLEAPMultiViewPreprocessor:
         print(f"Established canonical camera order: {canonical_order}")
         return canonical_order
     
-    def _discover_multiview_frames(self, loader: SLEAPDataLoader, 
-                                   session_path: str) -> List[Dict[str, Any]]:
+    def _discover_multiview_frames(self, loader: SLEAPDataLoader,
+                                   session_path: str,
+                                   reproj_file: Optional[h5py.File] = None) -> List[Dict[str, Any]]:
         """
         Discover all frames that have multi-view data.
-        
+
         Args:
             loader: SLEAPDataLoader instance
             session_path: Path to session
-            
+            reproj_file: Optional open reprojections.h5 handle. When provided and
+                         use_reprojections=True, camera/frame availability is derived
+                         from reprojection validity in addition to SLEAP annotation
+                         coverage. Cameras absent from reprojections.h5 (excluded from
+                         triangulation) are removed from the candidate set.
+
         Returns:
             List of frame info dicts with keys: frame_idx, available_cameras
         """
-        # Collect all annotated frame indices per camera
+        # Collect all annotated frame indices per camera (from SLEAP)
         camera_frames: Dict[str, Set[int]] = {}
-        
+
         for camera_name in loader.camera_views:
             try:
                 camera_data = loader.load_camera_data(camera_name)
@@ -267,7 +274,35 @@ class SLEAPMultiViewPreprocessor:
             except Exception as e:
                 print(f"Warning: Failed to get frames for camera {camera_name}: {e}")
                 camera_frames[camera_name] = set()
-        
+
+        # When using reprojections: adjust camera_frames based on reprojection validity.
+        # - Cameras absent from reprojections.h5 were excluded from triangulation (bad
+        #   calibration) and must be removed so they don't contribute raw SLEAP keypoints.
+        # - Cameras present in reprojections.h5 gain any frames where triangulation
+        #   succeeded even if SLEAP missed a detection (e.g. Camera3 with only 14k frames).
+        if self.use_reprojections and reproj_file is not None:
+            cameras_to_remove = []
+            for camera_name in list(camera_frames.keys()):
+                ds = self._resolve_reprojection_dataset(reproj_file, camera_name, warn=False)
+                if ds is None:
+                    cameras_to_remove.append(camera_name)
+                else:
+                    # Fast scan: read first keypoint's x-coordinate per frame (~576 KB).
+                    # A non-NaN value means triangulation succeeded for at least that joint.
+                    try:
+                        first_kp_x = np.array(ds[:, 0, 0, 0])  # (n_frames,)
+                        reproj_valid = set(np.where(~np.isnan(first_kp_x))[0].tolist())
+                        camera_frames[camera_name] = camera_frames[camera_name] | reproj_valid
+                    except Exception as e:
+                        print(f"Warning: Failed to scan reprojection frames for {camera_name}: {e}")
+
+            for camera_name in cameras_to_remove:
+                del camera_frames[camera_name]
+
+            if cameras_to_remove:
+                print(f"  Excluded {len(cameras_to_remove)} camera(s) not in reprojections.h5 "
+                      f"(not triangulated): {cameras_to_remove}")
+
         # Find frames that appear in multiple cameras
         all_frames: Set[int] = set()
         for frames in camera_frames.values():
@@ -354,12 +389,28 @@ class SLEAPMultiViewPreprocessor:
                     loader_3d = None
                     has_3d_data = False
             
+            # Open reprojections file if use_reprojections is enabled
+            reproj_file = None
+            if self.use_reprojections:
+                session_path_obj = Path(session_path)
+                reproj_candidates = list(session_path_obj.glob('reprojections*.h5'))
+                if reproj_candidates:
+                    reproj_path = reproj_candidates[0]
+                    try:
+                        reproj_file = h5py.File(str(reproj_path), 'r')
+                        print(f"Info: Using reprojections file: {reproj_path}")
+                    except Exception as e:
+                        print(f"Warning: Failed to open reprojections file {reproj_path}: {e}")
+                        reproj_file = None
+                else:
+                    print(f"Warning: --use_reprojections enabled but no reprojections*.h5 found in {session_path}")
+
             # Track total cameras for this session
             num_cameras = len(loader.camera_views)
             self.stats['total_cameras'] = max(self.stats['total_cameras'], num_cameras)
             
             # Discover multi-view frames
-            multiview_frames = self._discover_multiview_frames(loader, session_path)
+            multiview_frames = self._discover_multiview_frames(loader, session_path, reproj_file=reproj_file)
             
             if len(multiview_frames) == 0:
                 print(f"No multi-view frames found in {session_path}")
@@ -420,7 +471,8 @@ class SLEAPMultiViewPreprocessor:
                         video_frame_positions=video_frame_positions,
                         ground_truth_betas=ground_truth_betas,
                         loader_3d=loader_3d,
-                        has_3d_data=has_3d_data
+                        has_3d_data=has_3d_data,
+                        reproj_handle=reproj_file
                     )
                     if sample is not None:
                         samples.append(sample)
@@ -434,6 +486,10 @@ class SLEAPMultiViewPreprocessor:
             # Close video captures
             for cap in video_cap_cache.values():
                 cap.release()
+
+            # Close reprojections file handle
+            if reproj_file is not None:
+                reproj_file.close()
             
             self.stats['sessions_processed'] += 1
             self.stats['processed_samples'] += len(samples)
@@ -452,7 +508,8 @@ class SLEAPMultiViewPreprocessor:
                                   video_frame_positions: Dict[str, int],
                                   ground_truth_betas: Optional[np.ndarray],
                                   loader_3d: Optional['SLEAP3DDataLoader'] = None,
-                                  has_3d_data: bool = False) -> Optional[Dict[str, Any]]:
+                                  has_3d_data: bool = False,
+                                  reproj_handle: Optional[h5py.File] = None) -> Optional[Dict[str, Any]]:
         """
         Process a single multi-view frame (all cameras for one time instant).
         
@@ -606,26 +663,63 @@ class SLEAPMultiViewPreprocessor:
                 
                 frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                 
-                # Extract keypoints
-                keypoints_2d, visibility = loader.extract_2d_keypoints(camera_data, frame_idx)
+                # Extract 2D keypoints: try reprojections first, fall back to SLEAP
+                used_reproj = False
+                if self.use_reprojections and reproj_handle is not None:
+                    ds = self._resolve_reprojection_dataset(reproj_handle, camera_name)
+                    if ds is not None:
+                        try:
+                            kp = np.asarray(ds[frame_idx, 0, :, :])  # (n_keypoints, 2)
+                            vis = (~np.isnan(kp).any(axis=1)).astype(np.float32)
+                            vis *= np.all(kp > 0, axis=1).astype(np.float32)
+                            if vis.sum() == 0:
+                                # All reprojected keypoints are NaN/zero for this frame:
+                                # triangulation failed. Exclude rather than fall back to
+                                # raw SLEAP (which would break 3D-2D consistency).
+                                self.stats['views_excluded_no_keypoints'] += 1
+                                continue
+                            keypoints_2d = kp
+                            visibility = vis
+                            used_reproj = True
+                            self.stats['views_reprojected'] += 1
+                        except Exception as e:
+                            if self.debug:
+                                print(f"    Warning: Failed to read reprojection for {camera_name} frame {frame_idx}: {e}")
+                    else:
+                        # Camera absent from reprojections.h5 (excluded from triangulation).
+                        # Do not fall back to raw SLEAP when --use_reprojections is set,
+                        # as that would mix inconsistent 2D supervision with 3D targets.
+                        self.stats['views_excluded_no_keypoints'] += 1
+                        continue
+
+                if not used_reproj:
+                    keypoints_2d, visibility = loader.extract_2d_keypoints(camera_data, frame_idx)
+
                 if len(keypoints_2d) == 0:
                     self.stats['views_excluded_no_keypoints'] += 1
                     continue
-                
+
                 # Get image size for mapping
                 image_size = loader.get_camera_image_size(camera_name)
-                
-                # Undistort image and keypoints if enabled and camera calibration is available
+
+                # Undistort image (and keypoints if they came from SLEAP, not reprojections)
+                # Reprojected keypoints are already in undistorted/ideal pinhole space
                 if self.undistort_images and has_3d_data and loader_3d is not None:
                     try:
                         cam_params = loader_3d.get_camera_parameters(camera_name)
                         K = cam_params['intrinsic']['K']
                         distortion_coeffs = cam_params['intrinsic'].get('distortion', None)
-                        
+
                         if distortion_coeffs is not None and len(distortion_coeffs) > 0:
-                            frame_rgb, keypoints_2d = self._undistort_image_and_keypoints(
-                                frame_rgb, keypoints_2d, K, distortion_coeffs
-                            )
+                            if used_reproj:
+                                # Only undistort the image; reprojected keypoints are already ideal pinhole
+                                frame_rgb = cv2.undistort(frame_rgb, K.astype(np.float64),
+                                                         np.array(distortion_coeffs).flatten().astype(np.float64),
+                                                         newCameraMatrix=K.astype(np.float64))
+                            else:
+                                frame_rgb, keypoints_2d = self._undistort_image_and_keypoints(
+                                    frame_rgb, keypoints_2d, K, distortion_coeffs
+                                )
                             self.stats['views_undistorted'] += 1
                     except Exception as e:
                         if self.debug:
@@ -672,15 +766,23 @@ class SLEAPMultiViewPreprocessor:
                     try:
                         # Get camera parameters from 3D loader
                         cam_params = loader_3d.get_camera_parameters(camera_name)
-                        K = cam_params['intrinsic']['K']
+                        K = cam_params['intrinsic']['K'].copy().astype(np.float32)
                         R = cam_params['extrinsic']['R']
                         t = cam_params['extrinsic']['t']
-                        img_size = cam_params['image_size']
-                        
-                        view_camera_intrinsics.append(K.astype(np.float32))
+
+                        # Adjust intrinsic matrix for the crop/resize applied to
+                        # the image so that 3D→2D projection during training lands
+                        # in the same coordinate system as the preprocessed 2D
+                        # keypoint targets.
+                        K = self._adjust_intrinsics_for_transform(K, transform_info)
+
+                        view_camera_intrinsics.append(K)
                         view_camera_extrinsics_R.append(R.astype(np.float32))
                         view_camera_extrinsics_t.append(t.astype(np.float32))
-                        view_image_sizes.append(np.array([img_size['width'], img_size['height']], dtype=np.int32))
+                        # Store preprocessed image dimensions (always square after
+                        # crop + resize) instead of original calibration dimensions.
+                        view_image_sizes.append(np.array(
+                            [self.target_resolution, self.target_resolution], dtype=np.int32))
                     except Exception as e:
                         print(f"Warning: Failed to extract camera parameters for {camera_name}: {e}")
                         # Add placeholder camera parameters
@@ -911,7 +1013,31 @@ class SLEAPMultiViewPreprocessor:
             undistorted_keypoints = keypoints_2d
         
         return undistorted_image, undistorted_keypoints
-    
+
+    def _resolve_reprojection_dataset(self, reproj_handle: h5py.File, camera_name: str,
+                                      warn: bool = True) -> Optional[h5py.Dataset]:
+        """
+        Map a camera_name to a dataset in reprojections.h5.
+        Tries exact match first, then case-insensitive exact match, then
+        single-character camera ID (e.g. 'camA' -> 'A').
+        """
+        try:
+            if camera_name in reproj_handle:
+                return reproj_handle[camera_name]
+            # Case-insensitive exact match
+            keys_lower = {k.lower(): k for k in reproj_handle.keys()}
+            if camera_name.lower() in keys_lower:
+                return reproj_handle[keys_lower[camera_name.lower()]]
+            # Single-character camera ID (e.g. 'camA' -> 'A')
+            if len(camera_name) > 0 and camera_name[-1].upper() in reproj_handle:
+                return reproj_handle[camera_name[-1].upper()]
+        except Exception:
+            pass
+        if warn:
+            print(f"Warning: Could not resolve reprojection dataset for camera '{camera_name}' "
+                  f"(available: {list(reproj_handle.keys())})")
+        return None
+
     def _find_video_file(self, loader: SLEAPDataLoader, camera_name: str) -> Optional[Path]:
         """Find video file for a camera."""
         if loader.data_structure_type == 'camera_dirs':
@@ -1165,6 +1291,57 @@ class SLEAPMultiViewPreprocessor:
         
         return adjusted_keypoints
     
+    def _adjust_intrinsics_for_transform(self, K: np.ndarray,
+                                          transform_info: Dict[str, Any]) -> np.ndarray:
+        """
+        Adjust camera intrinsic matrix K for the image crop/resize applied
+        during preprocessing.
+
+        When an image is cropped and resized, the mapping from 3-D camera
+        coordinates to 2-D pixel coordinates changes.  The intrinsic matrix
+        must be updated so that projections during training land in the same
+        coordinate system as the preprocessed 2-D keypoint targets.
+
+        Supports all three crop modes:
+        - 'centred': square center-crop then uniform resize
+        - 'bbox_crop': bounding-box crop then uniform resize
+        - 'default': direct (potentially non-uniform) resize
+
+        Args:
+            K: Original 3×3 intrinsic matrix (will not be mutated).
+            transform_info: Dictionary returned by ``_preprocess_image``.
+
+        Returns:
+            Adjusted 3×3 intrinsic matrix matching the preprocessed image.
+        """
+        K_adj = K.copy()
+        mode = transform_info['mode']
+
+        if mode in ('centred', 'bbox_crop'):
+            y_offset, x_offset = transform_info['crop_offset']
+            scale_factor = transform_info['scale_factor']
+
+            # 1. Shift principal point for crop offset
+            K_adj[0, 2] -= x_offset   # cx
+            K_adj[1, 2] -= y_offset   # cy
+
+            # 2. Scale focal lengths and principal point for resize
+            if isinstance(scale_factor, tuple):
+                # Fallback path inside bbox_crop when no valid keypoints
+                scale_y, scale_x = scale_factor
+                K_adj[0, 0] *= scale_x;  K_adj[0, 2] *= scale_x
+                K_adj[1, 1] *= scale_y;  K_adj[1, 2] *= scale_y
+            else:
+                K_adj[0, 0] *= scale_factor;  K_adj[0, 2] *= scale_factor
+                K_adj[1, 1] *= scale_factor;  K_adj[1, 2] *= scale_factor
+        else:
+            # 'default' mode — non-uniform scale
+            scale_y, scale_x = transform_info['scale_factor']
+            K_adj[0, 0] *= scale_x;  K_adj[0, 2] *= scale_x
+            K_adj[1, 1] *= scale_y;  K_adj[1, 2] *= scale_y
+
+        return K_adj
+
     def _sanitize_array(self, arr: np.ndarray, default_value: float = 0.0) -> np.ndarray:
         """Replace NaN/inf values with default."""
         if arr is None:
@@ -1443,6 +1620,7 @@ class SLEAPMultiViewPreprocessor:
             metadata_group.attrs['has_3d_keypoints'] = any(has_3d_data_list)
             metadata_group.attrs['load_3d_data'] = self.load_3d_data
             metadata_group.attrs['undistort_images'] = self.undistort_images
+            metadata_group.attrs['used_reprojections'] = self.use_reprojections
             # Store mapping info for downstream consumers/debugging
             try:
                 metadata_group.attrs['keypoints_3d_joint_order'] = 'smal'
@@ -1482,6 +1660,7 @@ class SLEAPMultiViewPreprocessor:
             metadata_group.attrs['views_excluded_no_keypoints'] = self.stats['views_excluded_no_keypoints']
             metadata_group.attrs['views_excluded_processing_error'] = self.stats['views_excluded_processing_error']
             metadata_group.attrs['views_undistorted'] = self.stats['views_undistorted']
+            metadata_group.attrs['views_reprojected'] = self.stats['views_reprojected']
 
 
 def main():
@@ -1529,7 +1708,7 @@ Examples:
                             "unet_mobilenet_v3")
     parser.add_argument("--jpeg_quality", type=int, default=95,
                        help="JPEG compression quality 1-100 (default: 95)")
-    parser.add_argument("--crop_mode", type=str, default='default',
+    parser.add_argument("--crop_mode", type=str, default='centred',
                        choices=['default', 'centred', 'bbox_crop'],
                        help="Image cropping mode (default: default)")
     
@@ -1549,6 +1728,10 @@ Examples:
     parser.add_argument("--no_undistort", action="store_true",
                        help="Skip undistorting images and 2D keypoints using camera calibration "
                             "(default: undistort if calibration is available)")
+
+    # Reprojection options
+    parser.add_argument("--use_reprojections", action="store_true",
+                       help="Use per-session reprojections.h5 for 2D keypoints instead of raw SLEAP predictions")
 
     # SMAL model options
     parser.add_argument("--smal_file", type=str, default=None,
@@ -1609,6 +1792,7 @@ Examples:
         print(f"Backbone: {args.backbone_name}")
         print(f"Crop mode: {args.crop_mode}")
         print(f"Undistort images: {not args.no_undistort}")
+        print(f"Use reprojections: {args.use_reprojections}")
         if args.smal_file:
             print(f"SMAL model: {args.smal_file}")
         print("="*60)
@@ -1635,7 +1819,8 @@ Examples:
             load_3d_data=load_3d,
             frame_skip=args.frame_skip,
             debug=args.debug,
-            undistort_images=undistort
+            undistort_images=undistort,
+            use_reprojections=args.use_reprojections
         )
         
         stats = preprocessor.process_dataset(
@@ -1697,6 +1882,14 @@ Examples:
                 inclusion_rate = 100.0 * total_included / total_potential
                 print(f"  Overall view inclusion rate: {inclusion_rate:.1f}%")
             
+            # Reprojection statistics
+            views_reprojected = stats.get('views_reprojected', 0)
+            if views_reprojected > 0:
+                print(f"  Views using reprojected keypoints: {views_reprojected}")
+                if total_included > 0:
+                    reproj_rate = 100.0 * views_reprojected / total_included
+                    print(f"  Reprojection rate: {reproj_rate:.1f}%")
+
             # Undistortion statistics
             views_undistorted = stats.get('views_undistorted', 0)
             if views_undistorted > 0:

--- a/smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py
+++ b/smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py
@@ -1519,7 +1519,10 @@ Examples:
     parser.add_argument("--target_resolution", type=int, default=224,
                        help="Target image resolution (default: 224)")
     parser.add_argument("--backbone", dest="backbone_name", default='vit_large_patch16_224',
-                       help="Backbone network name (default: vit_large_patch16_224)")
+                       help="Backbone network name (default: vit_large_patch16_224). "
+                            "Supported: vit_base_patch16_224, vit_large_patch16_224, "
+                            "resnet50/101/152, unet_efficientnet_b0/b3, unet_resnet34, "
+                            "unet_mobilenet_v3")
     parser.add_argument("--jpeg_quality", type=int, default=95,
                        help="JPEG compression quality 1-100 (default: 95)")
     parser.add_argument("--crop_mode", type=str, default='default',

--- a/smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py
+++ b/smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py
@@ -1516,8 +1516,12 @@ Examples:
                        help="Path to CSV lookup table for ground truth shape betas")
     
     # Processing options
-    parser.add_argument("--target_resolution", type=int, default=224,
-                       help="Target image resolution (default: 224)")
+    parser.add_argument("--resolution", type=int, default=None,
+                       help="Target image resolution. Overrides backbone default. "
+                            "If not specified, derived from --backbone "
+                            "(224 for ViT, 512 for ResNet/UNet)")
+    parser.add_argument("--target_resolution", type=int, default=None,
+                       help="(Deprecated, use --resolution) Target image resolution")
     parser.add_argument("--backbone", dest="backbone_name", default='vit_large_patch16_224',
                        help="Backbone network name (default: vit_large_patch16_224). "
                             "Supported: vit_base_patch16_224, vit_large_patch16_224, "
@@ -1560,6 +1564,17 @@ Examples:
     
     args = parser.parse_args()
 
+    # Resolve target resolution: --resolution > --target_resolution > backbone default
+    if args.resolution is not None:
+        target_resolution = args.resolution
+    elif args.target_resolution is not None:
+        target_resolution = args.target_resolution
+    else:
+        # Derive from backbone using BackboneFactory as single source of truth
+        from neuralSMIL.backbone_factory import BackboneFactory
+        target_resolution = BackboneFactory.get_default_input_resolution(args.backbone_name)
+    args.target_resolution = target_resolution
+
     # Override SMAL model if smal_file is provided
     if args.smal_file:
         if not os.path.exists(args.smal_file):
@@ -1586,7 +1601,12 @@ Examples:
         print(f"Output file: {args.output_path}")
         print(f"Minimum views per sample: {args.min_views}")
         print(f"Frame skip: {args.frame_skip} (process every {args.frame_skip} frame(s))")
-        print(f"Target resolution: {args.target_resolution}x{args.target_resolution}")
+        if args.resolution is not None:
+            res_source = "from --resolution"
+        else:
+            res_source = f"default for {args.backbone_name}"
+        print(f"Target resolution: {args.target_resolution}x{args.target_resolution} ({res_source})")
+        print(f"Backbone: {args.backbone_name}")
         print(f"Crop mode: {args.crop_mode}")
         print(f"Undistort images: {not args.no_undistort}")
         if args.smal_file:


### PR DESCRIPTION
## Summary
- Add `UNetBackbone` to `BackboneFactory` with pretrained timm encoder + skip-connection decoder and `forward_with_spatial()` support (EfficientNet-B0/B3, ResNet34, MobileNetV3)
- Introduce `BackboneFactory.get_default_input_resolution()` as single source of truth for backbone-specific input sizes, replacing ~15 scattered `if backbone.startswith('vit'): 224 else 512` conditionals across the codebase
- Add `get_spatial_dim()` to backbone interface so transformer decoder cross-attention context_dim is set from backbone capabilities rather than hardcoded per-name checks
- Generalize multiview spatial feature extraction: any backbone implementing `forward_with_spatial()` now provides cross-attention context (ViT patch tokens, UNet decoder feature maps)
- Fix `ModuleNotFoundError` in `mp.spawn` child processes by switching lazy imports from `from smal_fitter.neuralSMIL.backbone_factory` to direct `from backbone_factory` imports
- Add `sys.path` setup to `run_multiview_inference.py` for DDP spawn compatibility
- Add UNet gradient checkpointing, hidden_dim defaults, and config support across both new dataclass and legacy config systems

## Test plan
- [x] Verify multi-GPU training launches without `ModuleNotFoundError`
- [x] Verify single-view and multi-view training with ViT backbone (regression check)
- [x] Test UNet backbone creation via `BackboneFactory.create_backbone('unet_efficientnet_b3')`
- [x] Verify `forward_with_spatial()` returns correct shapes for both ViT and UNet
- [x] Run `pytest -m "not slow"`