### PR TITLE
SMIL animation export + Blender import (draft)

### DIFF
--- a/3D_model_prep/SMIL_processing_addon.py
+++ b/3D_model_prep/SMIL_processing_addon.py
@@ -3533,6 +3533,10 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
         betas_avg = npz_data["betas"]       # (N_BETAS,)
         betas_per_frame = npz_data["betas_per_frame"] if "betas_per_frame" in npz_data.files else None
         log_beta_scales = npz_data["log_beta_scales"] if "log_beta_scales" in npz_data.files else None
+        # Optional global mesh scale (root-centered). When present, the inference
+        # renderer applied: rendered_v = (v - J0) * mesh_scale + trans. We must
+        # mirror that with armature.scale and an offset to armature.location.
+        mesh_scale = npz_data["mesh_scale"] if "mesh_scale" in npz_data.files else None
         fps = float(npz_data["fps"]) if "fps" in npz_data.files else float(sidecar.get("fps", 30.0))
 
         n_frames, n_joints, _ = poses.shape
@@ -3598,6 +3602,16 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
             R_rest = np.array(armature.pose.bones[bone_name].bone.matrix_local.to_3x3(), dtype=np.float64)
             rest_rot_inv_per_joint.append(R_rest.T)  # orthonormal: T == inv
 
+        # Rest position of the root joint (joints[0]) in armature-local space.
+        # Needed when mesh_scale is present: the inference renderer applies
+        # rendered_v = (v - J0) * mesh_scale + trans. To replicate this with
+        # armature.scale = s and armature.location = L, the visible vertex
+        # becomes L + s * v, which equals (v - J0) * s + trans iff
+        # L = trans - s * J0.
+        root_joint_rest = np.array(
+            armature.pose.bones[joint_names[0]].bone.head_local, dtype=np.float64
+        )
+
         for f in range(n_frames):
             scene.frame_set(f)
 
@@ -3620,8 +3634,15 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
                         pb.scale = (float(s[0]), float(s[1]), float(s[2]))
                         pb.keyframe_insert(data_path="scale", frame=f)
 
-            # Root translation on the armature object.
-            armature.location = (float(trans[f, 0]), float(trans[f, 1]), float(trans[f, 2]))
+            # Root translation (and global mesh scale, when present).
+            if mesh_scale is not None:
+                s = float(mesh_scale[f])
+                loc = trans[f].astype(np.float64) - s * root_joint_rest
+                armature.scale = (s, s, s)
+                armature.keyframe_insert(data_path="scale", frame=f)
+            else:
+                loc = trans[f].astype(np.float64)
+            armature.location = (float(loc[0]), float(loc[1]), float(loc[2]))
             armature.keyframe_insert(data_path="location", frame=f)
 
             # Per-frame shape keys (only in static-skeleton mode).

--- a/3D_model_prep/SMIL_processing_addon.py
+++ b/3D_model_prep/SMIL_processing_addon.py
@@ -3684,8 +3684,21 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
             _apply_betas_to_shape_keys(mesh_obj, betas_avg, frame=0)
 
         # Cameras.
+        created_cams = []
         if self.create_cameras:
-            self._create_cameras(sidecar.get("cameras", []))
+            created_cams = self._create_cameras(sidecar.get("cameras", []))
+
+        # Group armature + cameras under a single empty so the whole imported
+        # scene can be rotated/oriented as one. The mesh is intentionally left
+        # parented to the armature — re-parenting it here would break the
+        # Armature modifier's deformation chain.
+        scene_root = bpy.data.objects.new(name="SMIL_Animation_Root", object_data=None)
+        scene_root.empty_display_type = "ARROWS"
+        context.collection.objects.link(scene_root)
+        for child in (armature, *created_cams):
+            child.parent = scene_root
+            # Empty is at identity, so leaving matrix_parent_inverse as identity
+            # preserves each child's existing world transform.
 
         scene.frame_set(0)
         self.report(
@@ -3700,6 +3713,7 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
     def _create_cameras(self, cameras):
         import math
         from mathutils import Matrix
+        created = []
         for cam in cameras:
             name = str(cam.get("view_name", "smil_cam"))
             R = np.array(cam.get("R", np.eye(3).tolist()), dtype=np.float64).reshape(3, 3)
@@ -3728,6 +3742,8 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
             # after the rig itself has been scaled up.
             mat[:3, 3] = self.IMPORT_SCALE * (-R @ t)
             cam_obj.matrix_world = Matrix(mat.tolist())
+            created.append(cam_obj)
+        return created
 
 
 class SMPLProperties(bpy.types.PropertyGroup):

--- a/3D_model_prep/SMIL_processing_addon.py
+++ b/3D_model_prep/SMIL_processing_addon.py
@@ -1815,6 +1815,11 @@ class SMPL_PT_Panel(bpy.types.Panel):
 
         layout.separator()
         layout.operator("smpl.import_animation", text="Import SMIL Animation (.npz)")
+        # Stays greyed out until SMPL_OT_ExportAnimationGLTF.poll() finds
+        # SMIL_Animation_Root in the scene.
+        layout.operator(
+            "smpl.export_animation_gltf", text="Export animated model as glTF"
+        )
 
 
 def store_smpl_data(context, data, obj=None):
@@ -3746,6 +3751,79 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
         return created
 
 
+class SMPL_OT_ExportAnimationGLTF(bpy.types.Operator):
+    bl_idname = "smpl.export_animation_gltf"
+    bl_label = "Export Animated Model as glTF"
+    bl_description = (
+        "Export the imported SMIL animation (rig, mesh, cameras) as a glTF 2.0 "
+        "file via Blender's built-in exporter. Available once Import SMIL "
+        "Animation has produced a SMIL_Animation_Root empty."
+    )
+
+    filepath: bpy.props.StringProperty(subtype="FILE_PATH")
+    filter_glob: bpy.props.StringProperty(
+        default="*.glb;*.gltf", options={"HIDDEN"}
+    )
+
+    @classmethod
+    def poll(cls, context):
+        # poll() drives the UI auto-grey-out — true only when a previous
+        # import succeeded and left the root empty in place.
+        return bpy.data.objects.get("SMIL_Animation_Root") is not None
+
+    def invoke(self, context, event):
+        if not self.filepath:
+            self.filepath = "smil_animation.glb"
+        context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    def execute(self, context):
+        root = bpy.data.objects.get("SMIL_Animation_Root")
+        if root is None:
+            self.report(
+                {"WARNING"},
+                "No imported SMIL animation found (SMIL_Animation_Root missing).",
+            )
+            return {"CANCELLED"}
+
+        prev_active = context.view_layer.objects.active
+        prev_selected = [o for o in context.view_layer.objects if o.select_get()]
+        try:
+            bpy.ops.object.select_all(action="DESELECT")
+            export_objs = [root] + list(root.children_recursive)
+            for obj in export_objs:
+                obj.select_set(True)
+            context.view_layer.objects.active = root
+
+            filepath = bpy.path.abspath(self.filepath)
+            bpy.ops.export_scene.gltf(
+                filepath=filepath,
+                use_selection=True,
+                export_animations=True,
+                export_apply=False,
+            )
+        except Exception as e:
+            self.report({"WARNING"}, f"glTF export failed: {e}")
+            return {"CANCELLED"}
+        finally:
+            try:
+                bpy.ops.object.select_all(action="DESELECT")
+            except Exception:
+                pass
+            for obj in prev_selected:
+                try:
+                    obj.select_set(True)
+                except Exception:
+                    pass
+            try:
+                context.view_layer.objects.active = prev_active
+            except Exception:
+                pass
+
+        self.report({"INFO"}, f"Exported glTF animation to {filepath}")
+        return {"FINISHED"}
+
+
 class SMPLProperties(bpy.types.PropertyGroup):
     pkl_filepath: bpy.props.StringProperty(
         name="PKL Filepath",
@@ -4050,6 +4128,7 @@ classes = (
     SMPL_OT_RecomputeJointPositions,  # <-- Add here
     SMPL_OT_ClearMorphPCA,
     SMPL_OT_ImportAnimation,
+    SMPL_OT_ExportAnimationGLTF,
     SMPLProperties,
 )
 

--- a/3D_model_prep/SMIL_processing_addon.py
+++ b/3D_model_prep/SMIL_processing_addon.py
@@ -924,15 +924,24 @@ def create_shapekeys_from_pkl_shapedirs(data, obj):
     if not obj.data.shape_keys:
         obj.shape_key_add(name="Basis")
     
+    # PCA-derived betas can fall well outside Blender's default 0..1 slider range.
+    # Widen the range so animation imports load weights verbatim instead of clipping.
+    pkl_shape_key_slider_min = -10.0
+    pkl_shape_key_slider_max = 10.0
+
     # Create shapekeys from shapedirs
     for i in range(num_shapekeys):
         shape_key_name = f"Shape_{i}"
         shape_key = obj.shape_key_add(name=shape_key_name)
-        
+
         # Apply displacements from shapedirs
         for vert_index in range(num_vertices):
             displacement = shapedirs[vert_index, :, i]
             shape_key.data[vert_index].co = base_vertices[vert_index] + displacement
+
+        shape_key.slider_min = pkl_shape_key_slider_min
+        shape_key.slider_max = pkl_shape_key_slider_max
+        shape_key.value = 0.0
     
     # Create covariance matrix and mean betas
     # For independent shapekeys, use identity matrix

--- a/3D_model_prep/SMIL_processing_addon.py
+++ b/3D_model_prep/SMIL_processing_addon.py
@@ -3586,16 +3586,32 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
         for bone_name in joint_names:
             armature.pose.bones[bone_name].rotation_mode = "AXIS_ANGLE"
 
+        # Cache each bone's rest rotation (armature space). SMAL pose rotations
+        # are expressed in a frame that is world-aligned at rest; Blender's
+        # rotation_axis_angle is in the bone's local rest frame. SMIL armatures
+        # build every bone with head→tail along world +Z (see
+        # create_armature_and_weights), so each bone's rest rotation R_0 is
+        # non-trivial and we must conjugate: R_basis = R_0ᵀ · R_smal · R_0,
+        # which for axis-angle reduces to angle unchanged, axis = R_0ᵀ · axis.
+        rest_rot_inv_per_joint = []
+        for bone_name in joint_names:
+            R_rest = np.array(armature.pose.bones[bone_name].bone.matrix_local.to_3x3(), dtype=np.float64)
+            rest_rot_inv_per_joint.append(R_rest.T)  # orthonormal: T == inv
+
         for f in range(n_frames):
             scene.frame_set(f)
 
             # Per-joint axis-angle rotation.
             for j, bone_name in enumerate(joint_names):
-                aa = poses[f, j]                    # (3,)
+                aa = poses[f, j]                    # (3,) world-aligned axis-angle
                 angle = float(np.linalg.norm(aa))
-                axis = (aa / angle) if angle > 1e-8 else np.array([0.0, 0.0, 1.0])
+                if angle > 1e-8:
+                    axis_world = aa / angle
+                    axis_local = rest_rot_inv_per_joint[j] @ axis_world
+                else:
+                    axis_local = np.array([0.0, 0.0, 1.0])
                 pb = armature.pose.bones[bone_name]
-                pb.rotation_axis_angle = (angle, float(axis[0]), float(axis[1]), float(axis[2]))
+                pb.rotation_axis_angle = (angle, float(axis_local[0]), float(axis_local[1]), float(axis_local[2]))
                 pb.keyframe_insert(data_path="rotation_axis_angle", frame=f)
 
                 if self.apply_joint_scales and log_beta_scales is not None:
@@ -3646,12 +3662,20 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
             cam_obj = bpy.data.objects.new(name=name, object_data=cam_data)
             bpy.context.collection.objects.link(cam_obj)
 
-            # R/t from the inference pipeline are world->view (PyTorch3D convention).
-            # The camera object's transform is camera->world, so invert.
+            # PyTorch3D's FoVPerspectiveCameras uses the row-vector world→view
+            # convention: p_view = p_world @ R + T. In column-vector form this
+            # is p_view = Rᵀ · p_world + T, so the world-to-view matrix is
+            # [Rᵀ | T] and camera-to-world is [R | -R · T].
+            #
+            # Additionally, PyTorch3D camera local axes are (+X left, +Y up,
+            # +Z forward) while Blender's are (+X right, +Y up, -Z forward).
+            # Right-multiplying by diag(-1, 1, -1) flips the camera's local X
+            # and Z so it looks the same direction in Blender as in PyTorch3D.
+            cam_axis_flip = np.diag([-1.0, 1.0, -1.0])
             mat = np.eye(4)
-            mat[:3, :3] = R
-            mat[:3, 3] = t
-            cam_obj.matrix_world = Matrix(mat.tolist()).inverted()
+            mat[:3, :3] = R @ cam_axis_flip
+            mat[:3, 3] = -R @ t
+            cam_obj.matrix_world = Matrix(mat.tolist())
 
 
 class SMPLProperties(bpy.types.PropertyGroup):

--- a/3D_model_prep/SMIL_processing_addon.py
+++ b/3D_model_prep/SMIL_processing_addon.py
@@ -3519,6 +3519,13 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
         default=True,
     )
 
+    # PyTorch3D and Blender disagree on natural scene scale: inference clips look
+    # tiny in a default Blender scene. Multiplying the rig's root transform and
+    # the camera world positions by IMPORT_SCALE brings them to a comfortable
+    # working size without touching focal length, per-bone rotation/scale, or
+    # the camera object's own size.
+    IMPORT_SCALE = 10.0
+
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)
         return {"RUNNING_MODAL"}
@@ -3650,13 +3657,19 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
                         pb.keyframe_insert(data_path="scale", frame=f)
 
             # Root translation (and global mesh scale, when present).
+            # IMPORT_SCALE multiplies both the rig's world scale and its world
+            # translation so the visible vertex (location + scale * vertex)
+            # ends up at IMPORT_SCALE * (inference vertex), matching what the
+            # cameras (also scaled below) expect.
             if mesh_scale is not None:
                 s = float(mesh_scale[f])
-                loc = trans[f].astype(np.float64) - s * root_joint_rest
-                armature.scale = (s, s, s)
-                armature.keyframe_insert(data_path="scale", frame=f)
+                loc = self.IMPORT_SCALE * (trans[f].astype(np.float64) - s * root_joint_rest)
+                rig_scale = self.IMPORT_SCALE * s
             else:
-                loc = trans[f].astype(np.float64)
+                loc = self.IMPORT_SCALE * trans[f].astype(np.float64)
+                rig_scale = self.IMPORT_SCALE
+            armature.scale = (rig_scale, rig_scale, rig_scale)
+            armature.keyframe_insert(data_path="scale", frame=f)
             armature.location = (float(loc[0]), float(loc[1]), float(loc[2]))
             armature.keyframe_insert(data_path="location", frame=f)
 
@@ -3710,7 +3723,10 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
             cam_axis_flip = np.diag([-1.0, 1.0, -1.0])
             mat = np.eye(4)
             mat[:3, :3] = R @ cam_axis_flip
-            mat[:3, 3] = -R @ t
+            # Scale the world-space camera position (not the camera object's
+            # own scale) by IMPORT_SCALE so cameras stay framed on the rig
+            # after the rig itself has been scaled up.
+            mat[:3, 3] = self.IMPORT_SCALE * (-R @ t)
             cam_obj.matrix_world = Matrix(mat.tolist())
 
 

--- a/3D_model_prep/SMIL_processing_addon.py
+++ b/3D_model_prep/SMIL_processing_addon.py
@@ -1804,6 +1804,9 @@ class SMPL_PT_Panel(bpy.types.Panel):
         )
         layout.operator("smpl.apply_pose_correctives", text="Apply Pose Correctives")
 
+        layout.separator()
+        layout.operator("smpl.import_animation", text="Import SMIL Animation (.npz)")
+
 
 def store_smpl_data(context, data, obj=None):
     """Store SMPL data in a temporary file and save the path"""
@@ -3418,6 +3421,239 @@ class SMPL_OT_ClearMorphPCA(bpy.types.Operator):
         return {'FINISHED'}
 
 
+def _resolve_shape_key_for_beta(obj, beta_index):
+    """Return the shape key block that corresponds to beta_index, or None.
+
+    Prefers 'Shape_<i>' (direct shapedir mapping as written by create_shapekeys_from_pkl_shapedirs),
+    falls back to 'PC_<i+1>' (1-indexed PCA mapping from create_shapekeys), then to positional
+    order skipping the Basis key.
+    """
+    if not obj.data.shape_keys:
+        return None
+    keys = obj.data.shape_keys.key_blocks
+    for candidate in (f"Shape_{beta_index}", f"PC_{beta_index + 1}"):
+        if candidate in keys:
+            return keys[candidate]
+    non_basis = [k for k in keys if k.name != "Basis"]
+    if beta_index < len(non_basis):
+        return non_basis[beta_index]
+    return None
+
+
+def _apply_betas_to_shape_keys(obj, betas, frame=None):
+    """Set shape-key values from a flat betas vector, optionally keyframing at `frame`."""
+    for i, value in enumerate(betas):
+        key = _resolve_shape_key_for_beta(obj, i)
+        if key is None:
+            break
+        key.value = float(value)
+        if frame is not None:
+            key.keyframe_insert(data_path="value", frame=frame)
+
+
+def _load_animation_files(npz_path):
+    """Load .npz + sidecar .json from a path (sidecar path derived by suffix swap)."""
+    import json
+    npz_data = np.load(npz_path)
+    json_path = os.path.splitext(npz_path)[0] + ".json"
+    if not os.path.exists(json_path):
+        raise FileNotFoundError(f"Sidecar .json not found next to {npz_path}")
+    with open(json_path, "r") as f:
+        sidecar = json.load(f)
+    return npz_data, sidecar
+
+
+def _find_mesh_with_armature(context):
+    """Return (mesh_obj, armature_obj) for the active object, or (None, None)."""
+    obj = context.active_object
+    if obj is None:
+        return None, None
+    if obj.type == "ARMATURE":
+        for child in obj.children:
+            if child.type == "MESH":
+                return child, obj
+        return None, obj
+    if obj.type == "MESH":
+        armature = obj.find_armature()
+        if armature is not None:
+            return obj, armature
+    return None, None
+
+
+class SMPL_OT_ImportAnimation(bpy.types.Operator):
+    bl_idname = "smpl.import_animation"
+    bl_label = "Import Inference Animation"
+    bl_description = (
+        "Import a SMIL inference animation (.npz + sidecar .json) onto the active "
+        "SMIL rig. Drives per-bone rotation/scale, root translation, and (when "
+        "skeleton is static) per-frame shape-key weights."
+    )
+
+    filepath: bpy.props.StringProperty(subtype="FILE_PATH")
+    filter_glob: bpy.props.StringProperty(default="*.npz", options={"HIDDEN"})
+
+    static_shape: bpy.props.BoolProperty(
+        name="Static shape (use clip-averaged betas)",
+        description=(
+            "Apply only the clip-averaged betas once at frame 0 instead of per-frame "
+            "shape keyframes. Forced on when static_joint_locs is False in the sidecar."
+        ),
+        default=False,
+    )
+    apply_joint_scales: bpy.props.BoolProperty(
+        name="Apply per-joint scale",
+        description="Keyframe bone.scale from log_beta_scales (exp-applied).",
+        default=True,
+    )
+    create_cameras: bpy.props.BoolProperty(
+        name="Create cameras from sidecar",
+        default=True,
+    )
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    # ------------------------------------------------------------------ main
+
+    def execute(self, context):
+        try:
+            npz_data, sidecar = _load_animation_files(bpy.path.abspath(self.filepath))
+        except Exception as e:
+            self.report({"ERROR"}, f"Failed to load animation files: {e}")
+            return {"CANCELLED"}
+
+        mesh_obj, armature = _find_mesh_with_armature(context)
+        if armature is None:
+            self.report({"ERROR"}, "Select a SMIL mesh or its armature before importing.")
+            return {"CANCELLED"}
+
+        poses = npz_data["poses"]           # (F, N_JOINTS, 3)
+        trans = npz_data["trans"]           # (F, 3)
+        betas_avg = npz_data["betas"]       # (N_BETAS,)
+        betas_per_frame = npz_data["betas_per_frame"] if "betas_per_frame" in npz_data.files else None
+        log_beta_scales = npz_data["log_beta_scales"] if "log_beta_scales" in npz_data.files else None
+        fps = float(npz_data["fps"]) if "fps" in npz_data.files else float(sidecar.get("fps", 30.0))
+
+        n_frames, n_joints, _ = poses.shape
+        joint_names = sidecar.get("joint_names", [])
+
+        # Joint-count validation against the active armature.
+        armature_bone_names = [b.name for b in armature.pose.bones]
+        missing = [name for name in joint_names if name not in armature_bone_names]
+        if missing:
+            self.report(
+                {"ERROR"},
+                f"Armature is missing {len(missing)} bones from the animation "
+                f"(first: {missing[:3]}). Import a matching SMIL model first.",
+            )
+            return {"CANCELLED"}
+
+        # Branch on skeleton mode (see docs/animation export plan).
+        static_joint_locs = bool(sidecar.get("static_joint_locs", False))
+        effective_static_shape = self.static_shape or not static_joint_locs
+
+        if not static_joint_locs:
+            # Apply averaged betas statically, then recompute joint locations once.
+            if mesh_obj is not None:
+                _apply_betas_to_shape_keys(mesh_obj, betas_avg, frame=None)
+                if mesh_obj.get("static_joint_locs", False) is False:
+                    prev_active = context.view_layer.objects.active
+                    context.view_layer.objects.active = mesh_obj
+                    try:
+                        bpy.ops.smpl.recompute_joint_positions()
+                    except Exception as e:
+                        self.report({"WARNING"}, f"Joint recomputation failed: {e}")
+                    finally:
+                        context.view_layer.objects.active = prev_active
+            self.report(
+                {"INFO"},
+                "static_joint_locs=False: applied averaged betas and recomputed joints; "
+                "per-frame shape animation is disabled for this clip.",
+            )
+
+        # Configure scene frame range and fps.
+        scene = context.scene
+        scene.frame_start = 0
+        scene.frame_end = n_frames - 1
+        scene.render.fps = max(1, int(round(fps)))
+
+        # Per-frame keyframing.
+        context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode="POSE")
+
+        # Ensure axis-angle rotation mode on all pose bones we drive.
+        for bone_name in joint_names:
+            armature.pose.bones[bone_name].rotation_mode = "AXIS_ANGLE"
+
+        for f in range(n_frames):
+            scene.frame_set(f)
+
+            # Per-joint axis-angle rotation.
+            for j, bone_name in enumerate(joint_names):
+                aa = poses[f, j]                    # (3,)
+                angle = float(np.linalg.norm(aa))
+                axis = (aa / angle) if angle > 1e-8 else np.array([0.0, 0.0, 1.0])
+                pb = armature.pose.bones[bone_name]
+                pb.rotation_axis_angle = (angle, float(axis[0]), float(axis[1]), float(axis[2]))
+                pb.keyframe_insert(data_path="rotation_axis_angle", frame=f)
+
+                if self.apply_joint_scales and log_beta_scales is not None:
+                    if log_beta_scales.ndim == 3 and log_beta_scales.shape[1] == n_joints:
+                        s = np.exp(log_beta_scales[f, j])
+                        pb.scale = (float(s[0]), float(s[1]), float(s[2]))
+                        pb.keyframe_insert(data_path="scale", frame=f)
+
+            # Root translation on the armature object.
+            armature.location = (float(trans[f, 0]), float(trans[f, 1]), float(trans[f, 2]))
+            armature.keyframe_insert(data_path="location", frame=f)
+
+            # Per-frame shape keys (only in static-skeleton mode).
+            if mesh_obj is not None and not effective_static_shape and betas_per_frame is not None:
+                _apply_betas_to_shape_keys(mesh_obj, betas_per_frame[f], frame=f)
+
+        bpy.ops.object.mode_set(mode="OBJECT")
+
+        # Static-shape single keyframe (applies to both user-forced and skeleton-forced paths).
+        if effective_static_shape and mesh_obj is not None:
+            _apply_betas_to_shape_keys(mesh_obj, betas_avg, frame=0)
+
+        # Cameras.
+        if self.create_cameras:
+            self._create_cameras(sidecar.get("cameras", []))
+
+        scene.frame_set(0)
+        self.report(
+            {"INFO"},
+            f"Imported {n_frames} frames at {fps:.2f} fps "
+            f"(static_shape={'on' if effective_static_shape else 'off'}).",
+        )
+        return {"FINISHED"}
+
+    # ------------------------------------------------------------------ cameras
+
+    def _create_cameras(self, cameras):
+        import math
+        from mathutils import Matrix
+        for cam in cameras:
+            name = str(cam.get("view_name", "smil_cam"))
+            R = np.array(cam.get("R", np.eye(3).tolist()), dtype=np.float64).reshape(3, 3)
+            t = np.array(cam.get("t", [0.0, 0.0, 0.0]), dtype=np.float64).reshape(-1)
+            fov_deg = float(cam.get("fov", 45.0))
+
+            cam_data = bpy.data.cameras.new(name=name)
+            cam_data.angle = math.radians(fov_deg)
+            cam_obj = bpy.data.objects.new(name=name, object_data=cam_data)
+            bpy.context.collection.objects.link(cam_obj)
+
+            # R/t from the inference pipeline are world->view (PyTorch3D convention).
+            # The camera object's transform is camera->world, so invert.
+            mat = np.eye(4)
+            mat[:3, :3] = R
+            mat[:3, 3] = t
+            cam_obj.matrix_world = Matrix(mat.tolist()).inverted()
+
+
 class SMPLProperties(bpy.types.PropertyGroup):
     pkl_filepath: bpy.props.StringProperty(
         name="PKL Filepath",
@@ -3721,6 +3957,7 @@ classes = (
     SMPL_OT_LoadAllUnposedMeshes,
     SMPL_OT_RecomputeJointPositions,  # <-- Add here
     SMPL_OT_ClearMorphPCA,
+    SMPL_OT_ImportAnimation,
     SMPLProperties,
 )
 

--- a/3D_model_prep/SMIL_processing_addon.py
+++ b/3D_model_prep/SMIL_processing_addon.py
@@ -3591,6 +3591,12 @@ class SMPL_OT_ImportAnimation(bpy.types.Operator):
         scene.frame_end = n_frames - 1
         scene.render.fps = max(1, int(round(fps)))
 
+        # Inference cameras are assumed square; default the render output to 1080x1080
+        # so viewport/render framing matches the camera intrinsics out of the box.
+        scene.render.resolution_x = 1080
+        scene.render.resolution_y = 1080
+        scene.render.resolution_percentage = 100
+
         # Per-frame keyframing.
         context.view_layer.objects.active = armature
         bpy.ops.object.mode_set(mode="POSE")

--- a/docs/animation_export_plan.md
+++ b/docs/animation_export_plan.md
@@ -1,0 +1,348 @@
+# SMIL Animation Export & Blender Import — Implementation Plan & Status
+
+**Branch:** `inference_animation_export` (rebased onto `augmentation-robustness`)
+**Last updated:** 2026-04-13
+
+## Goal
+
+`run_singleview_inference.py` and `run_multiview_inference.py` predict full SMIL
+parameter trajectories (global rotation, per-joint axis-angle pose, translation,
+betas, per-joint log-scales, per-joint translations, camera params) but
+previously *discarded* them after rendering the MP4 preview. This work makes
+those trajectories first-class, shareable outputs.
+
+## Four-phase strategy
+
+0. **Phase 0 — Branch setup.** ✅ Done — `inference_animation_export` created
+   off `backbone_factory_overhaul`, then rebased onto `augmentation-robustness`
+   (strict superset; 0 divergent commits, 36 commits ahead; no conflicts on
+   rebase).
+1. **Phase 1 — Lossless Python export.** ✅ Done — AMASS-compatible `.npz`
+   + human-readable `.json` sidecar, written from both inference scripts behind
+   a `--export_animation PATH` flag.
+2. **Phase 2 — Blender addon importer.** ✅ Operator implemented and
+   registered; awaiting end-to-end test in Blender 4.2 with a real `.npz`.
+3. **Phase 3 — Addon-side export to shareable formats.** ⏳ Not started —
+   wrapper around `bpy.ops.export_scene.gltf()` / `.fbx()` with sensible
+   defaults for skeletal + morph-target animation + cameras.
+
+## Phase 1 — format choice (AMASS `.npz` + JSON sidecar)
+
+### Formats considered and rejected
+
+- **BVH / FBX / Alembic** — lossy or toolchain-hostile for a parametric animal rig.
+- **glTF 2.0** — strong baked-delivery path (morph targets + TRS animation) but
+  bakes away the SMIL parameter semantics we want to preserve for research.
+- **USD (UsdSkel + BlendShapeAnimation)** — best semantic match of any standard
+  format, but Blender's UsdSkel importer still has rough edges as of 2025.
+- **FBX first** — semantically capable (Shape Deformers + per-bone TRS +
+  cameras), but Autodesk FBX SDK Python bindings are closed-source /
+  version-locked; `pyfbx` / `pyfbx_jasper` are incomplete with spotty
+  blend-shape support. Routing via `blender --background` requires the Phase 2
+  importer to exist first, collapsing "FBX first" back into "addon first."
+  FBX delivery therefore deferred to Phase 3.
+
+### Chosen format
+
+AMASS-compatible `.npz` with a documented SMIL extension schema, paired with a
+small sidecar `.json` for human-readable metadata. De facto convention in the
+parametric-body community (SMPL / SMPL-X / SMAL); lossless; diffable; trivially
+loaded with `np.load`. We control both ends.
+
+### On-disk schema
+
+`<clip_name>.npz` (binary, primary):
+
+```
+poses            (F, N_JOINTS, 3)   float32  axis-angle per joint (index 0 = root / global_rot)
+trans            (F, 3)             float32  world translation
+betas            (N_BETAS,)         float32  clip-averaged shape vector (AMASS baseline)
+betas_per_frame  (F, N_BETAS)       float32  per-frame shape vector (drives Blender morph animation)
+log_beta_scales  (F, N_JOINTS, 3)   float32  per-joint log scale (when model predicts)
+betas_trans      (F, N_JOINTS, 3)   float32  per-joint trans (when model predicts)
+fps              scalar             float32
+```
+
+Why both `betas` and `betas_per_frame`: glTF morph targets, FBX Shape Deformers,
+and USD BlendShapeAnimation all animate weights per-frame as a standard feature
+(facial animation relies on this). AMASS's static-betas convention is a domain
+assumption, not a format limitation — we store both and let the importer
+choose.
+
+`<clip_name>.json` (sidecar):
+
+```json
+{
+  "schema_version": "1.0",
+  "model_id": "...",
+  "source_checkpoint": "...",
+  "source_input": "...",
+  "n_frames": ...,
+  "n_joints": ...,
+  "n_betas": ...,
+  "joint_names": [...],
+  "parents": [...],
+  "rotation_representation": "axis_angle",
+  "root_joint_index": 0,
+  "static_joint_locs": true | false,
+  "ignore_hardcoded_body": true | false,
+  "fps": 30,
+  "cameras": [{"view_name": "...", "R": 3x3, "t": 3, "fov": ...}, ...]
+}
+```
+
+### Field sourcing (verified against code)
+
+- `rotation_representation`: always the string `"axis_angle"` on output. The
+  regressor may internally use `"6d"` or `"axis_angle"`
+  ([smil_image_regressor.py:103,119,143](../smal_fitter/neuralSMIL/smil_image_regressor.py));
+  exporter normalises via the `rotation_6d_to_axis_angle` path
+  (`pytorch3d.transforms.rotation_6d_to_matrix` → `matrix_to_axis_angle`)
+  inside `animation_export.py` to avoid pulling the full regressor import
+  chain.
+- `root_joint_index`: fixed at 0; root identified as the entry where
+  `dd["kintree_table"][0] == -1`
+  ([config.py:96](../config.py), [smal_torch.py:205](../smal_model/smal_torch.py)).
+- `static_joint_locs`: real flag (not invented). Derived from the pkl key
+  `dd["static_joint_locs"]` and exposed as `config.STATIC_JOINT_LOCATIONS`
+  ([config.py:82-89](../config.py)). Controls joint computation inside
+  `SMAL.__call__` ([smal_torch.py:254-263, 342-350](../smal_model/smal_torch.py)):
+  - `True`  → use stored `self.J` directly.
+  - `False` → always recompute `J = J_regressor @ v_shaped` each forward pass.
+- `ignore_hardcoded_body`: recorded for informational parity with
+  [config.py:49](../config.py); controls symmetry / joint-name loading, not
+  joint recomputation.
+
+### Correctness implication of `static_joint_locs`
+
+- **`static_joint_locs == true`** — joint positions are fixed. Per-frame
+  `betas_per_frame` shape animation is safe; importer keyframes shape keys per
+  frame by default.
+- **`static_joint_locs == false`** — joint positions depend on current shape
+  (`J_regressor @ v_shaped`). Per-frame shape changes would require
+  re-regressing joints every frame, which a static Blender armature can't
+  represent. In this mode the importer must:
+  1. Use the clip-averaged `betas` only (ignore `betas_per_frame`).
+  2. Apply those betas to the shape keys once (static for the clip).
+  3. Invoke the existing `SMPL_OT_RecomputeJointPositions` operator
+     ([SMIL_processing_addon.py:3356](../3D_model_prep/SMIL_processing_addon.py))
+     once to re-regress the armature's rest pose to the averaged shape.
+  4. Then keyframe rotation / bone scale / root trans as normal.
+  Importer emits an INFO message explaining per-frame shape animation is
+  disabled in this mode.
+
+## Phase 1 — implementation (DONE)
+
+### Files
+
+- **NEW** [smal_fitter/neuralSMIL/animation_export.py](../smal_fitter/neuralSMIL/animation_export.py)
+  — `AnimationRecorder` class (per-frame accumulation: `record()` / `write()`
+  / `set_cameras()` / `num_frames()`); `build_recorder_from_config` constructor
+  that pulls joint metadata from the global `config`;
+  `build_multiview_cameras` that averages `cam_{rot,trans,fov}_per_view` across
+  frames into a static sidecar block; local `rotation_6d_to_axis_angle` with
+  lazy pytorch3d import. Schema version `"1.0"`.
+
+- **MODIFIED** [smal_fitter/neuralSMIL/run_singleview_inference.py](../smal_fitter/neuralSMIL/run_singleview_inference.py)
+  — added `--export_animation PATH` CLI flag; added `animation_recorder`
+  optional parameter to `process_video`; calls
+  `animation_recorder.record(predicted_params)` immediately after
+  `run_inference_on_image` and *before* camera smoothing (captures raw
+  pre-smoothing values); writes at end of `main()`.
+
+- **MODIFIED** [smal_fitter/neuralSMIL/run_multiview_inference.py](../smal_fitter/neuralSMIL/run_multiview_inference.py)
+  — added `--export_animation` flag; new `_export_animation` helper that
+  reuses existing DDP temp-dir machinery
+  (`write_predictions_to_temp` / `load_all_predictions_from_temp`) with a
+  dedicated `.animation_export_temp_*` directory so the gather doesn't
+  interfere with the separate smoothing gather path; builds averaged
+  multi-view cameras from `dataset.get_canonical_camera_order()`; writes on
+  rank 0 only. Invoked immediately after `run_inference_phase` returns.
+
+- **NEW** [tests/test_animation_export.py](../tests/test_animation_export.py)
+  — 5 round-trip tests, all passing:
+  1. Round-trip axis-angle with full optional fields (poses, trans, betas,
+     betas_per_frame, log_beta_scales, betas_trans, fps, sidecar schema).
+  2. 6D rotations normalise to axis-angle (identity 6D → zero axis-angle).
+  3. Optional fields absent when not recorded.
+  4. Empty recorder raises RuntimeError.
+  5. Invalid rotation_representation raises ValueError.
+
+### Commits (on `inference_animation_export`, in order)
+
+```
+a122ab9  Add AnimationRecorder helper for SMIL inference export
+e4f1bc9  Wire --export_animation into singleview inference
+d416d5c  Wire --export_animation into multiview inference
+93e0155  Add round-trip tests for AnimationRecorder
+5c4a5db  Add SMPL_OT_ImportAnimation operator for SMIL animation playback
+```
+
+## Phase 2 — Blender addon importer (IMPLEMENTED, UNTESTED)
+
+### Files
+
+- **MODIFIED** [3D_model_prep/SMIL_processing_addon.py](../3D_model_prep/SMIL_processing_addon.py)
+  — new operator `SMPL_OT_ImportAnimation`
+  (bl_idname: `smpl.import_animation`), registered in the `classes` tuple and
+  surfaced as a panel button `"Import SMIL Animation (.npz)"` in
+  `SMPL_PT_Panel.draw()` (below `smpl.apply_pose_correctives`).
+
+### Helper functions (in addon)
+
+- `_resolve_shape_key_for_beta(obj, beta_index)` — prefers `Shape_<i>`, falls
+  back to `PC_<i+1>`, then positional (skipping `Basis`).
+- `_apply_betas_to_shape_keys(obj, betas, frame=None)` — sets shape-key values
+  with optional keyframing.
+- `_load_animation_files(npz_path)` — loads `.npz` + sidecar `.json`.
+- `_find_mesh_with_armature(context)` — resolves active object → (mesh,
+  armature).
+
+### Operator execute flow
+
+1. Load `.npz` + `.json`.
+2. Validate `joint_names` against armature bone names.
+3. Branch on sidecar `static_joint_locs`:
+   - `true` — use `betas_per_frame` (default) or clip-averaged `betas` if
+     operator's `static_shape` property is set.
+   - `false` — force clip-averaged `betas`, apply once to shape keys, call
+     `bpy.ops.smpl.recompute_joint_positions()` to re-regress rest pose;
+     emit INFO message explaining per-frame shape animation is disabled.
+4. Set `scene.frame_start`, `scene.frame_end`, `scene.render.fps` from sidecar.
+5. Set all bones to `rotation_mode = 'AXIS_ANGLE'`.
+6. Per frame:
+   - Keyframe bone `rotation_axis_angle` (normalise axis).
+   - Keyframe bone `scale` from `exp(log_beta_scales)`.
+   - Keyframe armature object `location` from `trans[f]`.
+   - Keyframe shape keys from `betas_per_frame[f]` (static-skeleton mode only).
+7. Create one Blender camera per sidecar view via `_create_cameras`, inverting
+   the PyTorch3D world→view `R|t` into Blender's camera→world convention.
+
+### Operator properties
+
+- `static_shape: BoolProperty` — collapses per-frame shape to clip-averaged
+  `betas` at frame 0 (for users who want a fixed body).
+- `apply_joint_scales: BoolProperty` — toggle `log_beta_scales` keyframing.
+- `create_cameras: BoolProperty` — toggle camera creation from sidecar.
+
+### Out of scope for Phase 2
+
+- Posedir correctives application (existing logic at
+  [SMIL_processing_addon.py:705-760](../3D_model_prep/SMIL_processing_addon.py)
+  can be wired in later).
+- Drivers-based live evaluation.
+- Animated cameras.
+
+## Phase 3 — shareable export (NOT STARTED)
+
+### Planned
+
+- New operator `SMPL_OT_ExportSharedAnimation`
+  (bl_idname: `smpl.export_shared_animation`) with format enum
+  (`GLTF` default, `FBX` optional).
+- Thin wrapper around Blender's built-in exporters:
+  - **glTF**: `bpy.ops.export_scene.gltf(filepath=..., export_format='GLB',
+    export_animations=True, export_morph=True,
+    export_morph_animation=True, export_cameras=True,
+    export_apply=False)`.
+  - **FBX**: `bpy.ops.export_scene.fbx(filepath=...,
+    use_armature_deform_only=False, add_leaf_bones=False, bake_anim=True,
+    bake_anim_use_all_bones=True, bake_anim_use_nla_strips=False,
+    bake_anim_use_all_actions=False, bake_anim_step=1.0,
+    mesh_smooth_type='FACE', use_mesh_modifiers=True)`.
+- Pre-export sanity: ensure scene frame range matches imported clip; ensure
+  shape-key fcurves exist (warn + offer static-shape fallback otherwise).
+- No custom FBX/glTF writing — delegate entirely to Blender's exporters. Addon
+  only curates the settings matrix.
+
+## Verification
+
+### Phase 1 — Python export ✅
+
+- **Unit:** `tests/test_animation_export.py` — 5 tests, all passing in the
+  `pytorch3d` conda env on Windows.
+- **Integration:** pending — blocked by dataset/checkpoint mismatch (see
+  Runtime notes below).
+- **Regression:** without `--export_animation`, both inference scripts must
+  produce byte-identical MP4s to prior master (guard rail for the default
+  path). Not yet re-verified post-rebase.
+
+### Phase 2 — Blender import ⏳
+
+- **Manual:** launch Blender 4.2, import SMIL model via existing
+  `smpl.import_model`, import `.npz` via new `smpl.import_animation`, scrub
+  timeline, confirm bones rotate, shape keys drive, per-view cameras appear
+  with correct framing.
+- **Fidelity check:** in Blender, evaluate rig at frame F, read back bone
+  rotations, compare to source `.npz` `poses[F]` — should be within float
+  precision.
+
+### Phase 3 — shareable export ⏳
+
+- Open `.glb` in third-party glTF viewer (e.g.
+  gltf-viewer.donmccurdy.com or Windows 3D Viewer); confirm skeletal +
+  morph-target animation + camera are present.
+- Repeat for `.fbx` in Unity or Maya.
+
+## Runtime notes / current blockers
+
+### Inference run needs an HF-weight cache
+
+`timm.create_model(..., pretrained=True)` at
+[backbone_factory.py:325](../smal_fitter/neuralSMIL/backbone_factory.py#L325)
+pulls ImageNet weights from HuggingFace. On machines without internet (or
+where HF is unreachable — WSL2 networking frequently is), the backbone
+constructor fails with `LocalEntryNotFoundError`.
+
+Workarounds tried:
+
+- **Download once, run offline.** Run
+  `python hpc_files/download_backbone_weights.py` on a machine with internet
+  access (populates `$HF_HOME/hub`), then on the inference host
+  `export HF_HUB_OFFLINE=1` before running inference.
+- **WSL ↔ Windows cache share.** Downloads on Windows land at
+  `C:\Users\Fabian\.cache\huggingface` — WSL has its own cache at
+  `/home/<user>/.cache/huggingface`. Point WSL at the Windows cache via
+  `export HF_HOME=/mnt/c/Users/Fabian/.cache/huggingface` (plus
+  `export HF_HUB_OFFLINE=1`).
+
+Potential future fix: pass `pretrained=False` from
+`load_multiview_model_from_checkpoint` since the checkpoint load supersedes
+the ImageNet init. Not yet implemented.
+
+### Checkpoint max_views vs dataset max_views mismatch
+
+During the test run, the `multiview_checkpoints_MOUSE_Unet_512_EffB3_v3`
+checkpoint has `view_embeddings.weight` of shape `(12, D)` (trained with
+`max_views=12`), but `SMILymice_3D_only.h5` exposes 18 canonical cameras. When
+a sample comes with view indices ≥ 12, the embedding lookup crashes with
+`indexSelectLargeIndex` CUDA asserts (0/200 predictions completed).
+
+User resolution: will provide a dataset matching the checkpoint's 12-view
+range — no code change needed.
+
+## Session continuation checklist
+
+When resuming elsewhere:
+
+1. `git fetch origin && git checkout inference_animation_export` (rebased onto
+   `augmentation-robustness`; 5 commits ahead of that base — see list above).
+2. Ensure conda env `pytorch3d` is active (Python 3.10, PyTorch 2.3.1,
+   CUDA 11.8).
+3. Populate HF cache (`python hpc_files/download_backbone_weights.py`) and
+   `export HF_HUB_OFFLINE=1` if the inference host lacks reliable HF access.
+4. Use a dataset whose view count ≤ checkpoint's `max_views`.
+5. Integration test:
+   ```bash
+   python smal_fitter/neuralSMIL/run_multiview_inference.py \
+       --dataset <h5> --smal_file <pkl> \
+       --checkpoint <ckpt.pth> \
+       --max_frames 20 \
+       --export_animation True
+   ```
+   Expect `.npz` + `.json` next to the usual MP4 outputs.
+6. Phase 2 test: open Blender 4.2, load SMIL model via existing addon
+   operators, then the new **Import SMIL Animation (.npz)** button in the SMPL
+   panel. Load the `.npz` from step 5.
+7. Critical assessment of code so far (user's explicit next step).
+8. Then Phase 3 (glTF/FBX export wrapper).

--- a/docs/animation_export_plan.md
+++ b/docs/animation_export_plan.md
@@ -1,7 +1,7 @@
 # SMIL Animation Export & Blender Import — Implementation Plan & Status
 
 **Branch:** `inference_animation_export` (rebased onto `augmentation-robustness`)
-**Last updated:** 2026-04-13
+**Last updated:** 2026-05-08
 
 ## Goal
 
@@ -224,6 +224,20 @@ d416d5c  Wire --export_animation into multiview inference
   `betas` at frame 0 (for users who want a fixed body).
 - `apply_joint_scales: BoolProperty` — toggle `log_beta_scales` keyframing.
 - `create_cameras: BoolProperty` — toggle camera creation from sidecar.
+
+### Outstanding items for Phase 2 (TODO — to be implemented)
+
+Items surfaced from end-to-end testing in Blender; deferred for follow-up:
+
+- **Imported model scaling.** Update the scaling applied to the SMIL model when
+  it's brought into Blender so the imported armature/mesh lands at the expected
+  world-space size (matches the inference rig / per-frame `mesh_scale`).
+- **Camera parameters.** A few sidecar-driven camera parameters need
+  adjustment on the importer side (specifics TBD during implementation).
+- **Default range of shape parameters (blend-shape weights).** Adjust the
+  default min/max range of the imported SMIL model's shape-key (blend-shape)
+  weights so per-frame `betas_per_frame` values keyframe within the allowed
+  range without being clamped.
 
 ### Out of scope for Phase 2
 

--- a/smal_fitter/neuralSMIL/animation_export.py
+++ b/smal_fitter/neuralSMIL/animation_export.py
@@ -1,0 +1,290 @@
+"""Export recorded SMIL inference parameters to an AMASS-compatible .npz + sidecar .json.
+
+Used by run_singleview_inference.py and run_multiview_inference.py to persist the
+full parametric output of the neural regressors (pose, trans, betas, per-joint
+scale/trans, cameras) alongside the existing MP4 previews. The on-disk schema is
+documented in .claude/plans/iterative-kindling-swan.md (Phase 1).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import torch
+
+
+SCHEMA_VERSION = "1.0"
+
+
+def rotation_6d_to_axis_angle(d6: torch.Tensor) -> torch.Tensor:
+    """Convert 6D rotation representation to axis-angle.
+
+    Mirrors `smil_image_regressor.rotation_6d_to_axis_angle` but avoids importing
+    that module (and its heavy dependency chain) for consumers that only need the
+    conversion. Uses pytorch3d's transforms directly.
+    """
+    from pytorch3d.transforms import rotation_6d_to_matrix, matrix_to_axis_angle
+    return matrix_to_axis_angle(rotation_6d_to_matrix(d6))
+
+
+def _to_numpy(t: Any) -> np.ndarray:
+    if isinstance(t, torch.Tensor):
+        return t.detach().cpu().float().numpy()
+    return np.asarray(t, dtype=np.float32)
+
+
+class AnimationRecorder:
+    """Accumulates per-frame predicted_params dicts and writes .npz + .json.
+
+    Each `record(predicted_params)` call appends one frame. Batch dim of 1 is
+    assumed — callers running batched inference must loop and record per batch
+    element. Rotations are normalised to axis-angle on write regardless of the
+    inbound `rotation_representation`.
+    """
+
+    def __init__(
+        self,
+        output_path: Union[str, Path],
+        rotation_representation: str,
+        n_joints: int,
+        n_betas: int,
+        joint_names: List[str],
+        parents: List[int],
+        fps: float,
+        static_joint_locs: bool,
+        ignore_hardcoded_body: bool,
+        source_checkpoint: Optional[str] = None,
+        source_input: Optional[str] = None,
+        model_id: Optional[str] = None,
+    ) -> None:
+        if rotation_representation not in ("axis_angle", "6d"):
+            raise ValueError(
+                f"rotation_representation must be 'axis_angle' or '6d', got {rotation_representation!r}"
+            )
+        self.output_path = Path(output_path)
+        self.rotation_representation = rotation_representation
+        self.n_joints = int(n_joints)
+        self.n_betas = int(n_betas)
+        self.joint_names = [str(n) for n in joint_names]
+        self.parents = [int(p) for p in parents]
+        self.fps = float(fps)
+        self.static_joint_locs = bool(static_joint_locs)
+        self.ignore_hardcoded_body = bool(ignore_hardcoded_body)
+        self.source_checkpoint = source_checkpoint
+        self.source_input = source_input
+        self.model_id = model_id
+
+        self._poses: List[np.ndarray] = []
+        self._trans: List[np.ndarray] = []
+        self._betas: List[np.ndarray] = []
+        self._log_beta_scales: List[np.ndarray] = []
+        self._betas_trans: List[np.ndarray] = []
+
+        # Per-frame camera buffers (singleview). Multi-view cameras are stored
+        # via set_cameras() because they're static per view for a given clip.
+        self._cam_rot: List[np.ndarray] = []
+        self._cam_trans: List[np.ndarray] = []
+        self._fov: List[np.ndarray] = []
+
+        self._cameras_sidecar: List[Dict[str, Any]] = []
+
+    # ------------------------------------------------------------------ record
+
+    def _rot_to_aa(self, rot: torch.Tensor) -> torch.Tensor:
+        if self.rotation_representation == "6d":
+            return rotation_6d_to_axis_angle(rot)
+        return rot
+
+    def record(self, predicted_params: Dict[str, Any]) -> None:
+        global_rot = predicted_params["global_rot"]
+        joint_rot = predicted_params["joint_rot"]
+
+        if isinstance(global_rot, torch.Tensor):
+            global_rot = global_rot.detach().cpu()
+        if isinstance(joint_rot, torch.Tensor):
+            joint_rot = joint_rot.detach().cpu()
+
+        global_rot_aa = self._rot_to_aa(global_rot)
+        joint_rot_aa = self._rot_to_aa(joint_rot)
+
+        if global_rot_aa.dim() == 2:  # (B, 3) -> (B, 1, 3)
+            global_rot_aa = global_rot_aa.unsqueeze(1)
+        poses = torch.cat([global_rot_aa, joint_rot_aa], dim=1)  # (B, N_JOINTS, 3)
+
+        self._poses.append(_to_numpy(poses[0]))
+        self._trans.append(_to_numpy(predicted_params["trans"][0]))
+        self._betas.append(_to_numpy(predicted_params["betas"][0]))
+
+        if predicted_params.get("log_beta_scales", None) is not None:
+            self._log_beta_scales.append(_to_numpy(predicted_params["log_beta_scales"][0]))
+        if predicted_params.get("betas_trans", None) is not None:
+            self._betas_trans.append(_to_numpy(predicted_params["betas_trans"][0]))
+
+        # Singleview cameras (one per frame); averaged on write.
+        if predicted_params.get("cam_rot", None) is not None:
+            self._cam_rot.append(_to_numpy(predicted_params["cam_rot"][0]))
+        if predicted_params.get("cam_trans", None) is not None:
+            self._cam_trans.append(_to_numpy(predicted_params["cam_trans"][0]))
+        if predicted_params.get("fov", None) is not None:
+            self._fov.append(_to_numpy(predicted_params["fov"][0]))
+
+    def set_cameras(self, cameras: List[Dict[str, Any]]) -> None:
+        """Explicitly set the cameras block of the sidecar (multi-view path).
+
+        Each entry: {"view_name": str, "R": 3x3 list, "t": 3 list, "fov": float}.
+        """
+        self._cameras_sidecar = list(cameras)
+
+    def num_frames(self) -> int:
+        return len(self._poses)
+
+    # ------------------------------------------------------------------- write
+
+    def _build_averaged_singleview_camera(self) -> List[Dict[str, Any]]:
+        if not self._cam_rot:
+            return []
+        R = np.stack(self._cam_rot).mean(axis=0)
+        t = np.stack(self._cam_trans).mean(axis=0) if self._cam_trans else np.zeros(3, np.float32)
+        fov = float(np.mean(self._fov)) if self._fov else 0.0
+        return [{
+            "view_name": "view_0",
+            "R": R.tolist(),
+            "t": t.flatten().tolist(),
+            "fov": fov,
+        }]
+
+    def write(self) -> Dict[str, Path]:
+        if not self._poses:
+            raise RuntimeError("AnimationRecorder has no frames to write.")
+
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        npz_path = self.output_path.with_suffix(".npz")
+        json_path = self.output_path.with_suffix(".json")
+
+        poses = np.stack(self._poses).astype(np.float32)
+        trans = np.stack(self._trans).astype(np.float32)
+        betas_per_frame = np.stack(self._betas).astype(np.float32)
+        betas_avg = betas_per_frame.mean(axis=0).astype(np.float32)
+
+        payload: Dict[str, Any] = {
+            "poses": poses,
+            "trans": trans,
+            "betas": betas_avg,
+            "betas_per_frame": betas_per_frame,
+            "fps": np.float32(self.fps),
+        }
+        if self._log_beta_scales:
+            payload["log_beta_scales"] = np.stack(self._log_beta_scales).astype(np.float32)
+        if self._betas_trans:
+            payload["betas_trans"] = np.stack(self._betas_trans).astype(np.float32)
+
+        np.savez(npz_path, **payload)
+
+        cameras = self._cameras_sidecar or self._build_averaged_singleview_camera()
+
+        sidecar = {
+            "schema_version": SCHEMA_VERSION,
+            "model_id": self.model_id,
+            "source_checkpoint": self.source_checkpoint,
+            "source_input": self.source_input,
+            "n_frames": int(poses.shape[0]),
+            "n_joints": self.n_joints,
+            "n_betas": self.n_betas,
+            "joint_names": self.joint_names,
+            "parents": self.parents,
+            "rotation_representation": "axis_angle",
+            "root_joint_index": 0,
+            "static_joint_locs": self.static_joint_locs,
+            "ignore_hardcoded_body": self.ignore_hardcoded_body,
+            "fps": self.fps,
+            "cameras": cameras,
+        }
+        with open(json_path, "w") as f:
+            json.dump(sidecar, f, indent=2)
+
+        return {"npz": npz_path, "json": json_path}
+
+
+def build_multiview_cameras(
+    all_predictions: List,
+    camera_order: List[str],
+) -> List[Dict[str, Any]]:
+    """Average `cam_{rot,trans,fov}_per_view` across frames into a static sidecar block.
+
+    Args:
+        all_predictions: list of (global_idx, predicted_params_cpu) — as produced by
+            run_multiview_inference.run_inference_phase.
+        camera_order: dataset.get_canonical_camera_order(), names per view index.
+    """
+    if not all_predictions:
+        return []
+
+    first = all_predictions[0][1]
+    if "cam_rot_per_view" not in first:
+        return []
+
+    n_views = len(first["cam_rot_per_view"])
+    R_sum = [np.zeros((3, 3), np.float64) for _ in range(n_views)]
+    t_sum = [np.zeros(3, np.float64) for _ in range(n_views)]
+    fov_sum = [0.0] * n_views
+    counts = [0] * n_views
+
+    for _, params in all_predictions:
+        if "cam_rot_per_view" not in params:
+            continue
+        for v in range(n_views):
+            R = _to_numpy(params["cam_rot_per_view"][v][0]).reshape(3, 3)
+            t = _to_numpy(params["cam_trans_per_view"][v][0]).reshape(-1)
+            fov = float(_to_numpy(params["fov_per_view"][v][0]).reshape(-1)[0])
+            R_sum[v] += R
+            t_sum[v] += t
+            fov_sum[v] += fov
+            counts[v] += 1
+
+    cameras: List[Dict[str, Any]] = []
+    for v in range(n_views):
+        if counts[v] == 0:
+            continue
+        name = camera_order[v] if v < len(camera_order) else f"view_{v}"
+        cameras.append({
+            "view_name": str(name),
+            "R": (R_sum[v] / counts[v]).tolist(),
+            "t": (t_sum[v] / counts[v]).tolist(),
+            "fov": fov_sum[v] / counts[v],
+        })
+    return cameras
+
+
+def build_recorder_from_config(
+    output_path: Union[str, Path],
+    rotation_representation: str,
+    fps: float,
+    source_checkpoint: Optional[str] = None,
+    source_input: Optional[str] = None,
+    model_id: Optional[str] = None,
+) -> AnimationRecorder:
+    """Convenience constructor that pulls joint metadata from the global `config`."""
+    import config as smil_config  # local import to keep this module importable in tests
+
+    dd = smil_config.dd
+    joint_names = list(dd.get("J_names", [f"J_{i}" for i in range(smil_config.N_POSE + 1)]))
+    parents = list(np.asarray(dd["kintree_table"][0]).astype(int).tolist())
+    n_joints = smil_config.N_POSE + 1  # root + per-joint pose entries
+
+    return AnimationRecorder(
+        output_path=output_path,
+        rotation_representation=rotation_representation,
+        n_joints=n_joints,
+        n_betas=smil_config.N_BETAS,
+        joint_names=joint_names,
+        parents=parents,
+        fps=fps,
+        static_joint_locs=bool(getattr(smil_config, "STATIC_JOINT_LOCATIONS", False)),
+        ignore_hardcoded_body=bool(getattr(smil_config, "ignore_hardcoded_body", False)),
+        source_checkpoint=source_checkpoint,
+        source_input=source_input,
+        model_id=model_id,
+    )

--- a/smal_fitter/neuralSMIL/animation_export.py
+++ b/smal_fitter/neuralSMIL/animation_export.py
@@ -16,7 +16,7 @@ import numpy as np
 import torch
 
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"
 
 
 def rotation_6d_to_axis_angle(d6: torch.Tensor) -> torch.Tensor:
@@ -82,6 +82,7 @@ class AnimationRecorder:
         self._betas: List[np.ndarray] = []
         self._log_beta_scales: List[np.ndarray] = []
         self._betas_trans: List[np.ndarray] = []
+        self._mesh_scale: List[np.ndarray] = []
 
         # Per-frame camera buffers (singleview). Multi-view cameras are stored
         # via set_cameras() because they're static per view for a given clip.
@@ -122,6 +123,8 @@ class AnimationRecorder:
             self._log_beta_scales.append(_to_numpy(predicted_params["log_beta_scales"][0]))
         if predicted_params.get("betas_trans", None) is not None:
             self._betas_trans.append(_to_numpy(predicted_params["betas_trans"][0]))
+        if predicted_params.get("mesh_scale", None) is not None:
+            self._mesh_scale.append(_to_numpy(predicted_params["mesh_scale"][0]).reshape(-1))
 
         # Singleview cameras (one per frame); averaged on write.
         if predicted_params.get("cam_rot", None) is not None:
@@ -180,6 +183,11 @@ class AnimationRecorder:
             payload["log_beta_scales"] = np.stack(self._log_beta_scales).astype(np.float32)
         if self._betas_trans:
             payload["betas_trans"] = np.stack(self._betas_trans).astype(np.float32)
+        if self._mesh_scale:
+            # Store as (F,) — global isotropic scale applied around the root joint:
+            # rendered_v = (v - J0) * mesh_scale + trans. Importers must subtract the
+            # rest-pose root joint position before scaling and re-apply the trans.
+            payload["mesh_scale"] = np.stack(self._mesh_scale).astype(np.float32).reshape(-1)
 
         np.savez(npz_path, **payload)
 

--- a/smal_fitter/neuralSMIL/multiview_visualization.py
+++ b/smal_fitter/neuralSMIL/multiview_visualization.py
@@ -1,0 +1,361 @@
+"""Shared multi-view visualization helpers.
+
+Both ``train_multiview_regressor.py`` and ``run_multiview_inference.py`` need to
+build the same input/render grid for a multi-view sample. The pipelines used to
+keep near-duplicate copies of these helpers, which drifted (e.g. the inference
+side painted a red background that clashed with the red predicted-keypoint
+markers). This module hosts the single canonical implementation; both callers
+import from here.
+"""
+
+from typing import Optional
+
+import numpy as np
+import torch
+
+from smil_image_regressor import rotation_6d_to_axis_angle
+
+
+def run_forward_multiview_single_sample(model,
+                                        x_data: dict,
+                                        y_data: dict,
+                                        device: str) -> Optional[dict]:
+    """Run a single-sample multi-view forward pass and return ``predicted_params``."""
+    images = x_data.get('images', [])
+    num_views = len(images)
+    if num_views == 0:
+        return None
+
+    cam_indices = x_data.get('camera_indices', list(range(num_views)))
+    if isinstance(cam_indices, np.ndarray):
+        cam_indices = cam_indices.tolist()
+    if len(cam_indices) != num_views:
+        if len(cam_indices) > num_views:
+            cam_indices = cam_indices[:num_views]
+        else:
+            cam_indices = list(cam_indices) + list(range(len(cam_indices), num_views))
+
+    images_per_view = []
+    for img in images:
+        img_tensor = model.preprocess_image(img).to(device)
+        images_per_view.append(img_tensor.squeeze(0))
+
+    images_tensors = [img.unsqueeze(0) for img in images_per_view]
+    camera_indices_tensor = torch.tensor([cam_indices], device=device)
+    view_mask = torch.ones(1, num_views, dtype=torch.bool, device=device)
+
+    with torch.no_grad():
+        return model.forward_multiview(
+            images_tensors, camera_indices_tensor, view_mask, target_data=[y_data]
+        )
+
+
+def create_rendered_view_with_keypoints(model,
+                                        predicted_params: dict,
+                                        view_idx: int,
+                                        target_keypoints: Optional[np.ndarray],
+                                        target_visibility: Optional[np.ndarray],
+                                        device: str,
+                                        img_size: int,
+                                        aspect_ratio: Optional[float] = None,
+                                        disable_scaling: bool = False,
+                                        disable_translation: bool = False) -> np.ndarray:
+    """Render a single view's predicted 2D keypoints over a blue tint background.
+
+    GT keypoints are drawn as green circles, predicted keypoints as red crosses.
+    The background uses a per-view blue gradient — red is intentionally kept low
+    so the predicted-keypoint markers remain legible.
+    """
+    vis_params = predicted_params
+    if disable_scaling or disable_translation:
+        vis_params = predicted_params.copy()
+        if disable_scaling and 'log_beta_scales' in vis_params:
+            vis_params['log_beta_scales'] = torch.zeros_like(vis_params['log_beta_scales'])
+        if disable_translation and 'betas_trans' in vis_params:
+            vis_params['betas_trans'] = torch.zeros_like(vis_params['betas_trans'])
+
+    fov = vis_params['fov_per_view'][view_idx]
+    cam_rot = vis_params['cam_rot_per_view'][view_idx]
+    cam_trans = vis_params['cam_trans_per_view'][view_idx]
+
+    pred_kps = None
+    try:
+        with torch.no_grad():
+            aspect_tensor = None
+            if aspect_ratio is not None:
+                aspect_tensor = torch.tensor([aspect_ratio], dtype=torch.float32, device=device)
+
+            rendered_joints = model._render_keypoints_with_camera(
+                vis_params, fov, cam_rot, cam_trans, aspect_ratio=aspect_tensor
+            )
+        pred_kps = rendered_joints[0].detach().cpu().numpy() * img_size
+    except Exception as e:
+        print(f"Keypoint rendering failed: {e}")
+
+    img = np.ones((img_size, img_size, 3), dtype=np.uint8) * 50
+    img[:, :, 2] = min(255, 70 + view_idx * 25)
+    img[:, :, 1] = min(255, 55 + view_idx * 8)
+    img[:, :, 0] = 45
+
+    gt_kps = None
+    gt_vis = None
+    if target_keypoints is not None:
+        if len(target_keypoints.shape) == 3:
+            if view_idx < target_keypoints.shape[0]:
+                gt_kps = target_keypoints[view_idx] * img_size
+                if target_visibility is not None and view_idx < target_visibility.shape[0]:
+                    gt_vis = target_visibility[view_idx]
+        elif len(target_keypoints.shape) == 2 and view_idx == 0:
+            gt_kps = target_keypoints * img_size
+            gt_vis = target_visibility
+
+    from PIL import Image, ImageDraw, ImageFont
+    pil_img = Image.fromarray(img)
+    draw = ImageDraw.Draw(pil_img)
+
+    if gt_kps is not None:
+        for j, (y, x) in enumerate(gt_kps):
+            if gt_vis is None or gt_vis[j] > 0.5:
+                x, y = float(x), float(y)
+                if 0 <= x < img_size and 0 <= y < img_size:
+                    draw.ellipse([x - 3, y - 3, x + 3, y + 3], outline='green', width=2)
+
+    if pred_kps is not None:
+        for j, (y, x) in enumerate(pred_kps):
+            x, y = float(x), float(y)
+            if 0 <= x < img_size and 0 <= y < img_size:
+                draw.line([x - 4, y, x + 4, y], fill='red', width=2)
+                draw.line([x, y - 4, x, y + 4], fill='red', width=2)
+
+    try:
+        try:
+            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 10)
+        except Exception:
+            font = ImageFont.load_default()
+        draw.text((5, img_size - 25), "O GT", fill='green', font=font)
+        draw.text((5, img_size - 12), "+ Pred", fill='red', font=font)
+    except Exception:
+        pass
+
+    return np.array(pil_img)
+
+
+_MULTIVIEW_WRAP_THRESHOLD = 12
+_MULTIVIEW_WRAP_COLS = 6
+
+
+def compute_multiview_grid_layout(total_view_slots: int,
+                                  img_size: int,
+                                  margin: int = 5) -> dict:
+    """Pre-compute the multi-view grid layout once for a given slot count.
+
+    Views > ``_MULTIVIEW_WRAP_THRESHOLD`` wrap to ``_MULTIVIEW_WRAP_COLS`` columns
+    and stack into multiple input/render row-pairs so wide grids stay readable
+    in standard media players. Inference call sites should invoke this once at
+    startup with ``total_view_slots = model.max_views`` and reuse the returned
+    dimensions for every frame — that keeps the video stream uniform even when
+    individual samples have fewer views than the model supports.
+    """
+    if total_view_slots <= 0:
+        raise ValueError(f"total_view_slots must be > 0, got {total_view_slots}")
+
+    cols = _MULTIVIEW_WRAP_COLS if total_view_slots > _MULTIVIEW_WRAP_THRESHOLD else total_view_slots
+    num_blocks = (total_view_slots + cols - 1) // cols  # ceil
+    grid_width = cols * img_size + (cols + 1) * margin
+    grid_height = num_blocks * (2 * img_size + 2 * margin) + margin
+    return {
+        'cols': cols,
+        'num_blocks': num_blocks,
+        'grid_width': grid_width,
+        'grid_height': grid_height,
+        'img_size': img_size,
+        'margin': margin,
+        'total_view_slots': total_view_slots,
+    }
+
+
+def _multiview_cell_offsets(view_idx: int, layout: dict) -> tuple:
+    """Pixel offsets (x, input_y, render_y) for ``view_idx`` in the given layout."""
+    cols = layout['cols']
+    img_size = layout['img_size']
+    margin = layout['margin']
+    block = view_idx // cols
+    col = view_idx % cols
+    x = margin + col * (img_size + margin)
+    input_y = margin + block * (2 * img_size + 2 * margin)
+    render_y = input_y + img_size + margin
+    return x, input_y, render_y
+
+
+def create_multiview_visualization(model,
+                                   x_data: dict,
+                                   y_data: dict,
+                                   device: str,
+                                   predicted_params: Optional[dict] = None,
+                                   disable_scaling: bool = False,
+                                   disable_translation: bool = False,
+                                   total_view_slots: Optional[int] = None) -> Optional[np.ndarray]:
+    """Build the input/predicted grid for a multi-view sample.
+
+    Single-row layout (≤ 12 slots)::
+
+        +-----------+-----------+-----------+-----+
+        |  Input V0 |  Input V1 |  Input V2 | ... |
+        +-----------+-----------+-----------+-----+
+        | Render V0 | Render V1 | Render V2 | ... |
+        +-----------+-----------+-----------+-----+
+
+    Wrapped layout (> 12 slots, 6 cols per row-pair). Slots beyond ``num_views``
+    are rendered as empty (dark) cells so video output stays size-consistent.
+
+    ``total_view_slots`` controls the grid; when None it defaults to the
+    sample's actual ``num_views``. Inference passes ``model.max_views`` here so
+    every frame has identical dimensions.
+
+    If ``predicted_params`` is not provided, a forward pass is run internally.
+    """
+    images = x_data.get('images', [])
+    num_views = len(images)
+    if num_views == 0:
+        return None
+
+    if predicted_params is None:
+        predicted_params = run_forward_multiview_single_sample(model, x_data, y_data, device)
+        if predicted_params is None:
+            return None
+
+    img_size = int(model.renderer.image_size)
+    margin = 5
+    if total_view_slots is None:
+        total_view_slots = num_views
+    layout = compute_multiview_grid_layout(total_view_slots, img_size, margin)
+    grid_width = layout['grid_width']
+    grid_height = layout['grid_height']
+
+    canvas = np.ones((grid_height, grid_width, 3), dtype=np.uint8) * 40
+    target_keypoints = y_data.get('keypoints_2d', None)
+    target_visibility = y_data.get('keypoint_visibility', None)
+
+    for v in range(num_views):
+        x_offset, input_y, render_y = _multiview_cell_offsets(v, layout)
+
+        input_img = images[v]
+        if isinstance(input_img, np.ndarray):
+            if input_img.shape[0] != img_size or input_img.shape[1] != img_size:
+                from PIL import Image
+                pil_img = Image.fromarray(
+                    (input_img * 255).astype(np.uint8) if input_img.max() <= 1 else input_img.astype(np.uint8)
+                )
+                pil_img = pil_img.resize((img_size, img_size), Image.BILINEAR)
+                input_img = np.array(pil_img)
+            if input_img.max() <= 1.0:
+                input_img = (input_img * 255).astype(np.uint8)
+            else:
+                input_img = input_img.astype(np.uint8)
+            if len(input_img.shape) == 2:
+                input_img = np.stack([input_img] * 3, axis=-1)
+            elif input_img.shape[-1] == 4:
+                input_img = input_img[:, :, :3]
+            canvas[input_y:input_y + img_size, x_offset:x_offset + img_size] = input_img
+
+        try:
+            aspect_ratio = None
+            try:
+                if y_data.get('cam_aspect_per_view') is not None:
+                    aspect_ratio = float(np.array(y_data['cam_aspect_per_view'][v]).reshape(-1)[0])
+            except Exception:
+                aspect_ratio = None
+
+            rendered_img = create_rendered_view_with_keypoints(
+                model, predicted_params, v,
+                target_keypoints, target_visibility,
+                device, img_size, aspect_ratio=aspect_ratio,
+                disable_scaling=disable_scaling,
+                disable_translation=disable_translation,
+            )
+            canvas[render_y:render_y + img_size, x_offset:x_offset + img_size] = rendered_img
+        except Exception as e:
+            print(f"Warning: Could not render view {v}: {e}")
+            placeholder = np.ones((img_size, img_size, 3), dtype=np.uint8) * 128
+            canvas[render_y:render_y + img_size, x_offset:x_offset + img_size] = placeholder
+
+    try:
+        from PIL import Image, ImageDraw, ImageFont
+        pil_canvas = Image.fromarray(canvas)
+        draw = ImageDraw.Draw(pil_canvas)
+        try:
+            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 12)
+        except Exception:
+            font = ImageFont.load_default()
+        cam_names = x_data.get('camera_names', [])
+        # "Input"/"Pred" row labels on every block. Camera-name labels go on
+        # block 0 only — the wrapped layout reuses the same column ordering for
+        # every block, and inter-block gaps are too tight to fit a label row.
+        for block in range(layout['num_blocks']):
+            _, input_y, render_y = _multiview_cell_offsets(block * layout['cols'], layout)
+            draw.text((5, input_y + img_size // 2 - 6), "Input", fill=(255, 255, 255), font=font)
+            draw.text((5, render_y + img_size // 2 - 6), "Pred", fill=(255, 255, 255), font=font)
+        for col in range(layout['cols']):
+            v = col
+            if v >= total_view_slots:
+                break
+            x_pos = margin + col * (img_size + margin) + img_size // 2 - 10
+            cam_name = cam_names[v] if v < len(cam_names) else f'V{v}'
+            draw.text((x_pos, 2), str(cam_name)[:8], fill=(255, 255, 255), font=font)
+        canvas = np.array(pil_canvas)
+    except Exception:
+        pass
+
+    return canvas
+
+
+def print_joint_scale_diagnostics(model, predicted_params: dict, label: str = "") -> None:
+    """Print per-joint log-beta scales for a predicted sample (training-only debug)."""
+    if 'log_beta_scales' not in predicted_params:
+        return
+    try:
+        import config
+        from training_config import TrainingConfig
+
+        scale_trans_config = TrainingConfig.get_scale_trans_config()
+        use_pca_transformation = scale_trans_config.get('separate', {}).get('use_pca_transformation', True)
+
+        if model.scale_trans_mode == 'separate' and use_pca_transformation:
+            scale_weights = predicted_params['log_beta_scales'][0]
+            trans_weights = predicted_params.get('betas_trans', None)
+            if trans_weights is not None:
+                trans_weights = trans_weights[0:1]
+            log_beta_scales_joint, _ = model._transform_separate_pca_weights_to_joint_values(
+                scale_weights.unsqueeze(0), trans_weights
+            )
+            log_beta_scales_joint = log_beta_scales_joint[0]
+        else:
+            log_beta_scales_joint = predicted_params['log_beta_scales'][0]
+
+        scales_joint = torch.exp(log_beta_scales_joint)
+        joint_names = config.dd["J_names"]
+
+        header = f"Joint Scales{(' for ' + label) if label else ''}"
+        print(f"\n=== {header} ===")
+        print(f"Mode: {model.scale_trans_mode}")
+        print(f"{'Joint Name':<20} {'Scale X':>10} {'Scale Y':>10} {'Scale Z':>10} {'Mean Scale':>12}")
+        print("-" * 70)
+        for joint_idx, joint_name in enumerate(joint_names):
+            if joint_idx < scales_joint.shape[0]:
+                scale_xyz = scales_joint[joint_idx].cpu().numpy()
+                print(f"{joint_name:<20} {scale_xyz[0]:>10.4f} {scale_xyz[1]:>10.4f} "
+                      f"{scale_xyz[2]:>10.4f} {scale_xyz.mean():>12.4f}")
+
+        all_scales = scales_joint.cpu().numpy()
+        print(f"\nSummary Statistics:")
+        print(f"  Mean scale (all joints, all axes): {all_scales.mean():.4f}")
+        print(f"  Std scale (all joints, all axes): {all_scales.std():.4f}")
+        print(f"  Min scale: {all_scales.min():.4f}")
+        print(f"  Max scale: {all_scales.max():.4f}")
+        print(f"  Joints with scale > 1.1: {((all_scales > 1.1).any(axis=1).sum().item())}")
+        print(f"  Joints with scale < 0.9: {((all_scales < 0.9).any(axis=1).sum().item())}")
+        print("=" * 70 + "\n")
+    except Exception as e:
+        print(f"Warning: Failed to print joint scales: {e}")
+        import traceback
+        traceback.print_exc()

--- a/smal_fitter/neuralSMIL/run_multiview_inference.py
+++ b/smal_fitter/neuralSMIL/run_multiview_inference.py
@@ -860,22 +860,67 @@ def _compute_rank_indices(
     rank: int,
     world_size: int,
     sampler: Optional[DistributedSampler],
-    max_frames: Optional[int] = None,
+    start_idx: int = 0,
+    end_idx: Optional[int] = None,
 ) -> List[int]:
-    """Return the global dataset indices assigned to *rank*."""
+    """Return the global dataset indices in ``[start_idx, end_idx)`` assigned to *rank*.
+
+    With ``world_size > 1`` the range is striped across ranks (rank 0 takes
+    ``start_idx``, ``start_idx + world_size``, ...), matching the original
+    distributed behavior over the full dataset.
+    """
+    if end_idx is None:
+        end_idx = len(dataset)
+    end_idx = min(end_idx, len(dataset))
+    start_idx = max(0, start_idx)
+
     if sampler is not None:
         sampler.set_epoch(0)
-        indices = list(range(rank, len(dataset), world_size))
+        indices = list(range(start_idx + rank, end_idx, world_size))
     else:
-        indices = list(range(len(dataset)))
-
-    if max_frames is not None:
-        frames_per_rank = max(1, max_frames // world_size)
-        indices = indices[:frames_per_rank]
-        if rank == 0:
-            print(f"Limiting to {max_frames} total frames ({frames_per_rank} per rank)")
+        indices = list(range(start_idx, end_idx))
 
     return indices
+
+
+def _compute_subclip_ranges(
+    dataset_size: int,
+    max_frames: Optional[int],
+    num_subclips: int,
+    rank: int = 0,
+) -> List[Tuple[int, int]]:
+    """Return ``(start, end)`` index ranges (end exclusive) for each subclip.
+
+    With ``num_subclips > 1`` the dataset is divided into evenly-spaced slots
+    of size ``dataset_size // num_subclips``; each subclip starts at slot ``i``
+    and runs for ``max_frames`` frames. Falls back to a single full-dataset
+    clip when subclips can't fit (``--max_frames`` not set or per-slot space
+    smaller than ``max_frames``).
+    """
+    if num_subclips <= 1:
+        end = min(max_frames, dataset_size) if max_frames is not None else dataset_size
+        return [(0, end)]
+
+    if max_frames is None:
+        if rank == 0:
+            print(f"WARNING: --generate_num_subclips={num_subclips} requires --max_frames; "
+                  f"falling back to a single full-dataset clip.")
+        return [(0, dataset_size)]
+
+    slot_size = dataset_size // num_subclips
+    if slot_size < max_frames:
+        if rank == 0:
+            print(f"WARNING: dataset has {dataset_size} frames; {num_subclips} subclips of "
+                  f"{max_frames} frames each don't fit (only {slot_size} frames per slot). "
+                  f"Falling back to a single full-dataset clip.")
+        return [(0, dataset_size)]
+
+    ranges: List[Tuple[int, int]] = []
+    for i in range(num_subclips):
+        start = i * dataset_size // num_subclips
+        end = min(start + max_frames, dataset_size)
+        ranges.append((start, end))
+    return ranges
 
 
 def _export_animation(
@@ -896,7 +941,9 @@ def _export_animation(
     """
     if world_size > 1:
         # Reuse the existing temp-dir gather machinery dedicated to this export.
-        export_temp_base = Path.cwd() / f".animation_export_temp_{dataset_path.stem}"
+        # Derive the temp dir name from the export path so it stays unique when
+        # multiple subclips are exported in the same run.
+        export_temp_base = Path.cwd() / f".animation_export_temp_{Path(export_path).name}"
         if rank == 0:
             if export_temp_base.exists():
                 shutil.rmtree(export_temp_base)
@@ -1282,6 +1329,8 @@ def main_inference(
         print(f"Checkpoint: {args.checkpoint if args.checkpoint else '(auto-detect)'}")
         if args.max_frames is not None:
             print(f"Max frames: {args.max_frames} (testing mode)")
+        if args.generate_num_subclips > 1:
+            print(f"Subclips: {args.generate_num_subclips} (per-clip length: {args.max_frames})")
         if args.disable_scaling:
             print(f"Part scaling: DISABLED (comparison mode)")
         if args.disable_translation:
@@ -1359,180 +1408,201 @@ def main_inference(
         except Exception:
             pass  # Use default
 
-    # Compute which dataset indices this rank is responsible for
-    assigned_indices = _compute_rank_indices(
-        dataset, rank, world_size, sampler, max_frames=args.max_frames
-    )
-
-    # ── Phase 1: Inference (all ranks in parallel) ──────────────────────
-    if rank == 0:
-        print("\n── Phase 1: Running inference ──")
-    raw_predictions = run_inference_phase(dataset, model, device, assigned_indices, rank)
-
-    # Free GPU memory after inference — rendering will reload params to device as needed
-    torch.cuda.empty_cache()
-
-    # ── Phase 1b: Optional animation export (raw, pre-smoothing) ────────
-    export_animation_path = getattr(args, "export_animation", None)
-    if export_animation_path:
-        _export_animation(
-            raw_predictions=raw_predictions,
-            rank=rank,
-            world_size=world_size,
-            dataset=dataset,
-            model=model,
-            checkpoint_path=checkpoint_path,
-            dataset_path=dataset_path,
-            export_path=export_animation_path,
-            fps=float(args.fps),
-        )
-
-    # ── Phase 2: Gather + smooth predictions ────────────────────────────
-    smoothing_window = args.smoothing_window
-    dataset_name = dataset_path.stem
-    temp_base = Path.cwd() / f".inference_temp_{dataset_name}"
-
-    if world_size > 1 and smoothing_window > 0:
-        # Multi-GPU with smoothing: gather all predictions so every rank
-        # can build the full temporally-ordered sequence for correct smoothing.
-        if rank == 0:
-            print(f"\n── Phase 2: Gathering predictions across {world_size} ranks for smoothing (window={smoothing_window}) ──")
-            if temp_base.exists():
-                shutil.rmtree(temp_base)
-            temp_base.mkdir(parents=True, exist_ok=True)
-        dist.barrier()
-
-        write_predictions_to_temp(raw_predictions, temp_base, rank)
-        dist.barrier()
-
-        all_predictions = load_all_predictions_from_temp(temp_base, world_size)
-
-        # Apply smoothing over the full sorted sequence
-        smoother = PredictionSmoother(smoothing_window)
-        smoothed_params: Dict[int, dict] = {}
-        iterator = tqdm(all_predictions, desc="Applying temporal smoothing", disable=(rank != 0))
-        for global_idx, params in iterator:
-            smoothed_params[global_idx] = smoother(params)
-
-        # Clean up prediction temp files (keep temp_base for frame storage later)
-        for rank_idx in range(world_size):
-            pred_path = temp_base / f"rank_{rank_idx}" / "predictions.pkl"
-            if pred_path.exists():
-                pred_path.unlink()
-
-        del raw_predictions, all_predictions
-
-    elif smoothing_window > 0:
-        # Single GPU with smoothing
-        if rank == 0:
-            print(f"\n── Phase 2: Applying temporal smoothing (window={smoothing_window}) ──")
-        raw_predictions.sort(key=lambda x: x[0])
-        smoother = PredictionSmoother(smoothing_window)
-        smoothed_params = {}
-        for global_idx, params in tqdm(raw_predictions, desc="Applying temporal smoothing", disable=(rank != 0)):
-            smoothed_params[global_idx] = smoother(params)
-        del raw_predictions
-
-    else:
-        # No smoothing: use raw predictions directly
-        if rank == 0:
-            print("\n── Phase 2: No smoothing (window=0) ──")
-        smoothed_params = {idx: params for idx, params in raw_predictions}
-        del raw_predictions
-
-    # ── Phase 3: Render visualizations (all ranks in parallel) ──────────
-    if rank == 0:
-        print("\n── Phase 3: Rendering visualizations ──")
-    multiview_frames, singleview_frames_per_view, mv_frame_indices, sv_frame_indices_per_view = run_render_phase(
-        dataset=dataset,
-        model=model,
-        device=device,
-        smoothed_params=smoothed_params,
-        indices=assigned_indices,
+    # Determine subclip ranges (single full-dataset clip by default).
+    subclip_ranges = _compute_subclip_ranges(
+        dataset_size=len(dataset),
+        max_frames=args.max_frames,
+        num_subclips=args.generate_num_subclips,
         rank=rank,
-        grid_width=grid_width,
-        grid_height=grid_height,
-        singleview_size=singleview_size,
-        disable_scaling=args.disable_scaling,
-        disable_translation=args.disable_translation,
-        view_indices=view_indices,
     )
-    del smoothed_params
+    multi_subclip = len(subclip_ranges) > 1
 
-    # ── Phase 4: Write output videos ────────────────────────────────────
-    if rank == 0:
-        print("\n── Phase 4: Writing output videos ──")
-    multiview_out = Path(f"{dataset_name}_multiview_inference.mp4")
-    singleview_out_base = Path(f"{dataset_name}_singleview_inference.mp4")
+    dataset_name = dataset_path.stem
+    smoothing_window = args.smoothing_window
+    export_animation_path = getattr(args, "export_animation", None)
 
-    if world_size > 1:
-        if rank == 0:
-            if not temp_base.exists():
-                temp_base.mkdir(parents=True, exist_ok=True)
-        dist.barrier()
+    for clip_idx, (start_idx, end_idx) in enumerate(subclip_ranges):
+        if multi_subclip and rank == 0:
+            print(f"\n{'#'*60}")
+            print(f"# SUBCLIP {clip_idx + 1}/{len(subclip_ranges)}: "
+                  f"frames [{start_idx}, {end_idx}) ({end_idx - start_idx} frames)")
+            print(f"{'#'*60}")
 
-        write_frames_to_temp_storage(
-            multiview_frames=multiview_frames,
-            singleview_frames_per_view=singleview_frames_per_view,
-            mv_frame_indices=mv_frame_indices,
-            sv_frame_indices_per_view=sv_frame_indices_per_view,
-            temp_dir=temp_base,
-            rank=rank,
+        range_suffix = f"_frames{start_idx:06d}-{end_idx:06d}" if multi_subclip else ""
+
+        # Compute which dataset indices this rank is responsible for in this subclip
+        assigned_indices = _compute_rank_indices(
+            dataset, rank, world_size, sampler,
+            start_idx=start_idx, end_idx=end_idx,
         )
-        del multiview_frames, singleview_frames_per_view, mv_frame_indices, sv_frame_indices_per_view
+
+        # ── Phase 1: Inference (all ranks in parallel) ──────────────────────
+        if rank == 0:
+            print("\n── Phase 1: Running inference ──")
+        raw_predictions = run_inference_phase(dataset, model, device, assigned_indices, rank)
+
+        # Free GPU memory after inference — rendering will reload params to device as needed
         torch.cuda.empty_cache()
 
-        dist.barrier()
-
-        if rank == 0:
-            merge_frames_and_write_videos(
-                temp_dir=temp_base,
+        # ── Phase 1b: Optional animation export (raw, pre-smoothing) ────────
+        if export_animation_path:
+            clip_export_path = f"{export_animation_path}{range_suffix}"
+            _export_animation(
+                raw_predictions=raw_predictions,
+                rank=rank,
                 world_size=world_size,
-                multiview_out=multiview_out,
-                singleview_out_base=singleview_out_base,
-                fps=args.fps,
-                grid_width=grid_width,
-                grid_height=grid_height,
-                singleview_size=singleview_size,
-                view_indices=view_indices,
+                dataset=dataset,
+                model=model,
+                checkpoint_path=checkpoint_path,
+                dataset_path=dataset_path,
+                export_path=clip_export_path,
+                fps=float(args.fps),
             )
-            print(f"Cleaning up temporary directory: {temp_base}")
-            shutil.rmtree(temp_base)
 
-        dist.barrier()
-    else:
-        # Single GPU: write directly
-        if len(multiview_frames) > 0:
-            multiview_writer = cv2.VideoWriter(
-                str(multiview_out),
-                cv2.VideoWriter_fourcc(*"mp4v"),
-                args.fps,
-                (grid_width, grid_height),
+        # ── Phase 2: Gather + smooth predictions ────────────────────────────
+        temp_base = Path.cwd() / f".inference_temp_{dataset_name}{range_suffix}"
+
+        if world_size > 1 and smoothing_window > 0:
+            # Multi-GPU with smoothing: gather all predictions so every rank
+            # can build the full temporally-ordered sequence for correct smoothing.
+            if rank == 0:
+                print(f"\n── Phase 2: Gathering predictions across {world_size} ranks for smoothing (window={smoothing_window}) ──")
+                if temp_base.exists():
+                    shutil.rmtree(temp_base)
+                temp_base.mkdir(parents=True, exist_ok=True)
+            dist.barrier()
+
+            write_predictions_to_temp(raw_predictions, temp_base, rank)
+            dist.barrier()
+
+            all_predictions = load_all_predictions_from_temp(temp_base, world_size)
+
+            # Apply smoothing over the full sorted sequence
+            smoother = PredictionSmoother(smoothing_window)
+            smoothed_params: Dict[int, dict] = {}
+            iterator = tqdm(all_predictions, desc="Applying temporal smoothing", disable=(rank != 0))
+            for global_idx, params in iterator:
+                smoothed_params[global_idx] = smoother(params)
+
+            # Clean up prediction temp files (keep temp_base for frame storage later)
+            for rank_idx in range(world_size):
+                pred_path = temp_base / f"rank_{rank_idx}" / "predictions.pkl"
+                if pred_path.exists():
+                    pred_path.unlink()
+
+            del raw_predictions, all_predictions
+
+        elif smoothing_window > 0:
+            # Single GPU with smoothing
+            if rank == 0:
+                print(f"\n── Phase 2: Applying temporal smoothing (window={smoothing_window}) ──")
+            raw_predictions.sort(key=lambda x: x[0])
+            smoother = PredictionSmoother(smoothing_window)
+            smoothed_params = {}
+            for global_idx, params in tqdm(raw_predictions, desc="Applying temporal smoothing", disable=(rank != 0)):
+                smoothed_params[global_idx] = smoother(params)
+            del raw_predictions
+
+        else:
+            # No smoothing: use raw predictions directly
+            if rank == 0:
+                print("\n── Phase 2: No smoothing (window=0) ──")
+            smoothed_params = {idx: params for idx, params in raw_predictions}
+            del raw_predictions
+
+        # ── Phase 3: Render visualizations (all ranks in parallel) ──────────
+        if rank == 0:
+            print("\n── Phase 3: Rendering visualizations ──")
+        multiview_frames, singleview_frames_per_view, mv_frame_indices, sv_frame_indices_per_view = run_render_phase(
+            dataset=dataset,
+            model=model,
+            device=device,
+            smoothed_params=smoothed_params,
+            indices=assigned_indices,
+            rank=rank,
+            grid_width=grid_width,
+            grid_height=grid_height,
+            singleview_size=singleview_size,
+            disable_scaling=args.disable_scaling,
+            disable_translation=args.disable_translation,
+            view_indices=view_indices,
+        )
+        del smoothed_params
+
+        # ── Phase 4: Write output videos ────────────────────────────────────
+        if rank == 0:
+            print("\n── Phase 4: Writing output videos ──")
+        multiview_out = Path(f"{dataset_name}{range_suffix}_multiview_inference.mp4")
+        singleview_out_base = Path(f"{dataset_name}{range_suffix}_singleview_inference.mp4")
+
+        if world_size > 1:
+            if rank == 0:
+                if not temp_base.exists():
+                    temp_base.mkdir(parents=True, exist_ok=True)
+            dist.barrier()
+
+            write_frames_to_temp_storage(
+                multiview_frames=multiview_frames,
+                singleview_frames_per_view=singleview_frames_per_view,
+                mv_frame_indices=mv_frame_indices,
+                sv_frame_indices_per_view=sv_frame_indices_per_view,
+                temp_dir=temp_base,
+                rank=rank,
             )
-            for frame in multiview_frames:
-                multiview_writer.write(frame)
-            multiview_writer.release()
-            print(f"Wrote {multiview_out}")
+            del multiview_frames, singleview_frames_per_view, mv_frame_indices, sv_frame_indices_per_view
+            torch.cuda.empty_cache()
 
-        for view_idx in view_indices:
-            frames = singleview_frames_per_view.get(view_idx, [])
-            if len(frames) > 0:
-                if len(view_indices) == 1:
-                    singleview_out = singleview_out_base
-                else:
-                    stem = singleview_out_base.stem
-                    singleview_out = singleview_out_base.parent / f"{stem}_view{view_idx}.mp4"
+            dist.barrier()
 
-                singleview_writer = cv2.VideoWriter(
-                    str(singleview_out),
+            if rank == 0:
+                merge_frames_and_write_videos(
+                    temp_dir=temp_base,
+                    world_size=world_size,
+                    multiview_out=multiview_out,
+                    singleview_out_base=singleview_out_base,
+                    fps=args.fps,
+                    grid_width=grid_width,
+                    grid_height=grid_height,
+                    singleview_size=singleview_size,
+                    view_indices=view_indices,
+                )
+                print(f"Cleaning up temporary directory: {temp_base}")
+                shutil.rmtree(temp_base)
+
+            dist.barrier()
+        else:
+            # Single GPU: write directly
+            if len(multiview_frames) > 0:
+                multiview_writer = cv2.VideoWriter(
+                    str(multiview_out),
                     cv2.VideoWriter_fourcc(*"mp4v"),
                     args.fps,
-                    singleview_size,
+                    (grid_width, grid_height),
                 )
-                for frame in frames:
-                    singleview_writer.write(frame)
-                singleview_writer.release()
-                print(f"Wrote {singleview_out} ({len(frames)} frames)")
+                for frame in multiview_frames:
+                    multiview_writer.write(frame)
+                multiview_writer.release()
+                print(f"Wrote {multiview_out}")
+
+            for view_idx in view_indices:
+                frames = singleview_frames_per_view.get(view_idx, [])
+                if len(frames) > 0:
+                    if len(view_indices) == 1:
+                        singleview_out = singleview_out_base
+                    else:
+                        stem = singleview_out_base.stem
+                        singleview_out = singleview_out_base.parent / f"{stem}_view{view_idx}.mp4"
+
+                    singleview_writer = cv2.VideoWriter(
+                        str(singleview_out),
+                        cv2.VideoWriter_fourcc(*"mp4v"),
+                        args.fps,
+                        singleview_size,
+                    )
+                    for frame in frames:
+                        singleview_writer.write(frame)
+                    singleview_writer.release()
+                    print(f"Wrote {singleview_out} ({len(frames)} frames)")
 
 
 def ddp_main_inference(rank: int, world_size: int, args, master_port: str):
@@ -1570,9 +1640,15 @@ def main():
     )
     parser.add_argument("--dataset", required=True, type=str, help="Path to preprocessed SLEAP HDF5 dataset")
     parser.add_argument("--fps", type=int, default=60, help="Output video FPS (default: 60)")
-    parser.add_argument("--max_frames", type=int, default=None, help="Maximum number of frames to process (default: all frames). Useful for quick testing.")
+    parser.add_argument("--max_frames", type=int, default=None, help="Maximum number of frames to process (default: all frames). Useful for quick testing. With --generate_num_subclips > 1, this is the length of each subclip.")
+    parser.add_argument("--generate_num_subclips", type=int, default=1,
+                        help="Generate N subclips evenly spaced across the dataset, each --max_frames "
+                             "long. Subclip i starts at index i * len(dataset) / N. Each output "
+                             "video and exported animation file is suffixed with the frame range. "
+                             "Falls back to a single full-dataset clip if subclips don't fit. "
+                             "Default: 1 (single clip).")
     parser.add_argument("--disable_scaling", action="store_true", help="Disable part scaling (log_beta_scales) for comparison/debugging")
-    parser.add_argument("--disable_translation", action="store_true", default=True, help="Disable part translation (betas_trans) for comparison/debugging")
+    parser.add_argument("--disable_translation", action=argparse.BooleanOptionalAction, default=True, help="Disable part translation (betas_trans) for comparison/debugging. Pass --no-disable_translation to keep translation enabled.")
     parser.add_argument("--view_indices", type=str, default="0", help="Comma-separated list of camera view indices to render for singleview output (default: '0'). E.g., '0,4,11' renders views 0, 4, and 11.")
     parser.add_argument("--smoothing_window", type=int, default=0, help="Number of frames to average predictions over for temporal smoothing (default: 0, disabled)")
     parser.add_argument("--num_gpus", type=int, default=1, help="Number of GPUs to use (default: 1, ignored when using torchrun)")

--- a/smal_fitter/neuralSMIL/run_multiview_inference.py
+++ b/smal_fitter/neuralSMIL/run_multiview_inference.py
@@ -56,6 +56,7 @@ from smal_fitter import SMALFitter
 from sleap_data.sleap_multiview_dataset import SLEAPMultiViewDataset
 from configs import apply_smal_file_override
 import config
+from animation_export import build_recorder_from_config, build_multiview_cameras
 
 
 DEFAULT_CHECKPOINTS = [
@@ -877,6 +878,69 @@ def _compute_rank_indices(
     return indices
 
 
+def _export_animation(
+    raw_predictions: List[Tuple[int, dict]],
+    rank: int,
+    world_size: int,
+    dataset: SLEAPMultiViewDataset,
+    model: MultiViewSMILImageRegressor,
+    checkpoint_path: Path,
+    dataset_path: Path,
+    export_path: str,
+    fps: float,
+) -> None:
+    """Gather predictions to rank 0 and write an AMASS-style .npz + .json clip.
+
+    The export captures the *raw*, pre-smoothing network predictions so downstream
+    consumers (Blender addon, etc.) can apply their own smoothing if desired.
+    """
+    if world_size > 1:
+        # Reuse the existing temp-dir gather machinery dedicated to this export.
+        export_temp_base = Path.cwd() / f".animation_export_temp_{dataset_path.stem}"
+        if rank == 0:
+            if export_temp_base.exists():
+                shutil.rmtree(export_temp_base)
+            export_temp_base.mkdir(parents=True, exist_ok=True)
+        dist.barrier()
+
+        write_predictions_to_temp(raw_predictions, export_temp_base, rank)
+        dist.barrier()
+
+        if rank == 0:
+            all_predictions = load_all_predictions_from_temp(export_temp_base, world_size)
+        else:
+            all_predictions = None
+
+        dist.barrier()
+        if rank == 0:
+            shutil.rmtree(export_temp_base, ignore_errors=True)
+    else:
+        all_predictions = sorted(raw_predictions, key=lambda x: x[0])
+
+    if rank != 0 or not all_predictions:
+        return
+
+    recorder = build_recorder_from_config(
+        output_path=export_path,
+        rotation_representation=getattr(model, "rotation_representation", "6d"),
+        fps=fps,
+        source_checkpoint=str(checkpoint_path),
+        source_input=str(dataset_path),
+        model_id=getattr(model, "model_id", None),
+    )
+
+    cameras = build_multiview_cameras(all_predictions, dataset.get_canonical_camera_order())
+    if cameras:
+        recorder.set_cameras(cameras)
+
+    for _, params in all_predictions:
+        recorder.record(params)
+
+    written = recorder.write()
+    print(f"Animation export written: {written['npz']} + {written['json']} "
+          f"({recorder.num_frames()} frames)")
+
+
 def run_inference_phase(
     dataset: SLEAPMultiViewDataset,
     model: MultiViewSMILImageRegressor,
@@ -1308,6 +1372,21 @@ def main_inference(
     # Free GPU memory after inference — rendering will reload params to device as needed
     torch.cuda.empty_cache()
 
+    # ── Phase 1b: Optional animation export (raw, pre-smoothing) ────────
+    export_animation_path = getattr(args, "export_animation", None)
+    if export_animation_path:
+        _export_animation(
+            raw_predictions=raw_predictions,
+            rank=rank,
+            world_size=world_size,
+            dataset=dataset,
+            model=model,
+            checkpoint_path=checkpoint_path,
+            dataset_path=dataset_path,
+            export_path=export_animation_path,
+            fps=float(args.fps),
+        )
+
     # ── Phase 2: Gather + smooth predictions ────────────────────────────
     smoothing_window = args.smoothing_window
     dataset_name = dataset_path.stem
@@ -1501,6 +1580,10 @@ def main():
     parser.add_argument("--smal_file", type=str, default=None, help="Path to SMAL model file to override config.py SMAL_FILE (optional)")
     parser.add_argument("--shape_family", type=int, default=None, help="Shape family to use with --smal_file (optional, defaults to config.SHAPE_FAMILY)")
     parser.add_argument("--checkpoint", type=str, default=None, help="Path to model checkpoint (.pth) to use for inference (default: auto-detected from multiview_checkpoints/)")
+    parser.add_argument("--export_animation", type=str, default=None,
+                        help="Optional output path stem for SMIL animation export. "
+                             "Writes <stem>.npz + <stem>.json with raw (pre-smoothing) parameters "
+                             "and per-view cameras. Gathered to rank 0 in multi-GPU runs.")
     args = parser.parse_args()
     
     # Get master port from args or environment variable

--- a/smal_fitter/neuralSMIL/run_multiview_inference.py
+++ b/smal_fitter/neuralSMIL/run_multiview_inference.py
@@ -6,7 +6,8 @@ This script mirrors the visualization logic used during training in
 `train_multiview_regressor.py`, but runs over all samples in a preprocessed
 multi-view HDF5 dataset and writes two videos in the current working directory:
 
-  - "<DATASET>_multiview_inference.mp4" (multi-view grid visualization)
+  - "<DATASET>_multiview_inference.avi" (multi-view grid visualization, AVI+MJPG
+    so wide grids exceed MPEG-4's 8192px width cap)
   - "<DATASET>_smultiview_first_camera_render.mp4" (single-view render for view 0)
 """
 
@@ -57,6 +58,10 @@ from sleap_data.sleap_multiview_dataset import SLEAPMultiViewDataset
 from configs import apply_smal_file_override
 import config
 from animation_export import build_recorder_from_config, build_multiview_cameras
+from multiview_visualization import (
+    compute_multiview_grid_layout,
+    create_multiview_visualization,
+)
 
 
 DEFAULT_CHECKPOINTS = [
@@ -425,211 +430,6 @@ def load_multiview_model_from_checkpoint(checkpoint_path: Path,
     model.load_state_dict(nn_state_dict, strict=False)
     model.eval()
     return model
-
-
-def create_multiview_visualization(model: MultiViewSMILImageRegressor,
-                                   x_data: dict,
-                                   y_data: dict,
-                                   device: str,
-                                   disable_scaling: bool = False,
-                                   disable_translation: bool = False,
-                                   predicted_params: Optional[dict] = None) -> Optional[np.ndarray]:
-    """
-    Create multi-view grid visualization matching training visualization exactly.
-
-    CRITICAL: This function must match the training visualization in train_multiview_regressor.py
-    exactly, especially for PCA transformation and parameter application order.
-
-    Args:
-        model: MultiViewSMILImageRegressor model
-        x_data: Input data dictionary
-        y_data: Target data dictionary
-        device: PyTorch device
-        disable_scaling: If True, zero out log_beta_scales for visualization (testing/debugging)
-        disable_translation: If True, zero out betas_trans for visualization (testing/debugging)
-        predicted_params: Pre-computed predicted parameters. If None, runs forward pass internally.
-    """
-    images = x_data.get("images", [])
-    num_views = len(images)
-    if num_views == 0:
-        return None
-
-    # Run forward pass if predicted_params not provided
-    if predicted_params is None:
-        predicted_params = run_forward_multiview(model, x_data, y_data, device)
-        if predicted_params is None:
-            return None
-
-    # Calculate grid dimensions dynamically based on actual num_views (same as training)
-    # This allows samples with fewer views than max_views to be visualized correctly
-    # Derive img_size from the model's renderer resolution so visualization is correct
-    # for any backbone (ViT=224, ResNet/UNet=512, etc.)
-    img_size = int(model.renderer.image_size)
-    margin = 5
-    grid_width = num_views * img_size + (num_views + 1) * margin
-    grid_height = 2 * img_size + 3 * margin
-
-    canvas = np.ones((grid_height, grid_width, 3), dtype=np.uint8) * 40
-    target_keypoints = y_data.get("keypoints_2d", None)
-    target_visibility = y_data.get("keypoint_visibility", None)
-
-    for v in range(num_views):
-        x_offset = margin + v * (img_size + margin)
-        input_img = images[v]
-        if isinstance(input_img, np.ndarray):
-            if input_img.shape[0] != img_size or input_img.shape[1] != img_size:
-                from PIL import Image
-                pil_img = Image.fromarray((input_img * 255).astype(np.uint8) if input_img.max() <= 1 else input_img.astype(np.uint8))
-                pil_img = pil_img.resize((img_size, img_size), Image.BILINEAR)
-                input_img = np.array(pil_img)
-            if input_img.max() <= 1.0:
-                input_img = (input_img * 255).astype(np.uint8)
-            else:
-                input_img = input_img.astype(np.uint8)
-            if len(input_img.shape) == 2:
-                input_img = np.stack([input_img] * 3, axis=-1)
-            elif input_img.shape[-1] == 4:
-                input_img = input_img[:, :, :3]
-            canvas[margin:margin + img_size, x_offset:x_offset + img_size] = input_img
-
-        try:
-            # Extract aspect ratio for this view if available
-            aspect_ratio = None
-            try:
-                if y_data.get("cam_aspect_per_view") is not None:
-                    aspect_ratio = float(np.array(y_data["cam_aspect_per_view"][v]).reshape(-1)[0])
-            except Exception:
-                aspect_ratio = None
-            
-            rendered_img = create_rendered_view_with_keypoints(
-                model, predicted_params, v,
-                target_keypoints, target_visibility,
-                device, img_size, aspect_ratio=aspect_ratio,
-                disable_scaling=disable_scaling,
-                disable_translation=disable_translation
-            )
-            canvas[2 * margin + img_size:2 * margin + 2 * img_size,
-                   x_offset:x_offset + img_size] = rendered_img
-        except Exception as e:
-            print(f"Warning: Could not render view {v}: {e}")
-            placeholder = np.ones((img_size, img_size, 3), dtype=np.uint8) * 128
-            canvas[2 * margin + img_size:2 * margin + 2 * img_size,
-                   x_offset:x_offset + img_size] = placeholder
-
-    try:
-        from PIL import Image, ImageDraw, ImageFont
-        pil_canvas = Image.fromarray(canvas)
-        draw = ImageDraw.Draw(pil_canvas)
-        try:
-            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 12)
-        except Exception:
-            font = ImageFont.load_default()
-        draw.text((5, margin + img_size // 2 - 6), "Input", fill=(255, 255, 255), font=font)
-        draw.text((5, 2 * margin + img_size + img_size // 2 - 6), "Pred", fill=(255, 255, 255), font=font)
-        for v in range(num_views):
-            x_pos = margin + v * (img_size + margin) + img_size // 2 - 10
-            cam_name = x_data.get("camera_names", [f"V{v}"])[v] if v < len(x_data.get("camera_names", [])) else f"V{v}"
-            draw.text((x_pos, 2), str(cam_name)[:8], fill=(255, 255, 255), font=font)
-        canvas = np.array(pil_canvas)
-    except Exception:
-        pass
-
-    return canvas
-
-
-def create_rendered_view_with_keypoints(model: MultiViewSMILImageRegressor,
-                                        predicted_params: dict,
-                                        view_idx: int,
-                                        target_keypoints: np.ndarray,
-                                        target_visibility: np.ndarray,
-                                        device: str,
-                                        img_size: int,
-                                        aspect_ratio: Optional[float] = None,
-                                        disable_scaling: bool = False,
-                                        disable_translation: bool = False) -> np.ndarray:
-    """
-    Create a rendered view with keypoint overlays matching training visualization exactly.
-    
-    CRITICAL: This function must match the training visualization in train_multiview_regressor.py
-    exactly, especially for PCA transformation and parameter application order.
-    
-    Args:
-        model: MultiViewSMILImageRegressor model
-        predicted_params: Dictionary of predicted parameters (NOT modified by this function)
-        view_idx: Which view to render
-        target_keypoints: Ground truth keypoints
-        target_visibility: Ground truth visibility
-        device: PyTorch device
-        img_size: Output image size
-        aspect_ratio: Optional camera aspect ratio for correct projection
-        disable_scaling: If True, zero out log_beta_scales for visualization (testing/debugging)
-        disable_translation: If True, zero out betas_trans for visualization (testing/debugging)
-    """
-    # Create a modified copy of predicted_params for visualization if flags are set
-    # This ensures we don't modify the original params dict
-    vis_params = predicted_params
-    if disable_scaling or disable_translation:
-        vis_params = predicted_params.copy()
-        if disable_scaling and "log_beta_scales" in vis_params:
-            vis_params["log_beta_scales"] = torch.zeros_like(vis_params["log_beta_scales"])
-        if disable_translation and "betas_trans" in vis_params:
-            vis_params["betas_trans"] = torch.zeros_like(vis_params["betas_trans"])
-    
-    fov = vis_params["fov_per_view"][view_idx]
-    cam_rot = vis_params["cam_rot_per_view"][view_idx]
-    cam_trans = vis_params["cam_trans_per_view"][view_idx]
-
-    pred_kps = None
-    try:
-        with torch.no_grad():
-            # Convert aspect_ratio to tensor if provided
-            aspect_tensor = None
-            if aspect_ratio is not None:
-                aspect_tensor = torch.tensor([aspect_ratio], dtype=torch.float32, device=device)
-            
-            rendered_joints = model._render_keypoints_with_camera(
-                vis_params, fov, cam_rot, cam_trans, aspect_ratio=aspect_tensor
-            )
-        pred_kps = rendered_joints[0].detach().cpu().numpy()
-        pred_kps = pred_kps * img_size
-    except Exception as e:
-        print(f"Keypoint rendering failed: {e}")
-
-    img = np.ones((img_size, img_size, 3), dtype=np.uint8) * 60
-    for i in range(img_size):
-        img[i, :, 0] = min(255, 60 + view_idx * 30)
-
-    gt_kps = None
-    gt_vis = None
-    if target_keypoints is not None:
-        if len(target_keypoints.shape) == 3:
-            if view_idx < target_keypoints.shape[0]:
-                gt_kps = target_keypoints[view_idx] * img_size
-                if target_visibility is not None and view_idx < target_visibility.shape[0]:
-                    gt_vis = target_visibility[view_idx]
-        elif len(target_keypoints.shape) == 2 and view_idx == 0:
-            gt_kps = target_keypoints * img_size
-            gt_vis = target_visibility
-
-    from PIL import Image, ImageDraw
-    pil_img = Image.fromarray(img)
-    draw = ImageDraw.Draw(pil_img)
-
-    if gt_kps is not None:
-        for j, (y, x) in enumerate(gt_kps):
-            if gt_vis is None or gt_vis[j] > 0.5:
-                x, y = float(x), float(y)
-                if 0 <= x < img_size and 0 <= y < img_size:
-                    draw.ellipse([x - 3, y - 3, x + 3, y + 3], outline="green", width=2)
-
-    if pred_kps is not None:
-        for j, (y, x) in enumerate(pred_kps):
-            x, y = float(x), float(y)
-            if 0 <= x < img_size and 0 <= y < img_size:
-                draw.line([x - 4, y, x + 4, y], fill="red", width=2)
-                draw.line([x, y - 4, x, y + 4], fill="red", width=2)
-
-    return np.array(pil_img)
 
 
 class _InMemoryImageExporter:
@@ -1034,6 +834,7 @@ def run_render_phase(
     disable_scaling: bool = False,
     disable_translation: bool = False,
     view_indices: Optional[List[int]] = None,
+    total_view_slots: Optional[int] = None,
 ) -> Tuple[List[np.ndarray], Dict[int, List[np.ndarray]], List[int], Dict[int, List[int]]]:
     """Render visualizations for the assigned indices using pre-computed smoothed params.
 
@@ -1064,6 +865,7 @@ def run_render_phase(
                 disable_scaling=disable_scaling,
                 disable_translation=disable_translation,
                 predicted_params=params,
+                total_view_slots=total_view_slots,
             )
             if mv_frame is not None:
                 mv_frame = _pad_or_resize(mv_frame, (grid_width, grid_height))
@@ -1233,14 +1035,21 @@ def merge_frames_and_write_videos(
     
     print(f"Writing {len(all_mv_entries)} multiview frames...")
     
-    # Write multiview video
+    # Write multiview video. MPEG-4 caps frame dimensions at 8192 px, so wide
+    # multi-camera grids fall over silently with mp4v. AVI+MJPG has no such
+    # cap and stays well-supported everywhere we play these back.
     if len(all_mv_entries) > 0:
         multiview_writer = cv2.VideoWriter(
             str(multiview_out),
-            cv2.VideoWriter_fourcc(*"mp4v"),
+            cv2.VideoWriter_fourcc(*"MJPG"),
             fps,
             (grid_width, grid_height),
         )
+        if not multiview_writer.isOpened():
+            raise RuntimeError(
+                f"Failed to open multiview VideoWriter for {multiview_out} "
+                f"at {grid_width}x{grid_height}"
+            )
         for _, frame_path in all_mv_entries:
             frame = cv2.imread(frame_path)
             if frame is not None:
@@ -1390,11 +1199,17 @@ def main_inference(
     if world_size > 1:
         sampler = DistributedSampler(dataset, num_replicas=world_size, rank=rank, shuffle=False)
 
-    # Calculate frame dimensions — derive from the model's renderer resolution
+    # Calculate frame dimensions — derive from the model's renderer resolution.
+    # Layout (single-row vs wrapped 6-per-row block layout for >12 views) is
+    # decided once from model.max_views so every frame in the output video has
+    # identical dimensions, even when individual samples have fewer views.
     img_size = int(model.renderer.image_size)
-    margin = 5
-    grid_width = model_max_views * img_size + (model_max_views + 1) * margin
-    grid_height = 2 * img_size + 3 * margin
+    mv_layout = compute_multiview_grid_layout(model_max_views, img_size)
+    grid_width = mv_layout['grid_width']
+    grid_height = mv_layout['grid_height']
+    if rank == 0:
+        print(f"Multiview grid layout: {mv_layout['num_blocks']} block(s) × "
+              f"{mv_layout['cols']} col(s) → {grid_width}×{grid_height}")
 
     # Determine singleview frame size (use first sample to get actual size)
     singleview_size = (img_size, img_size)  # Default, overridden below by test render
@@ -1526,13 +1341,14 @@ def main_inference(
             disable_scaling=args.disable_scaling,
             disable_translation=args.disable_translation,
             view_indices=view_indices,
+            total_view_slots=model_max_views,
         )
         del smoothed_params
 
         # ── Phase 4: Write output videos ────────────────────────────────────
         if rank == 0:
             print("\n── Phase 4: Writing output videos ──")
-        multiview_out = Path(f"{dataset_name}{range_suffix}_multiview_inference.mp4")
+        multiview_out = Path(f"{dataset_name}{range_suffix}_multiview_inference.avi")
         singleview_out_base = Path(f"{dataset_name}{range_suffix}_singleview_inference.mp4")
 
         if world_size > 1:
@@ -1571,14 +1387,20 @@ def main_inference(
 
             dist.barrier()
         else:
-            # Single GPU: write directly
+            # Single GPU: write directly. See note in merge_frames_and_write_videos
+            # for why multiview uses AVI+MJPG instead of MP4.
             if len(multiview_frames) > 0:
                 multiview_writer = cv2.VideoWriter(
                     str(multiview_out),
-                    cv2.VideoWriter_fourcc(*"mp4v"),
+                    cv2.VideoWriter_fourcc(*"MJPG"),
                     args.fps,
                     (grid_width, grid_height),
                 )
+                if not multiview_writer.isOpened():
+                    raise RuntimeError(
+                        f"Failed to open multiview VideoWriter for {multiview_out} "
+                        f"at {grid_width}x{grid_height}"
+                    )
                 for frame in multiview_frames:
                     multiview_writer.write(frame)
                 multiview_writer.release()

--- a/smal_fitter/neuralSMIL/run_singleview_inference.py
+++ b/smal_fitter/neuralSMIL/run_singleview_inference.py
@@ -55,6 +55,7 @@ from training_config import TrainingConfig
 from smal_fitter import SMALFitter
 from Unreal2Pytorch3D import return_placeholder_data
 import config
+from animation_export import AnimationRecorder, build_recorder_from_config
 from sleap_data_loader import SLEAPDataLoader
 import importlib.util
 import importlib
@@ -1200,7 +1201,8 @@ def process_video(model: SMILImageRegressor, video_path: str, output_folder: str
                  camera_smoothing_window: int = 10,
                  sleap_helper: Optional[SLEAPCroppingHelper] = None,
                  sleap_camera: Optional[str] = None,
-                 video_export_mode: str = 'overlay') -> None:
+                 video_export_mode: str = 'overlay',
+                 animation_recorder: Optional[AnimationRecorder] = None) -> None:
     """
     Process a video file for inference.
     
@@ -1327,7 +1329,11 @@ def process_video(model: SMILImageRegressor, video_path: str, output_folder: str
                 
                 # Run inference
                 predicted_params = run_inference_on_image(model, preprocessed_tensor, device)
-                
+
+                # Record raw (pre-smoothing) parameters for Phase 1 animation export.
+                if animation_recorder is not None:
+                    animation_recorder.record(predicted_params)
+
                 # Apply camera parameter smoothing
                 if camera_smoothing_window > 0:
                     smoothed_params = smooth_camera_parameters(
@@ -1463,7 +1469,13 @@ Supported video formats: mp4, avi, mov, mkv (anything supported by OpenCV)
                        help='Path to SLEAP project directory (required for bbox_crop)')
     parser.add_argument('--sleap_camera', type=str, default=None,
                        help='Optional camera name override when using bbox_crop with SLEAP data')
-    
+
+    # Animation export (Phase 1)
+    parser.add_argument('--export_animation', type=str, default=None,
+                       help='Optional output path stem for SMIL animation export. '
+                            'Writes <stem>.npz + <stem>.json alongside the MP4. '
+                            'Only active when --input_video is used.')
+
     args = parser.parse_args()
     
     print("=" * 60)
@@ -1547,14 +1559,34 @@ Supported video formats: mp4, avi, mov, mkv (anything supported by OpenCV)
             # Process video
             print("\n" + "="*40)
             print("Running inference on video...")
+
+            animation_recorder: Optional[AnimationRecorder] = None
+            if args.export_animation:
+                output_fps = args.fps if args.fps is not None else cv2.VideoCapture(args.input_video).get(cv2.CAP_PROP_FPS)
+                animation_recorder = build_recorder_from_config(
+                    output_path=args.export_animation,
+                    rotation_representation=model.rotation_representation,
+                    fps=float(output_fps),
+                    source_checkpoint=args.checkpoint,
+                    source_input=args.input_video,
+                    model_id=getattr(model, "model_id", None),
+                )
+                print(f"Animation export enabled: {args.export_animation}.[npz|json]")
+
             process_video(
                 model, args.input_video, args.output_folder,
                 device, args.crop_mode, args.fps, args.save_frames, args.max_frames,
                 args.camera_smoothing,
                 sleap_helper=sleap_helper,
                 sleap_camera=args.sleap_camera,
-                video_export_mode=args.video_export_mode
+                video_export_mode=args.video_export_mode,
+                animation_recorder=animation_recorder,
             )
+
+            if animation_recorder is not None and animation_recorder.num_frames() > 0:
+                written = animation_recorder.write()
+                print(f"Animation export written: {written['npz']} + {written['json']} "
+                      f"({animation_recorder.num_frames()} frames)")
         
         print("\n" + "="*60)
         print("Inference completed successfully!")

--- a/smal_fitter/neuralSMIL/train_multiview_regressor.py
+++ b/smal_fitter/neuralSMIL/train_multiview_regressor.py
@@ -67,6 +67,12 @@ from smal_fitter import SMALFitter
 import config
 from training_config import TrainingConfig
 from configs import MultiViewConfig, load_config, save_config_json, apply_smal_file_override, ConfigurationError
+from multiview_visualization import (
+    create_multiview_visualization,
+    create_rendered_view_with_keypoints,
+    print_joint_scale_diagnostics,
+    run_forward_multiview_single_sample,
+)
 
 
 def set_random_seeds(seed: int = 0, deterministic: bool = False):
@@ -917,10 +923,17 @@ def visualize_multiview_training_progress(model: MultiViewSMILImageRegressor,
         # Process each sample
         for sample_idx, (x_data, y_data) in enumerate(collected_samples):
             try:
-                visualization = create_multiview_visualization(
-                    base_model, x_data, y_data, device, training_config
+                predicted_params = run_forward_multiview_single_sample(
+                    base_model, x_data, y_data, device
                 )
-                
+                if predicted_params is not None:
+                    print_joint_scale_diagnostics(
+                        base_model, predicted_params, label=f"Multiview Sample {sample_idx}"
+                    )
+                visualization = create_multiview_visualization(
+                    base_model, x_data, y_data, device, predicted_params=predicted_params
+                )
+
                 if visualization is not None:
                     # Save visualization
                     output_path = os.path.join(epoch_dir, f'sample_{sample_idx:03d}_epoch_{epoch:03d}.png')
@@ -946,331 +959,6 @@ def visualize_multiview_training_progress(model: MultiViewSMILImageRegressor,
         random.setstate(python_rng_state)
         if torch.cuda.is_available():
             torch.cuda.set_rng_state(cuda_rng_state)
-
-
-def create_multiview_visualization(model: MultiViewSMILImageRegressor,
-                                    x_data: dict,
-                                    y_data: dict,
-                                    device: str,
-                                    training_config: dict) -> np.ndarray:
-    """
-    Create a grid visualization for a single multi-view sample.
-    
-    Layout:
-    ┌────────────┬────────────┬────────────┬─────┐
-    │  Input V0  │  Input V1  │  Input V2  │ ... │  <- Input images
-    ├────────────┼────────────┼────────────┼─────┤
-    │ Render V0  │ Render V1  │ Render V2  │ ... │  <- Rendered with keypoints
-    └────────────┴────────────┴────────────┴─────┘
-    
-    Args:
-        model: MultiViewSMILImageRegressor
-        x_data: Input data dictionary for one sample
-        y_data: Target data dictionary for one sample
-        device: PyTorch device
-        training_config: Training configuration
-        
-    Returns:
-        Numpy array of the visualization image (H, W, 3) uint8
-    """
-    images = x_data.get('images', [])
-    num_views = len(images)
-    
-    if num_views == 0:
-        return None
-    
-    # Get camera indices
-    cam_indices = x_data.get('camera_indices', list(range(num_views)))
-    if isinstance(cam_indices, np.ndarray):
-        cam_indices = cam_indices.tolist()
-    
-    # Preprocess images and prepare batch
-    images_per_view = []
-    for img in images:
-        img_tensor = model.preprocess_image(img).to(device)  # (1, 3, H, W)
-        images_per_view.append(img_tensor.squeeze(0))  # (3, H, W)
-    
-    # Stack into tensors for model
-    images_tensors = [img.unsqueeze(0) for img in images_per_view]  # List of (1, 3, H, W)
-    camera_indices_tensor = torch.tensor([cam_indices], device=device)  # (1, num_views)
-    view_mask = torch.ones(1, num_views, dtype=torch.bool, device=device)  # (1, num_views)
-    
-    # Forward pass through model (no gradient needed for visualization)
-    with torch.no_grad():
-        predicted_params = model.forward_multiview(
-            images_tensors,
-            camera_indices_tensor,
-            view_mask,
-            target_data=[y_data]
-        )
-    
-    # Print joint scales with joint names
-    if 'log_beta_scales' in predicted_params:
-        try:
-            from training_config import TrainingConfig
-            scale_trans_config = TrainingConfig.get_scale_trans_config()
-            use_pca_transformation = scale_trans_config.get('separate', {}).get('use_pca_transformation', True)
-            
-            if model.scale_trans_mode == 'separate' and use_pca_transformation:
-                # PCA weights - transform to per-joint values
-                scale_weights = predicted_params['log_beta_scales'][0]  # (N_BETAS,) - PCA weights
-                trans_weights = predicted_params.get('betas_trans', None)
-                if trans_weights is not None:
-                    trans_weights = trans_weights[0:1]  # (1, N_BETAS)
-                log_beta_scales_joint, _ = model._transform_separate_pca_weights_to_joint_values(
-                    scale_weights.unsqueeze(0), trans_weights
-                )
-                log_beta_scales_joint = log_beta_scales_joint[0]  # (n_joints, 3)
-            else:
-                # Already per-joint values - use directly
-                log_beta_scales_joint = predicted_params['log_beta_scales'][0]  # (n_joints, 3)
-            
-            # Convert log scales to linear scales for readability
-            scales_joint = torch.exp(log_beta_scales_joint)  # (n_joints, 3)
-            
-            # Get joint names
-            joint_names = config.dd["J_names"]
-            
-            # Print scales for each joint
-            print(f"\n=== Joint Scales for Multiview Sample ===")
-            print(f"Mode: {model.scale_trans_mode}")
-            print(f"{'Joint Name':<20} {'Scale X':>10} {'Scale Y':>10} {'Scale Z':>10} {'Mean Scale':>12}")
-            print("-" * 70)
-            
-            for joint_idx, joint_name in enumerate(joint_names):
-                if joint_idx < scales_joint.shape[0]:
-                    scale_xyz = scales_joint[joint_idx].cpu().numpy()  # (3,)
-                    mean_scale = scale_xyz.mean()
-                    print(f"{joint_name:<20} {scale_xyz[0]:>10.4f} {scale_xyz[1]:>10.4f} {scale_xyz[2]:>10.4f} {mean_scale:>12.4f}")
-            
-            # Print summary statistics
-            all_scales = scales_joint.cpu().numpy()
-            print(f"\nSummary Statistics:")
-            print(f"  Mean scale (all joints, all axes): {all_scales.mean():.4f}")
-            print(f"  Std scale (all joints, all axes): {all_scales.std():.4f}")
-            print(f"  Min scale: {all_scales.min():.4f}")
-            print(f"  Max scale: {all_scales.max():.4f}")
-            print(f"  Joints with scale > 1.1: {((all_scales > 1.1).any(axis=1).sum().item())}")
-            print(f"  Joints with scale < 0.9: {((all_scales < 0.9).any(axis=1).sum().item())}")
-            print("=" * 70 + "\n")
-            
-        except Exception as e:
-            print(f"Warning: Failed to print joint scales: {e}")
-            import traceback
-            traceback.print_exc()
-    
-    # Visualization parameters — derive from model's actual renderer resolution
-    # so that visualization is correct for any backbone (ViT=224, ResNet/UNet=512, etc.)
-    img_size = int(model.renderer.image_size)
-    margin = 5
-    
-    # Create visualization grid
-    grid_width = num_views * img_size + (num_views + 1) * margin
-    grid_height = 2 * img_size + 3 * margin  # 2 rows: input + rendered
-    
-    # Create canvas with dark background
-    canvas = np.ones((grid_height, grid_width, 3), dtype=np.uint8) * 40
-    
-    # Get target keypoints for each view
-    target_keypoints = y_data.get('keypoints_2d', None)
-    target_visibility = y_data.get('keypoint_visibility', None)
-    
-    for v in range(num_views):
-        x_offset = margin + v * (img_size + margin)
-        
-        # === TOP ROW: Input images ===
-        input_img = images[v]
-        if isinstance(input_img, np.ndarray):
-            # Resize to visualization size if needed
-            if input_img.shape[0] != img_size or input_img.shape[1] != img_size:
-                from PIL import Image
-                pil_img = Image.fromarray((input_img * 255).astype(np.uint8) if input_img.max() <= 1 else input_img.astype(np.uint8))
-                pil_img = pil_img.resize((img_size, img_size), Image.BILINEAR)
-                input_img = np.array(pil_img)
-            
-            # Ensure uint8 format
-            if input_img.max() <= 1.0:
-                input_img = (input_img * 255).astype(np.uint8)
-            else:
-                input_img = input_img.astype(np.uint8)
-            
-            # Ensure RGB (3 channels)
-            if len(input_img.shape) == 2:
-                input_img = np.stack([input_img] * 3, axis=-1)
-            elif input_img.shape[-1] == 4:
-                input_img = input_img[:, :, :3]
-            
-            canvas[margin:margin + img_size, x_offset:x_offset + img_size] = input_img
-        
-        # === BOTTOM ROW: Rendered mesh with keypoints ===
-        try:
-            # Extract aspect ratio for this view if available
-            aspect_ratio = None
-            try:
-                if y_data.get('cam_aspect_per_view') is not None:
-                    aspect_ratio = float(np.array(y_data['cam_aspect_per_view'][v]).reshape(-1)[0])
-            except Exception:
-                aspect_ratio = None
-            
-            # Create rendered image with keypoint overlays
-            rendered_img = create_rendered_view_with_keypoints(
-                model, predicted_params, v, 
-                target_keypoints, target_visibility,
-                device, img_size, aspect_ratio=aspect_ratio
-            )
-            
-            canvas[2 * margin + img_size:2 * margin + 2 * img_size, 
-                   x_offset:x_offset + img_size] = rendered_img
-            
-        except Exception as e:
-            print(f"Warning: Could not render view {v}: {e}")
-            # Fill with placeholder
-            placeholder = np.ones((img_size, img_size, 3), dtype=np.uint8) * 128
-            canvas[2 * margin + img_size:2 * margin + 2 * img_size,
-                   x_offset:x_offset + img_size] = placeholder
-    
-    # Add row labels
-    try:
-        from PIL import Image, ImageDraw, ImageFont
-        pil_canvas = Image.fromarray(canvas)
-        draw = ImageDraw.Draw(pil_canvas)
-        
-        # Try to use a basic font
-        try:
-            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 12)
-        except:
-            font = ImageFont.load_default()
-        
-        # Add labels
-        draw.text((5, margin + img_size // 2 - 6), "Input", fill=(255, 255, 255), font=font)
-        draw.text((5, 2 * margin + img_size + img_size // 2 - 6), "Pred", fill=(255, 255, 255), font=font)
-        
-        # Add view labels
-        for v in range(num_views):
-            x_pos = margin + v * (img_size + margin) + img_size // 2 - 10
-            cam_name = x_data.get('camera_names', [f'V{v}'])[v] if v < len(x_data.get('camera_names', [])) else f'V{v}'
-            draw.text((x_pos, 2), str(cam_name)[:8], fill=(255, 255, 255), font=font)
-        
-        canvas = np.array(pil_canvas)
-    except ImportError:
-        pass  # PIL not available for text, skip labels
-    
-    return canvas
-
-
-def create_rendered_view_with_keypoints(model: MultiViewSMILImageRegressor,
-                                         predicted_params: dict,
-                                         view_idx: int,
-                                         target_keypoints: np.ndarray,
-                                         target_visibility: np.ndarray,
-                                         device: str,
-                                         img_size: int,
-                                         aspect_ratio: Optional[float] = None) -> np.ndarray:
-    """
-    Create a rendered view with keypoint overlays.
-    
-    Args:
-        model: The multi-view model
-        predicted_params: Output from forward_multiview
-        view_idx: Which view to render
-        target_keypoints: Ground truth keypoints (num_views, n_joints, 2) or (n_joints, 2)
-        target_visibility: Ground truth visibility (num_views, n_joints) or (n_joints,)
-        device: PyTorch device
-        img_size: Output image size
-        aspect_ratio: Optional camera aspect ratio for correct projection
-        
-    Returns:
-        Rendered image with keypoint overlays (img_size, img_size, 3) uint8
-    """
-    from smil_image_regressor import rotation_6d_to_axis_angle
-    
-    # Get camera parameters for this view
-    fov = predicted_params['fov_per_view'][view_idx]  # (batch_size, 1)
-    cam_rot = predicted_params['cam_rot_per_view'][view_idx]  # (batch_size, 3, 3)
-    cam_trans = predicted_params['cam_trans_per_view'][view_idx]  # (batch_size, 3)
-    
-    # Render 2D keypoints using body params + view camera
-    try:
-        with torch.no_grad():
-            # Convert aspect_ratio to tensor if provided
-            aspect_tensor = None
-            if aspect_ratio is not None:
-                aspect_tensor = torch.tensor([aspect_ratio], dtype=torch.float32, device=device)
-            
-            rendered_joints = model._render_keypoints_with_camera(
-                predicted_params, fov, cam_rot, cam_trans, aspect_ratio=aspect_tensor
-            )  # (batch_size, n_joints, 2)
-        
-        # Convert to numpy for visualization
-        pred_kps = rendered_joints[0].detach().cpu().numpy()  # (n_joints, 2)
-        pred_kps = pred_kps * img_size  # Scale to image coordinates
-        
-    except Exception as e:
-        print(f"Keypoint rendering failed: {e}")
-        pred_kps = None
-    
-    # Create base image (gray background for now, could be rendered mesh later)
-    # Use a subtle blue gradient to differentiate views (avoids conflict with red pred markers)
-    img = np.ones((img_size, img_size, 3), dtype=np.uint8) * 50
-    
-    # Add a pleasant blue tint that increases with view index
-    # Blue channel increases, slight decrease in red to create cooler tones
-    blue_intensity = min(255, 70 + view_idx * 25)
-    img[:, :, 2] = blue_intensity  # Blue channel
-    img[:, :, 1] = min(255, 55 + view_idx * 8)  # Slight green for pleasant tone
-    img[:, :, 0] = 45  # Keep red low for cool blue appearance
-    
-    # Get target keypoints for this view
-    gt_kps = None
-    gt_vis = None
-    if target_keypoints is not None:
-        if len(target_keypoints.shape) == 3:
-            # Multi-view format: (num_views, n_joints, 2)
-            if view_idx < target_keypoints.shape[0]:
-                gt_kps = target_keypoints[view_idx] * img_size  # (n_joints, 2)
-                if target_visibility is not None and view_idx < target_visibility.shape[0]:
-                    gt_vis = target_visibility[view_idx]  # (n_joints,)
-        elif len(target_keypoints.shape) == 2 and view_idx == 0:
-            # Single-view format: (n_joints, 2)
-            gt_kps = target_keypoints * img_size
-            gt_vis = target_visibility
-    
-    # Draw keypoints on image
-    from PIL import Image, ImageDraw
-    pil_img = Image.fromarray(img)
-    draw = ImageDraw.Draw(pil_img)
-    
-    # Draw ground truth keypoints (green circles)
-    if gt_kps is not None:
-        for j, (y, x) in enumerate(gt_kps):
-            if gt_vis is None or gt_vis[j] > 0.5:
-                # Keypoints are in (y, x) format, need (x, y) for PIL
-                x, y = float(x), float(y)
-                if 0 <= x < img_size and 0 <= y < img_size:
-                    draw.ellipse([x - 3, y - 3, x + 3, y + 3], outline='green', width=2)
-    
-    # Draw predicted keypoints (red crosses)
-    if pred_kps is not None:
-        for j, (y, x) in enumerate(pred_kps):
-            x, y = float(x), float(y)
-            if 0 <= x < img_size and 0 <= y < img_size:
-                # Draw cross
-                draw.line([x - 4, y, x + 4, y], fill='red', width=2)
-                draw.line([x, y - 4, x, y + 4], fill='red', width=2)
-    
-    # Add legend
-    try:
-        from PIL import ImageFont
-        try:
-            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 10)
-        except:
-            font = ImageFont.load_default()
-        draw.text((5, img_size - 25), "○ GT", fill='green', font=font)
-        draw.text((5, img_size - 12), "+ Pred", fill='red', font=font)
-    except:
-        pass
-    
-    return np.array(pil_img)
 
 
 def draw_keypoints_on_image(image_rgb: np.ndarray,
@@ -1526,61 +1214,10 @@ def render_singleview_for_sample(model: MultiViewSMILImageRegressor,
             target_data=[y_data]
         )
     
-    # Print joint scales with joint names (once per sample)
-    if 'log_beta_scales' in predicted_params:
-        try:
-            from training_config import TrainingConfig
-            scale_trans_config = TrainingConfig.get_scale_trans_config()
-            use_pca_transformation = scale_trans_config.get('separate', {}).get('use_pca_transformation', True)
-            
-            if model.scale_trans_mode == 'separate' and use_pca_transformation:
-                # PCA weights - transform to per-joint values
-                scale_weights = predicted_params['log_beta_scales'][0]  # (N_BETAS,) - PCA weights
-                trans_weights = predicted_params.get('betas_trans', None)
-                if trans_weights is not None:
-                    trans_weights = trans_weights[0:1]  # (1, N_BETAS)
-                log_beta_scales_joint, _ = model._transform_separate_pca_weights_to_joint_values(
-                    scale_weights.unsqueeze(0), trans_weights
-                )
-                log_beta_scales_joint = log_beta_scales_joint[0]  # (n_joints, 3)
-            else:
-                # Already per-joint values - use directly
-                log_beta_scales_joint = predicted_params['log_beta_scales'][0]  # (n_joints, 3)
-            
-            # Convert log scales to linear scales for readability
-            scales_joint = torch.exp(log_beta_scales_joint)  # (n_joints, 3)
-            
-            # Get joint names
-            joint_names = config.dd["J_names"]
-            
-            # Print scales for each joint
-            print(f"\n=== Joint Scales for Sample {sample_idx} (Single-View Renders) ===")
-            print(f"Mode: {model.scale_trans_mode}")
-            print(f"{'Joint Name':<20} {'Scale X':>10} {'Scale Y':>10} {'Scale Z':>10} {'Mean Scale':>12}")
-            print("-" * 70)
-            
-            for joint_idx, joint_name in enumerate(joint_names):
-                if joint_idx < scales_joint.shape[0]:
-                    scale_xyz = scales_joint[joint_idx].cpu().numpy()  # (3,)
-                    mean_scale = scale_xyz.mean()
-                    print(f"{joint_name:<20} {scale_xyz[0]:>10.4f} {scale_xyz[1]:>10.4f} {scale_xyz[2]:>10.4f} {mean_scale:>12.4f}")
-            
-            # Print summary statistics
-            all_scales = scales_joint.cpu().numpy()
-            print(f"\nSummary Statistics:")
-            print(f"  Mean scale (all joints, all axes): {all_scales.mean():.4f}")
-            print(f"  Std scale (all joints, all axes): {all_scales.std():.4f}")
-            print(f"  Min scale: {all_scales.min():.4f}")
-            print(f"  Max scale: {all_scales.max():.4f}")
-            print(f"  Joints with scale > 1.1: {((all_scales > 1.1).any(axis=1).sum().item())}")
-            print(f"  Joints with scale < 0.9: {((all_scales < 0.9).any(axis=1).sum().item())}")
-            print("=" * 70 + "\n")
-            
-        except Exception as e:
-            print(f"Warning: Failed to print joint scales for sample {sample_idx}: {e}")
-            import traceback
-            traceback.print_exc()
-    
+    print_joint_scale_diagnostics(
+        model, predicted_params, label=f"Sample {sample_idx} (Single-View Renders)"
+    )
+
     # Render each view separately using SMALFitter
     views_rendered = 0
     

--- a/tests/test_animation_export.py
+++ b/tests/test_animation_export.py
@@ -1,0 +1,169 @@
+"""Round-trip tests for the Phase 1 animation exporter.
+
+Builds a synthetic `predicted_params` dict (no model, no checkpoint), runs it
+through AnimationRecorder, reloads the resulting .npz + .json, and asserts the
+schema and tensor values are preserved.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+NEURAL_DIR = os.path.join(os.path.dirname(CURRENT_DIR), "smal_fitter", "neuralSMIL")
+sys.path.append(os.path.dirname(CURRENT_DIR))
+sys.path.append(NEURAL_DIR)
+
+from smal_fitter.neuralSMIL.animation_export import (  # noqa: E402
+    AnimationRecorder,
+    SCHEMA_VERSION,
+)
+
+
+N_JOINTS = 8
+N_POSE = N_JOINTS - 1
+N_BETAS = 20
+
+
+def _make_params_axis_angle(seed: int) -> dict:
+    g = torch.Generator().manual_seed(seed)
+    return {
+        "global_rot": torch.randn(1, 3, generator=g),
+        "joint_rot": torch.randn(1, N_POSE, 3, generator=g),
+        "trans": torch.randn(1, 3, generator=g),
+        "betas": torch.randn(1, N_BETAS, generator=g),
+        "log_beta_scales": torch.randn(1, N_JOINTS, 3, generator=g),
+        "betas_trans": torch.randn(1, N_JOINTS, 3, generator=g),
+        "cam_rot": torch.eye(3).unsqueeze(0),
+        "cam_trans": torch.randn(1, 3, generator=g),
+        "fov": torch.tensor([[45.0]]),
+    }
+
+
+def _make_recorder(tmp_path, rotation_representation="axis_angle"):
+    return AnimationRecorder(
+        output_path=tmp_path / "clip",
+        rotation_representation=rotation_representation,
+        n_joints=N_JOINTS,
+        n_betas=N_BETAS,
+        joint_names=[f"J_{i}" for i in range(N_JOINTS)],
+        parents=[-1] + list(range(N_JOINTS - 1)),
+        fps=30.0,
+        static_joint_locs=True,
+        ignore_hardcoded_body=False,
+        source_checkpoint="ckpt.pth",
+        source_input="input.mp4",
+        model_id="test_model",
+    )
+
+
+def test_round_trip_axis_angle(tmp_path):
+    rec = _make_recorder(tmp_path)
+    frames = [_make_params_axis_angle(i) for i in range(5)]
+    for f in frames:
+        rec.record(f)
+
+    out = rec.write()
+    assert out["npz"].exists() and out["json"].exists()
+
+    data = np.load(out["npz"])
+    assert data["poses"].shape == (5, N_JOINTS, 3)
+    assert data["trans"].shape == (5, 3)
+    assert data["betas"].shape == (N_BETAS,)
+    assert data["betas_per_frame"].shape == (5, N_BETAS)
+    assert data["log_beta_scales"].shape == (5, N_JOINTS, 3)
+    assert data["betas_trans"].shape == (5, N_JOINTS, 3)
+    assert float(data["fps"]) == pytest.approx(30.0)
+
+    # poses[f, 0] must equal global_rot; poses[f, 1:] must equal joint_rot.
+    for f_idx, params in enumerate(frames):
+        np.testing.assert_allclose(
+            data["poses"][f_idx, 0], params["global_rot"][0].numpy(), atol=1e-6
+        )
+        np.testing.assert_allclose(
+            data["poses"][f_idx, 1:], params["joint_rot"][0].numpy(), atol=1e-6
+        )
+        np.testing.assert_allclose(
+            data["betas_per_frame"][f_idx], params["betas"][0].numpy(), atol=1e-6
+        )
+
+    # Clip-averaged betas equal numpy mean of the per-frame betas.
+    expected_avg = np.stack([p["betas"][0].numpy() for p in frames]).mean(axis=0)
+    np.testing.assert_allclose(data["betas"], expected_avg, atol=1e-6)
+
+    with open(out["json"]) as fh:
+        sidecar = json.load(fh)
+    assert sidecar["schema_version"] == SCHEMA_VERSION
+    assert sidecar["rotation_representation"] == "axis_angle"
+    assert sidecar["root_joint_index"] == 0
+    assert sidecar["static_joint_locs"] is True
+    assert sidecar["n_frames"] == 5
+    assert sidecar["n_joints"] == N_JOINTS
+    assert sidecar["n_betas"] == N_BETAS
+    assert len(sidecar["joint_names"]) == N_JOINTS
+    assert len(sidecar["parents"]) == N_JOINTS
+    assert sidecar["fps"] == 30.0
+    assert len(sidecar["cameras"]) == 1
+    assert sidecar["cameras"][0]["view_name"] == "view_0"
+
+
+def test_6d_rotations_normalise_to_axis_angle(tmp_path):
+    rec = _make_recorder(tmp_path, rotation_representation="6d")
+    params = {
+        "global_rot": torch.tensor([[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]]),  # identity 6D
+        "joint_rot": torch.tensor([[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]]).expand(1, N_POSE, 6).clone(),
+        "trans": torch.zeros(1, 3),
+        "betas": torch.zeros(1, N_BETAS),
+    }
+    rec.record(params)
+    out = rec.write()
+    data = np.load(out["npz"])
+    # Identity rotation in axis-angle is the zero vector.
+    np.testing.assert_allclose(data["poses"], np.zeros((1, N_JOINTS, 3)), atol=1e-5)
+    with open(out["json"]) as fh:
+        sidecar = json.load(fh)
+    assert sidecar["rotation_representation"] == "axis_angle"
+
+
+def test_optional_fields_absent_when_not_recorded(tmp_path):
+    rec = _make_recorder(tmp_path)
+    params = {
+        "global_rot": torch.zeros(1, 3),
+        "joint_rot": torch.zeros(1, N_POSE, 3),
+        "trans": torch.zeros(1, 3),
+        "betas": torch.zeros(1, N_BETAS),
+    }
+    rec.record(params)
+    out = rec.write()
+    data = np.load(out["npz"])
+    assert "log_beta_scales" not in data.files
+    assert "betas_trans" not in data.files
+    with open(out["json"]) as fh:
+        sidecar = json.load(fh)
+    assert sidecar["cameras"] == []
+
+
+def test_write_without_frames_raises(tmp_path):
+    rec = _make_recorder(tmp_path)
+    with pytest.raises(RuntimeError):
+        rec.write()
+
+
+def test_invalid_rotation_representation_raises(tmp_path):
+    with pytest.raises(ValueError):
+        AnimationRecorder(
+            output_path=tmp_path / "clip",
+            rotation_representation="quaternion",
+            n_joints=N_JOINTS,
+            n_betas=N_BETAS,
+            joint_names=[f"J_{i}" for i in range(N_JOINTS)],
+            parents=[-1] + list(range(N_JOINTS - 1)),
+            fps=30.0,
+            static_joint_locs=True,
+            ignore_hardcoded_body=False,
+        )

--- a/tests/test_animation_export.py
+++ b/tests/test_animation_export.py
@@ -39,6 +39,7 @@ def _make_params_axis_angle(seed: int) -> dict:
         "betas": torch.randn(1, N_BETAS, generator=g),
         "log_beta_scales": torch.randn(1, N_JOINTS, 3, generator=g),
         "betas_trans": torch.randn(1, N_JOINTS, 3, generator=g),
+        "mesh_scale": torch.rand(1, 1, generator=g) + 0.5,
         "cam_rot": torch.eye(3).unsqueeze(0),
         "cam_trans": torch.randn(1, 3, generator=g),
         "fov": torch.tensor([[45.0]]),
@@ -78,6 +79,7 @@ def test_round_trip_axis_angle(tmp_path):
     assert data["betas_per_frame"].shape == (5, N_BETAS)
     assert data["log_beta_scales"].shape == (5, N_JOINTS, 3)
     assert data["betas_trans"].shape == (5, N_JOINTS, 3)
+    assert data["mesh_scale"].shape == (5,)
     assert float(data["fps"]) == pytest.approx(30.0)
 
     # poses[f, 0] must equal global_rot; poses[f, 1:] must equal joint_rot.
@@ -143,6 +145,7 @@ def test_optional_fields_absent_when_not_recorded(tmp_path):
     data = np.load(out["npz"])
     assert "log_beta_scales" not in data.files
     assert "betas_trans" not in data.files
+    assert "mesh_scale" not in data.files
     with open(out["json"]) as fh:
         sidecar = json.load(fh)
     assert sidecar["cameras"] == []


### PR DESCRIPTION
## Summary

End-to-end SMIL animation export from inference, a Blender importer that round-trips the result with correct rotation/camera conventions, and a one-click glTF wrapper for sharing the imported clip.

### Phase 1 — lossless Python export
- `AnimationRecorder` in `smal_fitter/neuralSMIL/animation_export.py` writes an AMASS-compatible `.npz` + human-readable `.json` sidecar (schema 1.0).
- `--export_animation PATH` wired into both `run_singleview_inference.py` and `run_multiview_inference.py`.
- Per-frame `mesh_scale` exported alongside the clip.
- Round-trip unit tests in `tests/test_animation_export.py` (including the `mesh_scale` field).

### Phase 2 — Blender addon importer
- `SMPL_OT_ImportAnimation` (surfaced as **Import SMIL Animation (.npz)** in the SMPL panel).
- Branches on sidecar `static_joint_locs` for per-frame vs static-shape modes.
- Rotation / camera-axis conventions matched to PyTorch3D world→view → Blender camera→world.
- Applies `mesh_scale` + root-centered offset.
- Defaults scene render resolution to 1080x1080 (matches square inference cameras).
- Widens PKL-loaded shape-key slider range to ±10 so animation imports don't clip large PCA betas.
- Rig and sidecar cameras are scaled by 10× on import (camera focal length and camera object scale untouched) to bridge PyTorch3D ↔ Blender natural units.
- Imported armature + cameras grouped under a `SMIL_Animation_Root` empty so the whole inferred scene can be oriented/rotated as one (mesh stays parented to the armature to preserve the Armature modifier).

### Phase 3 — shareable export
- New **Export animated model as glTF** button directly below the import button, auto-greyed via `poll()` until an import succeeds.
- Wraps Blender's built-in `bpy.ops.export_scene.gltf` with `use_selection=True` and the imported tree selected; restores prior selection afterwards; surfaces any exporter exception as a Blender warning.
- Verified to produce output identical to triggering the built-in glTF export window manually.

### Multi-view inference quality-of-life
- `--generate_num_subclips N` produces N evenly-spaced subclips of `--max_frames` length, with frame-range suffixes on every artifact (videos + animation export). Falls back to a single full-dataset clip if subclips can't fit.
- `_compute_rank_indices` now takes `start_idx`/`end_idx` (was `max_frames`).
- `--disable_translation` upgraded to `BooleanOptionalAction` so `--no-disable_translation` re-enables translation from the CLI.
- Multi-view inference visualization now goes through the shared multiview visualization helper, writing AVI/MJPG with wrapped layouts; training visualization shares the same helper.

## Test plan
- [x] Phase 1 round-trip unit tests (`tests/test_animation_export.py`)
- [x] Multi-view inference smoke run with `--export_animation` (400 frames, ViT-L stick AUG, `--no-disable_translation`)
- [x] Multi-view inference subclip mode smoke run (artifacts named `*_frames{start:06d}-{end:06d}.{npz,json,mp4}`)
- [x] End-to-end Blender 4.2 import of `.npz` produced by this branch
- [x] Importer scaling / square render default / shape-key range / scene-root empty
- [x] glTF export button output identical to Blender's native glTF export dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)