### PR TITLE
Training pipeline bug fixes (normalization, decoder, multi-view aug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Example 4-5 camera inference results with a molde trained on data collected from
 
 4. some more dependencies
    ```
-   pip install matplotlib scipy opencv-python nibabel trimesh timm pytest h5py psutil
+   pip install matplotlib scipy opencv-python nibabel trimesh timm pytest h5py psutil pandas toml
    ```
+   (`pandas` and `toml` are required by `smal_fitter/sleap_data/` — needed whenever you run the multi-view training or inference scripts.)
    
 5. Test your installation
    ```

--- a/smal_fitter/neuralSMIL/backbone_factory.py
+++ b/smal_fitter/neuralSMIL/backbone_factory.py
@@ -29,7 +29,41 @@ class BackboneInterface(nn.Module, ABC):
     registered when assigned as attributes of parent modules (e.g.
     SMILImageRegressor.backbone), making them visible to
     model.parameters(), optimizers, and checkpoint saving.
+
+    Input normalization contract
+    ----------------------------
+    Callers pass images as float tensors in [0, 1] with shape (B, 3, H, W).
+    Each backbone owns its own per-channel mean/std (matching the stats used
+    to pretrain its weights) and applies normalization as the first step of
+    its forward pass via ``_normalize``. This keeps training, inference and
+    benchmarking pipelines consistent without any caller-side bookkeeping.
     """
+
+    def __init__(self):
+        super().__init__()
+        # Default to identity; subclasses overwrite these buffers in __init__
+        # with the per-channel mean/std that match their pretrained weights.
+        # Registered as buffers so they move with .to(device) and are saved
+        # in checkpoints — inference code that only loads the model gets the
+        # correct normalization automatically.
+        self.register_buffer('pixel_mean', torch.zeros(1, 3, 1, 1))
+        self.register_buffer('pixel_std', torch.ones(1, 3, 1, 1))
+
+    def _normalize(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply per-channel normalization matching pretraining stats."""
+        return (x - self.pixel_mean) / self.pixel_std
+
+    def _set_normalization(self, mean, std) -> None:
+        """Overwrite the normalization buffers from (mean, std) sequences."""
+        mean_t = torch.as_tensor(mean, dtype=torch.float32).view(1, 3, 1, 1)
+        std_t = torch.as_tensor(std, dtype=torch.float32).view(1, 3, 1, 1)
+        self.pixel_mean.copy_(mean_t)
+        self.pixel_std.copy_(std_t)
+        print(
+            f"[{type(self).__name__}:{getattr(self, 'model_name', '?')}] "
+            f"input normalization: mean={mean_t.flatten().tolist()}, "
+            f"std={std_t.flatten().tolist()}"
+        )
 
     @abstractmethod
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -83,25 +117,38 @@ class ResNetBackbone(BackboneInterface):
         
         # Load pretrained ResNet model
         if model_name == 'resnet50':
-            self.backbone = models.resnet50(weights=models.ResNet50_Weights.DEFAULT if pretrained else None)
+            weights = models.ResNet50_Weights.DEFAULT if pretrained else None
+            self.backbone = models.resnet50(weights=weights)
             self.feature_dim = 2048
         elif model_name == 'resnet101':
-            self.backbone = models.resnet101(weights=models.ResNet101_Weights.DEFAULT if pretrained else None)
+            weights = models.ResNet101_Weights.DEFAULT if pretrained else None
+            self.backbone = models.resnet101(weights=weights)
             self.feature_dim = 2048
         elif model_name == 'resnet152':
-            self.backbone = models.resnet152(weights=models.ResNet152_Weights.DEFAULT if pretrained else None)
+            weights = models.ResNet152_Weights.DEFAULT if pretrained else None
+            self.backbone = models.resnet152(weights=weights)
             self.feature_dim = 2048
         else:
             raise ValueError(f"Unsupported ResNet model: {model_name}")
-        
+
         # Remove the final classification layer
         self.backbone = nn.Sequential(*list(self.backbone.children())[:-1])
-        
+
+        # Pull pretraining normalization stats from torchvision's weights
+        # metadata when available (falls back to standard ImageNet stats).
+        mean, std = [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
+        if weights is not None:
+            tfm = weights.transforms()
+            mean = list(getattr(tfm, 'mean', mean))
+            std = list(getattr(tfm, 'std', std))
+        self._set_normalization(mean, std)
+
         if freeze:
             self.freeze_weights()
-    
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through ResNet backbone."""
+        x = self._normalize(x)
         features = self.backbone(x)  # (batch_size, 2048, 1, 1)
         return features.view(x.size(0), -1)  # (batch_size, 2048)
     
@@ -149,12 +196,12 @@ class ViTBackbone(BackboneInterface):
         
         # Load pretrained ViT model from timm
         self.backbone = timm.create_model(
-            model_name, 
+            model_name,
             pretrained=pretrained,
             num_classes=0,  # Remove classification head
             global_pool='',  # Don't apply global pooling
         )
-        
+
         # Get feature dimension based on model
         if 'base' in model_name:
             self.feature_dim = 768
@@ -162,39 +209,47 @@ class ViTBackbone(BackboneInterface):
             self.feature_dim = 1024
         else:
             raise ValueError(f"Unsupported ViT model: {model_name}")
-        
+
+        # ViT pretraining stats vary by variant (e.g. augreg/IN21k weights use
+        # Inception-style [0.5, 0.5, 0.5] rather than standard ImageNet).
+        # Ask timm for the stats attached to the actual loaded weights.
+        data_cfg = timm.data.resolve_model_data_config(self.backbone)
+        self._set_normalization(data_cfg['mean'], data_cfg['std'])
+
         if freeze:
             self.freeze_weights()
-    
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through ViT backbone."""
+        x = self._normalize(x)
         # ViT outputs (batch_size, num_patches + 1, feature_dim) where +1 is for CLS token
         features = self.backbone.forward_features(x)  # (batch_size, 197, 768) for 224x224 input
-        
+
         # Use CLS token (first token) as global representation
         cls_token = features[:, 0]  # (batch_size, 768, 1024 for large)
-        
+
         return cls_token
-    
+
     def forward_with_spatial(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Forward pass through ViT backbone returning both global and spatial features.
-        
+
         Args:
             x: Input tensor of shape (batch_size, 3, height, width)
-            
+
         Returns:
             Tuple of (global_features, spatial_features)
             - global_features: CLS token (batch_size, feature_dim)
             - spatial_features: Patch tokens (batch_size, num_patches, feature_dim)
         """
+        x = self._normalize(x)
         # ViT outputs (batch_size, num_patches + 1, feature_dim) where +1 is for CLS token
         features = self.backbone.forward_features(x)  # (batch_size, 197, 768) for 224x224 input
-        
+
         # Split CLS token and patch tokens
         cls_token = features[:, 0]  # (batch_size, feature_dim)
         patch_tokens = features[:, 1:]  # (batch_size, num_patches, feature_dim)
-        
+
         return cls_token, patch_tokens
     
     def get_feature_dim(self) -> int:
@@ -354,6 +409,11 @@ class UNetBackbone(BackboneInterface):
         # ── Combined module (for BackboneInterface compatibility) ─────────────
         self.backbone = _UNetModule(encoder, decode_blocks, nn.AdaptiveAvgPool2d(1))
 
+        # Pull pretraining normalization stats from the timm encoder's data
+        # config (differs across efficientnet/convnext/mobilenet variants).
+        data_cfg = timm.data.resolve_model_data_config(self.backbone.encoder)
+        self._set_normalization(data_cfg['mean'], data_cfg['std'])
+
         if freeze:
             self.freeze_weights()
 
@@ -366,6 +426,7 @@ class UNetBackbone(BackboneInterface):
             bottleneck: feature map from the deepest encoder stage (B, C, H, W)
             decoder_outputs: list of feature maps from each decode block (coarse→fine)
         """
+        x = self._normalize(x)
         enc_feats = self.backbone.encoder(x)  # list: [fine … coarse]
         bottleneck = enc_feats[-1]
 

--- a/smal_fitter/neuralSMIL/configs/examples/multiview_sticks_UNET.json
+++ b/smal_fitter/neuralSMIL/configs/examples/multiview_sticks_UNET.json
@@ -17,29 +17,29 @@
     "train_ratio": 0.85,
     "val_ratio": 0.05,
     "test_ratio": 0.1,
-    "dataset_fraction": 0.1
+    "dataset_fraction": 0.2
   },
 
   "model": {
     "backbone_name": "unet_efficientnet_b3",
     "freeze_backbone": true,
-    "backbone_unfreeze_epoch": 50,
+    "backbone_unfreeze_epoch": 20,
     "backbone_lr_multiplier": 0.1,
     "hidden_dim": 1024,
     "head_type": "transformer_decoder",
     "use_unity_prior": false,
     "rgb_only": false,
-    "transformer_depth": 4,
+    "transformer_depth": 6,
     "transformer_heads": 8,
     "transformer_dim_head": 64,
     "transformer_mlp_dim": 1024,
     "transformer_dropout": 0.1,
-    "transformer_ief_iters": 1,
+    "transformer_ief_iters": 3,
     "transformer_trans_scale_factor": 1
   },
 
   "optimizer": {
-    "learning_rate": 5e-5,
+    "learning_rate": 1e-4,
     "weight_decay": 1e-4,
     "gradient_clip_norm": 1.0,
     "optimizer_type": "adamw",
@@ -74,7 +74,7 @@
       "ief_intermediate": 0.0
     },
     "curriculum_stages": {
-      "1": {
+      "0": {
         "joint_angle_regularization": 0.01,
         "limb_scale_regularization": 0.1,
         "limb_trans_regularization": 1
@@ -124,7 +124,7 @@
   },
 
   "scale_trans_beta": {
-    "mode": "entangled_with_betas"
+    "mode": "separate"
   },
 
   "mesh_scaling": {
@@ -134,18 +134,18 @@
   },
 
   "augmentation": {
-    "enabled": true,
+    "enabled": false,
     "geometric_enabled": false,
-    "color_jitter_brightness": 0.1,
-    "color_jitter_contrast": 0.1,
-    "color_jitter_saturation": 0.1,
+    "color_jitter_brightness": 0.05,
+    "color_jitter_contrast": 0.05,
+    "color_jitter_saturation": 0.05,
     "gaussian_noise_std": 0.01,
     "gaussian_blur_prob": 0.05,
-    "gaussian_blur_kernel_range": [3, 7],
-    "random_erasing_prob": 0.05,
+    "gaussian_blur_kernel_range": [3, 5],
+    "random_erasing_prob": 0.0,
     "random_erasing_scale_range": [0.01, 0.05],
     "crop_jitter_fraction": 0.0,
-    "scale_jitter_range": [0.9, 1.1]
+    "scale_jitter_range": [1.0, 1.0]
   },
 
   "joint_importance": {
@@ -171,8 +171,8 @@
   },
 
   "training": {
-    "batch_size": 2,
-    "num_epochs": 300,
+    "batch_size": 6,
+    "num_epochs": 500,
     "seed": 42,
     "rotation_representation": "6d",
     "num_workers": 32,
@@ -182,7 +182,7 @@
     "reset_ief_token_embedding": false,
     "use_gt_camera_init": true,
     "use_mixed_precision": false,
-    "backbone_chunk_size": 6,
-    "gradient_accumulation_steps": 2
+    "backbone_chunk_size": 5,
+    "gradient_accumulation_steps": 1
   }
 }

--- a/smal_fitter/neuralSMIL/smil_image_regressor.py
+++ b/smal_fitter/neuralSMIL/smil_image_regressor.py
@@ -363,7 +363,10 @@ class SMILImageRegressor(SMALFitter):
             # Assume values are in [0, 255] range
             image_data = image_data.astype(np.float32) / 255.0
         
-        # Resize to the model's configured input resolution
+        # Resize to the model's configured input resolution. Per-channel
+        # mean/std normalization is intentionally NOT applied here — each
+        # backbone owns its own pretraining stats and applies them as the
+        # first op inside its forward pass (see BackboneInterface._normalize).
         target_size = (self.input_resolution, self.input_resolution)
         if len(image_data.shape) == 4:
             # Batch of images

--- a/smal_fitter/neuralSMIL/transformer_decoder.py
+++ b/smal_fitter/neuralSMIL/transformer_decoder.py
@@ -154,18 +154,8 @@ class SMILTransformerDecoderHead(nn.Module):
         # Token embedding: projects concatenated parameter estimates into hidden_dim
         self.token_embedding = nn.Linear(self._param_feedback_dim, hidden_dim)
 
-        # Global feature projection: injects pooled image features into the
-        # decoder token so the decoder has direct access to visual information,
-        # not only through cross-attention to the (potentially few) spatial tokens.
-        self.global_feat_proj = nn.Linear(feature_dim, hidden_dim)
-
         # Positional embedding for tokens
         self.pos_embedding = nn.Parameter(torch.randn(1, 1, hidden_dim))
-
-        # Dropout applied after token embedding (before transformer layers)
-        # and before prediction heads (after transformer layers)
-        self.token_dropout = nn.Dropout(dropout)
-        self.head_dropout = nn.Dropout(dropout)
 
         # Transformer decoder layers
         self.layers = nn.ModuleList([
@@ -218,7 +208,7 @@ class SMILTransformerDecoderHead(nn.Module):
         self.betas_dim = config.N_BETAS
         self.trans_dim = 3
         self.fov_dim = 1
-        self.cam_rot_dim = 9  # 3x3 rotation matrix (flattened)
+        self.cam_rot_dim = 6  # 6D continuous rotation representation (Zhou et al. 2019)
         self.cam_trans_dim = 3
         
         # Handle scale and translation dimensions based on mode
@@ -266,30 +256,25 @@ class SMILTransformerDecoderHead(nn.Module):
         nn.init.xavier_uniform_(self.token_embedding.weight, gain=0.1)
         nn.init.constant_(self.token_embedding.bias, 0)
 
-        # Global feature projection — small gain so it starts near-zero and
-        # doesn't disrupt a pretrained decoder when first introduced.
-        nn.init.xavier_uniform_(self.global_feat_proj.weight, gain=0.1)
-        nn.init.constant_(self.global_feat_proj.bias, 0)
-
         # Initialize positional embedding
         nn.init.normal_(self.pos_embedding, std=0.02)
-        
-        # Initialize output heads with very small weights for IEF stability
-        for head in [self.pose_head, self.betas_head, self.trans_head, 
+
+        # Output head init — matches HMR2's INIT_DECODER_XAVIER gain (0.01).
+        for head in [self.pose_head, self.betas_head, self.trans_head,
                     self.fov_head, self.cam_rot_head, self.cam_trans_head]:
-            nn.init.xavier_uniform_(head.weight, gain=0.001)  # Even smaller gain
+            nn.init.xavier_uniform_(head.weight, gain=0.01)
             nn.init.constant_(head.bias, 0)
-        
+
         if self.scales_dim > 0:
-            nn.init.xavier_uniform_(self.scales_head.weight, gain=0.001)
+            nn.init.xavier_uniform_(self.scales_head.weight, gain=0.01)
             nn.init.constant_(self.scales_head.bias, 0)
-        
+
         if self.joint_trans_dim > 0:
-            nn.init.xavier_uniform_(self.joint_trans_head.weight, gain=0.001)
+            nn.init.xavier_uniform_(self.joint_trans_head.weight, gain=0.01)
             nn.init.constant_(self.joint_trans_head.bias, 0)
-        
+
         if self.allow_mesh_scaling:
-            nn.init.xavier_uniform_(self.mesh_scale_head.weight, gain=0.001)
+            nn.init.xavier_uniform_(self.mesh_scale_head.weight, gain=0.01)
             nn.init.constant_(self.mesh_scale_head.bias, 0)  # log(1.0) = 0
     
     def _initialize_prediction_buffers(self):
@@ -312,7 +297,8 @@ class SMILTransformerDecoderHead(nn.Module):
         self.register_buffer('init_trans', torch.zeros(1, self.trans_dim))
         # Initialize FOV with reasonable value based on ground truth (typically around 8 degrees)
         self.register_buffer('init_fov', torch.tensor([[8.0]]))
-        self.register_buffer('init_cam_rot', torch.eye(3).flatten().unsqueeze(0))
+        # 6D rotation: first two columns of identity rotation matrix
+        self.register_buffer('init_cam_rot', torch.tensor([[1., 0., 0., 0., 1., 0.]]))
         # Initialize camera translation with reasonable values based on ground truth range
         # Ground truth camera translation is typically around [0, 0, 100-150]
         self.register_buffer('init_cam_trans', torch.tensor([[0.0, 0.0, 100.0]]))
@@ -383,10 +369,12 @@ class SMILTransformerDecoderHead(nn.Module):
         if self.allow_mesh_scaling:
             pred_mesh_scale_list = []
         
-        # Project global image features once (constant across IEF iterations)
-        img_token = self.global_feat_proj(features).unsqueeze(1)  # (batch_size, 1, hidden_dim)
-
-        # Iterative Error Feedback (IEF)
+        # Iterative Error Feedback (IEF).
+        # Visual signal enters the decoder ONLY through cross-attention to
+        # spatial_features (HMR2-style). The decoder query token carries the
+        # current parameter estimate; previously we also added a pooled global
+        # feature to the token, which gave the head a memorisable image-level
+        # fingerprint and appeared to drive train/val divergence on betas.
         for i in range(self.ief_iters):
             # Concatenate all current parameter estimates as feedback
             param_tokens = [pred_pose, pred_betas, pred_trans, pred_fov, pred_cam_rot, pred_cam_trans]
@@ -401,20 +389,16 @@ class SMILTransformerDecoderHead(nn.Module):
             # (pose ~1, cam_trans ~100) without hardcoded assumptions.
             param_state = self.param_norm(param_state)
 
-            # Project current parameter state into a single decoder token and
-            # add global image features so the decoder has direct access to
-            # the pooled visual representation.
-            token = self.token_embedding(param_state).unsqueeze(1) + img_token  # (batch_size, 1, hidden_dim)
-            token = token + self.pos_embedding
-            token = self.token_dropout(token)
+            # Project current parameter state into a single decoder token.
+            token = self.token_embedding(param_state).unsqueeze(1) + self.pos_embedding
 
-            # Pass through transformer decoder layers
+            # Pass through transformer decoder layers (dropout lives inside
+            # the attention/FF blocks; no extra per-iter token dropout).
             for layer in self.layers:
                 token = layer(token, spatial_features)
 
             # Extract predictions (residual updates)
             token_out = token.squeeze(1)  # (batch_size, hidden_dim)
-            token_out = self.head_dropout(token_out)
 
             # Apply residual updates
             pred_pose = pred_pose + self.pose_head(token_out)
@@ -503,8 +487,10 @@ class SMILTransformerDecoderHead(nn.Module):
             pred_global_rot = global_rot_aa
             pred_joint_rot = joint_rot_aa
         
-        # Reshape camera rotation to 3x3 matrix
-        pred_cam_rot_mat = pred_cam_rot.view(batch_size, 3, 3)
+        # Convert 6D camera rotation (Zhou et al. 2019) to 3x3 matrix via
+        # Gram-Schmidt. The IEF accumulates raw 6D residuals; the rotation
+        # only needs to live on SO(3) at the output boundary.
+        pred_cam_rot_mat = rotation_6d_to_matrix(pred_cam_rot)
         
         # Prepare output dictionary
         output = {

--- a/smal_fitter/sleap_data/sleap_multiview_dataset.py
+++ b/smal_fitter/sleap_data/sleap_multiview_dataset.py
@@ -408,6 +408,11 @@ class SLEAPMultiViewDataset(torch.utils.data.Dataset):
                 lo, hi = self.aug_scale_jitter_range
                 shared_scale = np.random.uniform(lo, hi)
 
+            # Sample photometric params once per sample so all views share the
+            # same brightness/contrast/saturation/blur/erasing, preserving
+            # multi-view appearance consistency for the cross-attention decoder.
+            shared_photometric = self._sample_photometric_params()
+
             for vi in range(len(images)):
                 # Geometric augmentation (per-view, updates K and 2D keypoints)
                 if shared_scale is not None:
@@ -417,8 +422,10 @@ class SLEAPMultiViewDataset(torch.utils.data.Dataset):
                             scale=shared_scale,
                         )
                     )
-                # Photometric augmentation (per-view, independent randomness)
-                images[vi] = self._apply_photometric_augmentation(images[vi])
+                # Photometric augmentation (shared scalar params across views)
+                images[vi] = self._apply_photometric_augmentation(
+                    images[vi], shared_params=shared_photometric,
+                )
 
             x_data['images'] = images
             y_data['keypoints_2d'] = kp2d
@@ -570,60 +577,122 @@ class SLEAPMultiViewDataset(torch.utils.data.Dataset):
 
     # ── Augmentation ─────────────────────────────────────────────────────
 
-    def _apply_photometric_augmentation(self, image: np.ndarray) -> np.ndarray:
+    def _sample_photometric_params(self) -> Dict[str, Any]:
+        """Sample scalar photometric augmentation parameters once per sample.
+
+        Call site samples this once per multi-view sample and passes the
+        result to `_apply_photometric_augmentation` for every view, so all
+        views receive the same brightness/contrast/saturation shift, the
+        same blur kernel (or none), and the same erasing region (or none).
+        Gaussian sensor noise is resampled per view inside the application
+        function — physically, each camera has its own sensor noise.
+
+        Random erasing is parameterised in normalized coords so the same
+        relative region is erased in every view, even if views have
+        different pixel resolutions.
+        """
+        params: Dict[str, Any] = {
+            'brightness_delta': None,
+            'contrast_factor': None,
+            'saturation_factor': None,
+            'blur_kernel': None,
+            'erase': None,
+        }
+
+        if self.aug_color_jitter_brightness > 0:
+            params['brightness_delta'] = float(np.random.uniform(
+                -self.aug_color_jitter_brightness,
+                self.aug_color_jitter_brightness,
+            ))
+
+        if self.aug_color_jitter_contrast > 0:
+            params['contrast_factor'] = float(np.random.uniform(
+                max(0, 1 - self.aug_color_jitter_contrast),
+                1 + self.aug_color_jitter_contrast,
+            ))
+
+        if self.aug_color_jitter_saturation > 0:
+            params['saturation_factor'] = float(np.random.uniform(
+                max(0, 1 - self.aug_color_jitter_saturation),
+                1 + self.aug_color_jitter_saturation,
+            ))
+
+        if (self.aug_gaussian_blur_prob > 0
+                and np.random.random() < self.aug_gaussian_blur_prob):
+            lo, hi = self.aug_gaussian_blur_kernel_range
+            params['blur_kernel'] = int(np.random.choice(range(lo, hi + 1, 2)))
+
+        if (self.aug_random_erasing_prob > 0
+                and np.random.random() < self.aug_random_erasing_prob):
+            lo_s, hi_s = self.aug_random_erasing_scale_range
+            params['erase'] = {
+                'area_frac': float(np.random.uniform(lo_s, hi_s)),
+                'aspect': float(np.random.uniform(0.3, 1.0 / 0.3)),
+                'y0_frac': float(np.random.uniform(0.0, 1.0)),
+                'x0_frac': float(np.random.uniform(0.0, 1.0)),
+            }
+
+        return params
+
+    def _apply_photometric_augmentation(
+        self,
+        image: np.ndarray,
+        shared_params: Optional[Dict[str, Any]] = None,
+    ) -> np.ndarray:
         """Apply photometric augmentation to a single image.
 
         Args:
             image: (H, W, 3) float32 RGB in [0, 1].
+            shared_params: Optional pre-sampled parameters from
+                `_sample_photometric_params()`. When provided, scalar
+                parameters (brightness/contrast/saturation/blur/erase)
+                are reused so all views of a multi-view sample receive
+                matching augmentation. When None, parameters are sampled
+                fresh (single-view / standalone use).
 
         Returns:
             Augmented image, same shape and dtype, clipped to [0, 1].
         """
-        # Brightness: additive shift
-        if self.aug_color_jitter_brightness > 0:
-            delta = np.random.uniform(-self.aug_color_jitter_brightness,
-                                       self.aug_color_jitter_brightness)
-            image = image + delta
+        if shared_params is None:
+            shared_params = self._sample_photometric_params()
 
-        # Contrast: scale around mean
-        if self.aug_color_jitter_contrast > 0:
-            factor = np.random.uniform(max(0, 1 - self.aug_color_jitter_contrast),
-                                       1 + self.aug_color_jitter_contrast)
+        # Brightness: additive shift
+        if shared_params['brightness_delta'] is not None:
+            image = image + shared_params['brightness_delta']
+
+        # Contrast: scale around the per-view mean, with a shared factor.
+        # Keeping the mean local preserves "scale around mean" semantics
+        # when views have different overall luminance.
+        if shared_params['contrast_factor'] is not None:
             mean = image.mean()
-            image = (image - mean) * factor + mean
+            image = (image - mean) * shared_params['contrast_factor'] + mean
 
         # Saturation: blend with grayscale
-        if self.aug_color_jitter_saturation > 0:
-            factor = np.random.uniform(max(0, 1 - self.aug_color_jitter_saturation),
-                                       1 + self.aug_color_jitter_saturation)
+        if shared_params['saturation_factor'] is not None:
             gray = image.mean(axis=2, keepdims=True)
-            image = gray + (image - gray) * factor
+            image = gray + (image - gray) * shared_params['saturation_factor']
 
-        # Gaussian noise
+        # Gaussian noise (per-view realization — physical sensor noise)
         if self.aug_gaussian_noise_std > 0:
             noise = np.random.normal(0, self.aug_gaussian_noise_std,
                                      image.shape).astype(np.float32)
             image = image + noise
 
-        # Gaussian blur
-        if self.aug_gaussian_blur_prob > 0 and np.random.random() < self.aug_gaussian_blur_prob:
-            lo, hi = self.aug_gaussian_blur_kernel_range
-            # Kernel size must be odd
-            k = np.random.choice(range(lo, hi + 1, 2))
+        # Gaussian blur (shared kernel size across views)
+        if shared_params['blur_kernel'] is not None:
+            k = shared_params['blur_kernel']
             image = cv2.GaussianBlur(image, (k, k), 0)
 
-        # Random erasing (rectangular cutout filled with mean)
-        if self.aug_random_erasing_prob > 0 and np.random.random() < self.aug_random_erasing_prob:
+        # Random erasing (same relative region across views)
+        erase = shared_params['erase']
+        if erase is not None:
             h, w = image.shape[:2]
-            lo_s, hi_s = self.aug_random_erasing_scale_range
-            area_frac = np.random.uniform(lo_s, hi_s)
-            erase_area = int(h * w * area_frac)
-            aspect = np.random.uniform(0.3, 1.0 / 0.3)
-            eh = int(np.sqrt(erase_area * aspect))
-            ew = int(np.sqrt(erase_area / aspect))
+            erase_area = int(h * w * erase['area_frac'])
+            eh = int(np.sqrt(erase_area * erase['aspect']))
+            ew = int(np.sqrt(erase_area / erase['aspect']))
             eh, ew = min(eh, h), min(ew, w)
-            y0 = np.random.randint(0, h - eh + 1)
-            x0 = np.random.randint(0, w - ew + 1)
+            y0 = int(erase['y0_frac'] * max(0, h - eh))
+            x0 = int(erase['x0_frac'] * max(0, w - ew))
             image[y0:y0 + eh, x0:x0 + ew] = image.mean()
 
         return np.clip(image, 0.0, 1.0)


### PR DESCRIPTION
## Summary

Five training-pipeline bug fixes extracted from `inference_animation_export`, unrelated to animation export. All validated by training runs that produced new best-performing models on SMILy mouse and SMILy sticks datasets, and the full `pytest tests/` suite passes in a freshly installed pytorch3d env.

- **README**: `pandas` and `toml` are required by `smal_fitter/sleap_data/` but were missing from the install instructions, so a fresh env failed at first import.
- **Backbone owns its input normalization**: `BackboneInterface` now holds per-backbone `pixel_mean` / `pixel_std` buffers and applies them as the first op of each forward pass. Stats are pulled from the actual loaded weights — `Weights.transforms()` (torchvision) and `timm.data.resolve_model_data_config(...)` (timm) — so ViT variants using `[0.5, 0.5, 0.5]` no longer get fed ImageNet stats. Callers just pass float images in `[0, 1]`.
- **Decoder cleanup + 6D camera rotation**: drop the pooled-global-feature shortcut into the decoder query token (it was acting as an image-level fingerprint and driving train/val divergence on betas); visual signal now reaches the decoder only via cross-attention to spatial tokens (HMR2 style). Output-head init gain raised 0.001 → 0.01 to match HMR2's `INIT_DECODER_XAVIER`. Camera rotation switched from flattened 3×3 (9d) to the 6D continuous representation of Zhou et al. 2019; reshape via Gram-Schmidt (`rotation_6d_to_matrix`) at the output boundary.<br>⚠️ **Not backward compatible** with checkpoints predating this PR — `cam_rot_head` output dim changed 9 → 6.
- **Multi-view photometric aug shares scalar params**: brightness / contrast / saturation / blur / erasing are sampled once per multi-view sample so all views look like views of the same scene. Random erasing is parameterised in normalized coords to handle differing view resolutions. Gaussian sensor noise stays per-view (physically each camera has its own noise). Single-view callers keep their old behaviour.
- **`multiview_sticks_UNET.json`**: tuned to mirror the best-performing run (LR `5e-5`→`1e-4`, transformer depth `4`→`6`, IEF iters `1`→`3`, dataset_fraction `0.1`→`0.2`, batch size `2`→`6`, curriculum stage `"1"`→`"0"` so regularization actually kicks in from epoch 0, etc.).

## Test plan

- [x] `pytest tests/ -v -s` passes in freshly installed pytorch3d env (real-dataset h5 tests skipped because the file isn't on the install machine)
- [x] Validated by multiple training runs producing new best-performing models on SMILy mouse and SMILy sticks
- [x] Reviewer to confirm a pre-PR checkpoint errors cleanly on the cam_rot dim mismatch (expected, documented above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)