### PR TITLE
Multi-view replicAnt dataset integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,12 @@ extra_videos/
 exported/
 smpl_webuser/
 download/
+
+# scratch diagnostics (probes, smoke HDF5s, ad-hoc inspectors)
+probe_*.py
+inspect_smoke*.py
+roundtrip_smoke*.py
+SMOKE_*.h5
+SMOKE_*.json
+SMOKE_*/
+*_SMOKE_TEST.json

--- a/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
+++ b/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
@@ -11,6 +11,28 @@ This document outlines the architecture for integrating multi-camera replicAnt d
 
 ---
 
+## Status (2026-06-01)
+
+| Phase | What | State |
+|---|---|---|
+| 1 | `load_SMIL_Unreal_multiview_sample` loader | **COMPLETE** |
+| 3 | HDF5 preprocessor (`replicAntMultiViewPreprocessor`) | **NEXT** |
+| 4 | `UnifiedSMILDataset.from_path()` auto-detection | pending |
+| 2 | `MultiViewreplicAntSMILDataset` PyTorch test seam | pending, low priority |
+| 5 | Single-view sampler | deferred per design |
+| — | Step-0 smoke test (preprocess + short training) | follows Phase 3 |
+
+**Phase 1 highlights** (see commit history on `multiview-replicant-integration`):
+- Canonical-camera-frame storage (lowest CAM ID → R=I, t=0), forward-transform `canonical_to_world` for round-trip
+- Depth-buffer self-occlusion visibility refinement at load time (commit `eb5b5f8`)
+- Explicit `keypoint_in_dataset_per_view` bitmap so model-only joints stay invisible regardless of where the `[0, 0]` sentinel lands (commit `600f913`)
+- Diagnostics: `tests/validate_multiview_replicant_loader.py` (`--compare_frames`, `--named_overlay`) and `smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py`
+- Empirical: 0.00 px reprojection error on 12 cameras (frame 0), 7.6e-06 max abs round-trip on 3D keypoints, canonical-cam extrinsics R=I and t=0 to numerical precision, 328 → 259 keypoints kept after depth refinement on frame 100 (mouse model)
+
+**Important architectural shift from the original draft** — depth handling: the depth-buffer self-occlusion check runs at load time inside the loader, not as a post-process on stored bytes. The HDF5 schema therefore does NOT include a `/multiview_depth/` group, and the preprocessor does NOT take an `--include_depth_map` flag. Depth parameters are pass-through CLI args, recorded in `/metadata` attrs for reproducibility. See §Phase 3 below.
+
+---
+
 ## Current Architecture Analysis
 
 ### Single-View Data Pipeline
@@ -95,8 +117,8 @@ SLEAP sessions (multiple cameras per frame)
   frame_idx[num_samples]
   session_name[num_samples] (vlen str)                      # replicAnt: dataset name
   camera_names[num_samples, max_views] (vlen str)           # canonical camera name per slot
-  canonical_to_world_R[num_samples, 3, 3]                   # inverse of per-frame canonical-camera-frame
-  canonical_to_world_t[num_samples, 3]                      # ↳ enables round-trip to raw world coords
+  canonical_to_world_R[num_samples, 3, 3]                   # = R_0; FORWARD world->canonical transform
+  canonical_to_world_t[num_samples, 3]                      # = t_0; invert as (x_can - t_0) @ R_0.T to recover raw world
 ```
 
 **Note on the frame convention**: All `R`, `t`, `trans`, `global_rot`, and
@@ -160,7 +182,7 @@ replicAnt-dataset-multi-cam-mice/
      - `.JPG` — RGB image (always present)
      - `.json` — per-camera metadata (always present)
      - `_ID_CAM{id}.png` — ID/visibility mask (always present)
-     - `_Depth_CAM{id}.png` — depth map (optional; loaded only when `--include_depth_map` is set)
+     - `_Depth_CAM{id}.png` — depth map (loaded by the multi-view loader when `depth_occlusion_check=True`; falls back silently to ID-mask-only visibility if missing)
 3. **Per-camera metadata** (in `.json` files):
    - Same format as single-view replicAnt JSON
    - Contains camera parameters (view matrix, FOV, location, rotation)
@@ -175,101 +197,86 @@ replicAnt-dataset-multi-cam-mice/
 
 ## Implementation Strategy
 
-### Phase 1: Extend Unreal2Pytorch3D.py
+### Phase 1: `load_SMIL_Unreal_multiview_sample` — COMPLETE
 
-**New Functions** (add without breaking existing ones):
+Implemented in `smal_fitter/Unreal2Pytorch3D.py`. The original draft is gone; this section documents the **landed API** for downstream consumers (Phase 3 preprocessor, validation diagnostics).
+
+**Signature**:
 
 ```python
 def load_SMIL_Unreal_multiview_sample(
-    data_path,                # Path to dataset directory
-    frame_index,              # Frame number (0-padded as needed)
-    camera_indices=None,      # List of camera indices to load (None = all)
-    plot_tests=False,
-    propagate_scaling=True,
-    translation_factor=0.01,
-    load_images=True,
-    verbose=False
+    data_path: str,
+    frame_index: int,
+    camera_indices: list = None,           # None -> all cameras present for that frame
+    propagate_scaling: bool = True,
+    translation_factor: float = 0.01,
+    load_images: bool = True,
+    canonical_frame: bool = True,          # canonical-camera-frame storage on by default
+    depth_occlusion_check: bool = True,    # depth-buffer self-occlusion refinement
+    depth_max_cm: float = 1000.0,
+    depth_tolerance_cm: float = 5.0,
+    depth_neighborhood: int = 1,           # half-window, so 1 => 3x3 patch
+    verbose: bool = False,
 ) -> Tuple[Dict, Dict]:
-    """
-    Load multi-view replicAnt data from a flat-directory dataset for a specific frame.
-    
-    Dataset structure:
-    - Flat directory: {dataset_name}_{frame_idx:05d}_CAM{cam_id}.{ext}
-    - Per-camera files: .json (metadata), .JPG (image), _ID_CAM{id}.png (visibility mask)
-    - Synchronized frames: all cameras for same frame_idx are temporally aligned
-    - Shared pose/shape: identical across all cameras (only camera params differ)
-    
-    Args:
-        data_path: Path to dataset directory
-        frame_index: Frame number to load (e.g., 0, 1, 2, ...)
-        camera_indices: List of camera IDs to load (e.g., [1, 2, 3] or None for all)
-        
-    Returns:
-        x_output: Dictionary with per-view data
-            - image_paths: List[str] - paths to images per camera
-            - image_data: List[np.ndarray] - loaded images, shape (H, W, 3)
-            - mask_data: List[np.ndarray] - per-camera ID/visibility masks, shape (H, W)
-            - mask_paths: List[str] - paths to ID map files
-            - num_views: int - number of views loaded
-            - camera_ids: List[int] - camera IDs in order
-            
-        y_output: Dictionary with shared + per-view data
-            - pose_data: dict - raw pose data (from first camera)
-            - joint_angles: np.ndarray[n_joints, 3] - shared joint rotations
-            - joint_names: list - joint names
-            - shape_betas: np.ndarray[n_betas] - shared shape
-            
-            - cam_rot_per_view: List[np.ndarray] - rotation matrices per camera [3, 3]
-            - cam_trans_per_view: List[np.ndarray] - translation vectors per camera [3]
-            - fx_per_view: List[float] - focal length X per camera
-            - fy_per_view: List[float] - focal length Y per camera
-            - cx_per_view: List[float] - principal point X per camera
-            - cy_per_view: List[float] - principal point Y per camera
-            
-            - keypoints_2d_per_view: List[np.ndarray] - normalized 2D keypoints per camera
-            - keypoint_visibility_per_view: List[np.ndarray] - **PER-CAMERA VISIBILITY**
-                                           computed as: in_bounds AND (id_mask_pixel > 0)
-    """
-    # 1. Detect camera count and dataset name from _BatchData_*.json
-    # 2. Determine which camera indices to load (all or subset)
-    # 3. Build the per-frame canonical camera list:
-    #    a. Sort the resolved camera indices ascending.
-    #    b. The lowest-index resolved camera becomes canonical slot 0
-    #       (defines the per-frame world frame: R=I, t=0).
-    #    c. Subsequent resolved cameras fill slots 1..N-1 in order.
-    # 4. From the canonical-slot-0 camera's JSON:
-    #    a. Extract shared pose, shape, joint_angles via load_SMIL_Unreal_sample()
-    #       (or its inner helpers) to get raw world-frame values.
-    #    b. Capture (R_0, t_0) as canonical_to_world for the inverse transform.
-    # 5. For each canonical slot v:
-    #    a. Parse that camera's JSON (extrinsics + intrinsics).
-    #    b. Load image and ID mask.
-    #    c. Compute per-view keypoint visibility (see below).
-    # 6. Re-express in canonical-camera frame (see "Frame Convention" section):
-    #    a. Per-view extrinsics: (R_v, t_v) → relative to (R_0, t_0).
-    #    b. Model trans, global_rot, keypoints_3d → re-expressed in canonical frame.
-    # 7. Return consolidated multi-view data + canonical_to_world for round-trip.
 ```
 
-**Key Implementation Details**:
-- All output is in **canonical-camera frame** (see Frame Convention section below).
-  The raw world-frame values are computed internally then transformed; only the
-  transformed values plus `canonical_to_world = (R_0, t_0)` are returned.
-- Per-camera parameters extracted independently from each camera's JSON.
-- Per-camera ID masks loaded from `_ID_CAM{id}.png` files.
-- Per-camera visibility uses the existing `compute_keypoint_visibility()` logic:
-  ```python
-  visibility[cam] = 1.0 if (
-      keypoint within image bounds [0, 1] AND
-      id_mask[int(norm_y * H), int(norm_x * W)] > 0
-  ) else 0.0
-  ```
-- ID mask files follow pattern: `{dataset_name}_{frame_idx:05d}_ID_CAM{cam_id}.png`.
+**Behaviour**:
+- Auto-detects `dataset_name` and frame count from `_BatchData_*.json`.
+- Builds canonical camera ordering from `sorted(camera_indices)`; the lowest-numbered camera present this frame becomes canonical slot 0.
+- Maps each camera's keypoints into model `J_names` order; tracks an in-dataset bitmap so model-only joints (no dataset GT) stay invisible regardless of mask content.
+- Per-view visibility = `in_dataset AND in_bounds AND id_mask_pass AND depth_pass` (depth term skipped when `depth_occlusion_check=False` or the `_Depth_CAM{id}.png` file is missing).
+- When `canonical_frame=True` (default), re-expresses all camera extrinsics, model `root_loc`, `root_rot`, and `keypoints_3d` relative to canonical cam 0. Emits `canonical_to_world = (R_0, t_0)` as the forward transform; the inverse `x_world = (x_can - t_0) @ R_0.T` recovers the original world frame.
 
-**Backward Compatibility**: 
-- Keep `load_SMIL_Unreal_sample()` unchanged
-- Add `load_SMIL_Unreal_multiview_sample()` as new function
-- Both work with existing code paths
+**`x_output` schema**:
+```python
+{
+    "image_data":         List[np.ndarray | None],  # V x (H, W, 3) uint8 (None when load_images=False)
+    "image_paths":        List[str],                 # V
+    "input_image_mask":   List[np.ndarray | None],   # V x (H, W) binary id mask
+    "mask_paths":         List[str],                 # V
+    "depth_paths":        List[str],                 # V — file paths only, no in-memory depth
+    "num_views":          int,
+    "camera_ids":         List[int],                 # sorted ascending; index 0 == canonical
+}
+```
+
+**`y_output` schema** (shared fields first, then per-view):
+```python
+{
+    # Shared across all cameras
+    "shape_betas":        np.ndarray,                # (n_betas,)
+    "joint_angles":       np.ndarray,                # (n_joints, 3) axis-angle, J_names order
+    "joint_names":        list,                      # config.dd["J_names"]
+    "root_loc":           np.ndarray,                # (3,)   canonical-frame translation
+    "root_rot":           np.ndarray,                # (3,)   canonical-frame axis-angle
+    "scale_weights":      np.ndarray | None,         # PCA scale weights (if present in JSON)
+    "trans_weights":      np.ndarray | None,         # PCA trans weights (if present in JSON)
+    "translation_factor": float,
+    "propagate_scaling":  bool,
+    "pose_data":          dict,                      # raw cam-0 keypoints dict (back-compat)
+    "keypoints_3d":       np.ndarray,                # (n_joints, 3) canonical frame, J_names order
+    "keypoints_3d_world": np.ndarray,                # (n_joints, 3) raw PyTorch3D-mirrored world frame
+    "canonical_to_world": (np.ndarray, np.ndarray),  # (R_0 (3,3), t_0 (3,)) forward transform
+    "canonical_cam_id":   int,                       # canonical cam ID, or -1 when canonical_frame=False
+
+    # Per-view (V entries each)
+    "keypoints_2d_per_view":        List[np.ndarray],   # V x (n_joints, 2) [y/H, x/W] axis-swapped
+    "keypoint_visibility_per_view": List[np.ndarray],   # V x (n_joints,) float {0, 1}
+    "keypoint_in_dataset_per_view": List[np.ndarray],   # V x (n_joints,) bool — has dataset GT
+    "cam_rot_per_view":             List[torch.Tensor], # V x (3, 3) row-vector world->cam
+    "cam_trans_per_view":           List[torch.Tensor], # V x (3,)
+    "fx_per_view", "fy_per_view":   List[float],        # V
+    "cx_per_view", "cy_per_view":   List[float],        # V
+    "fov_per_view":                 List[float],        # V (degrees, from camera JSON)
+}
+```
+
+**Conventions to be aware of when consuming this**:
+- 2D keypoints are stored with an **intentional axis swap**: `kp[:, 0] = 2DPos.y / H`, `kp[:, 1] = 2DPos.x / W`. Downstream ID-mask and depth lookups depend on this. Don't "fix" without updating both sides.
+- All extrinsics and 3D points are in **PyTorch3D-mirrored** convention (x-axis negated vs raw Unreal). Projection: `u = -fx * X_cam.x / X_cam.z + cx`, `v = -fy * X_cam.y / X_cam.z + cy`.
+- `keypoint_in_dataset_per_view` is True iff the joint name appears in that camera's `keypoints` dict. Use it to distinguish "missing from dataset" from "present but culled by ID/depth".
+
+**Backward compatibility**: `load_SMIL_Unreal_sample()` (single-view) is unchanged.
 
 ---
 
@@ -336,6 +343,9 @@ class MultiViewreplicAntSMILDataset(torch.utils.data.Dataset):
             x_output: Dict with per-view images and masks
             y_output: Dict with shared pose + per-view camera parameters
         """
+        # The loader defaults (canonical_frame=True, depth_occlusion_check=True)
+        # match what the preprocessor uses, so production-side training stays
+        # byte-equivalent to direct-loader sampling for tests.
         x, y = load_SMIL_Unreal_multiview_sample(
             data_path=self.data_path,
             frame_index=idx,
@@ -343,88 +353,114 @@ class MultiViewreplicAntSMILDataset(torch.utils.data.Dataset):
             propagate_scaling=True,
             translation_factor=0.01,
             load_images=True,
-            verbose=False
         )
-        
-        # Convert rotation representations if needed
+
         if self.rotation_representation == '6d':
-            # Convert root rotation and joint angles
             if 'root_rot' in y:
                 y['root_rot'] = axis_angle_to_rotation_6d(y['root_rot'])
             if 'joint_angles' in y:
                 y['joint_angles'] = axis_angle_to_rotation_6d(y['joint_angles'])
-        
+
         return x, y
-        
+
     def __len__(self):
         return self.num_frames
 ```
 
 ---
 
-### Phase 3: Preprocessing to HDF5
+### Phase 3: HDF5 preprocessor — NEXT
 
-**New module**: `smal_fitter/sleap_data/preprocess_replicant_multiview_dataset.py` —
-sibling of `preprocess_sleap_multiview_dataset.py`, with the same output schema so
-`SLEAPMultiViewDataset` and `train_multiview_regressor.py` consume it unchanged.
+**New module**: `smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py`. Lives alongside `visualize_multiview_depth_occlusion.py` in the `replicAnt_data` package. (NOT in `sleap_data/` — the SLEAP and replicAnt code paths are siblings, not nested.)
 
-**Class**: `replicAntMultiViewPreprocessor`
+**Output schema**: identical to `SLEAPMultiViewDataset`'s expected HDF5 layout (`/metadata`, `/multiview_images`, `/multiview_keypoints`, `/parameters`, `/auxiliary` — see the SLEAP overview section above for the full table). The trainer (`train_multiview_regressor.py`) consumes both paths interchangeably.
+
+`canonical_camera_order` in `/metadata` attrs is `["CAM1", "CAM2", ...]` derived from `sorted(camera_indices)` on the first scanned frame.
+
+**Class**:
 
 ```python
 class replicAntMultiViewPreprocessor:
     def __init__(
         self,
-        target_resolution: int = 224,
-        backbone_name: str = 'vit_large_patch16_224',
+        target_resolution: int = 512,         # store at native; dataset class resizes at train time
+        backbone_name: str = "vit_large_patch16_224",
         jpeg_quality: int = 95,
         chunk_size: int = 8,
-        compression: str = 'gzip',
+        compression: str = "gzip",
         compression_level: int = 6,
         frame_skip: int = 1,
         camera_subset: Optional[List[int]] = None,
-        include_depth_map: bool = False,        # gate for /multiview_depth/ group
+        # Depth visibility-refinement passthrough to the loader.
+        # Defaults match load_SMIL_Unreal_multiview_sample.
+        depth_occlusion_check: bool = True,
+        depth_max_cm: float = 1000.0,
+        depth_tolerance_cm: float = 5.0,
+        depth_neighborhood: int = 1,
         propagate_scaling: bool = True,
         translation_factor: float = 0.01,
         debug: bool = False,
     ):
         ...
 
-    def preprocess(self, input_dir: str, output_hdf5: str, num_workers: int = 8):
-        """Produce an HDF5 file that matches the SLEAPMultiViewDataset schema."""
+    def preprocess(self, input_dir: str, output_hdf5: str,
+                   num_workers: int = 8,
+                   max_frames: Optional[int] = None) -> None:
+        """Produce an HDF5 matching the SLEAPMultiViewDataset schema."""
 ```
 
-**Output schema**: identical to the schema documented in the SLEAP overview above
-(`/metadata`, `/multiview_images`, `/multiview_keypoints`, `/parameters`,
-`/auxiliary`). `canonical_camera_order` is `["CAM1", "CAM2", ...]` derived from
-the first scanned frame.
+**Image storage**:
+- `/multiview_images/image_jpeg_view_{v}` as `vlen uint8` (JPEG-encoded). `jpeg_quality=95`.
+- Stored at the **native 512x512** of the replicAnt source. The dataset class resizes to backbone input size at training time. This keeps the HDF5 backbone-agnostic at the cost of ~2x disk versus pre-resizing to 224. Re-evaluate if disk pressure becomes real.
+- 12 cams x 10k frames lands in the ~5-10 GB range vs ~90 GB raw.
 
-**Image storage** (matches SLEAP preprocessor):
-- Per-view images are **JPEG-encoded in the HDF5** as variable-length `uint8` arrays
-  under `/multiview_images/image_jpeg_view_{v}` (one dataset per view slot).
-- `jpeg_quality` defaults to 95 (same as SLEAP path).
-- This keeps the 12-cam × 10k-frame replicAnt clip in the ~5–10 GB range rather
-  than ~90 GB raw.
+**Depth handling (architectural shift vs original draft)**:
+- Depth-buffer self-occlusion is applied at **load time** by `load_SMIL_Unreal_multiview_sample` (Phase 1). The HDF5 stores depth-refined visibility under `/multiview_keypoints/keypoint_visibility`.
+- **No `/multiview_depth/` group is written. No `--include_depth_map` flag exists.** Raw depth PNGs are not persisted in the HDF5.
+- The preprocessor passes the four depth knobs straight through to the loader and records the values used as `/metadata` attrs so the visibility computation is reproducible:
+  ```
+  /metadata attrs (depth additions vs SLEAP schema):
+    depth_occlusion_check: bool
+    depth_max_cm:          float
+    depth_tolerance_cm:    float
+    depth_neighborhood:    int
+  ```
+- **Implication**: changing the depth thresholds requires re-preprocessing. If a future caller needs runtime-tunable thresholds, the lowest-friction option is to add the `/multiview_depth/` group at that point and refresh from stored bytes. Keep the schema minimal until that need is proven.
 
 **Failure handling**:
-- Frames that fail to load any view (corrupt JSON, missing files, projection
-  failure, etc.) are **flagged and skipped**: the preprocessor logs the
-  `(frame_idx, reason)` and continues with the next `idx`. A summary count is
-  printed at the end and stored in `/metadata` attrs (`num_skipped_frames`,
-  `skipped_frame_indices`).
-- Per-camera failures within an otherwise-loadable frame mark just that view's
-  `view_mask[i, v] = False` and `camera_indices[i, v] = -1`; the frame is kept
-  as long as ≥1 view loads.
+- Per-frame: load failures (corrupt JSON, missing image, projection failure, etc.) are caught, logged as `(frame_idx, reason)`, and skipped. A summary count plus the skipped index list are written to `/metadata` attrs (`num_skipped_frames`, `skipped_frame_indices`).
+- Per-camera within a kept frame: failures mark just that view's `view_mask[i, v] = False` and `camera_indices[i, v] = -1`. Frame kept as long as >= 1 view loads.
+- HDF5 uses **contiguous sample slots**: `num_samples = number of successfully preprocessed frames`. The mapping back to source frame numbers is via `/auxiliary/frame_idx[sample_idx]`. There are no gaps in the sample axis.
 
-**Optional depth (`--include_depth_map`)**:
-- When set, an additional `/multiview_depth/` group is written:
-  ```
-  /multiview_depth/
-    depth_png_view_{v}[num_samples] (vlen uint8)    # PNG-encoded raw depth
-    depth_mask[num_samples, max_views]              # 1 if depth present, 0 otherwise
-  ```
-- When unset (default), depth files are ignored even if present on disk.
-- Future self-occlusion visibility refinement will read this group when
-  available; the trainer does not require it.
+**Parallelism**:
+- `concurrent.futures.ProcessPoolExecutor` with default 8 workers, one frame per task.
+- Each worker calls `load_SMIL_Unreal_multiview_sample`, JPEG-encodes the per-view images, returns a typed dict to the main process.
+- Main process drains the result queue in input order and writes to HDF5 sequentially (HDF5 is not thread-safe).
+- Workers must call `apply_smal_file_override(smal_file)` and `import config` at init, then `from Unreal2Pytorch3D import load_SMIL_Unreal_multiview_sample`. Use a top-level worker `initializer` function passed to the ProcessPoolExecutor — this is how `apply_smal_file_override` flows into each child.
+
+**Streaming HDF5 write**:
+- Pre-allocate all fixed-shape datasets at `num_samples_alloc = ceil(num_input_frames / frame_skip)`; resize down at the end after counting actual successes.
+- Apply `chunks=(chunk_size, ...)` and `compression="gzip"`, `compression_opts=6` on every dataset.
+- The vlen `uint8` JPEG datasets use `dtype=h5py.vlen_dtype(np.uint8)` and grow by per-sample element assignment.
+
+**CLI** (inside `__main__`):
+```
+--input_dir          (required)  flat-directory replicAnt dataset
+--output_hdf5        (required)
+--smal_file                       SMAL/SMIL .pkl matching the dataset's skeleton
+--shape_family                    optional
+--num_workers        8
+--jpeg_quality       95
+--chunk_size         8
+--frame_skip         1
+--camera_subset                   optional, list of ints
+--max_frames                      optional; for Step-0 smoke testing
+--depth_occlusion_check           default True; --no_depth_occlusion_check to disable
+--depth_max_cm       1000.0
+--depth_tolerance_cm 5.0
+--depth_neighborhood 1
+--debug              flag
+```
 
 ---
 
@@ -600,47 +636,35 @@ y_data = {
 
 ## Files to Create/Modify
 
-### New Files:
-1. `smal_fitter/sleap_data/preprocess_replicant_multiview_dataset.py` —
-   `replicAntMultiViewPreprocessor`, writes the SLEAP-compatible HDF5 schema.
-2. `smal_fitter/neuralSMIL/multiview_replicant_dataset.py` —
-   `MultiViewreplicAntSMILDataset` (test seam; thin wrapper around
-   `load_SMIL_Unreal_multiview_sample`).
-3. CLI entry, either:
-   - extend an existing `preprocess_dataset.py`, or
-   - add `smal_fitter/sleap_data/preprocess_replicant_multiview_dataset.py`'s
-     own `__main__` block (matches the SLEAP equivalent).
+### New Files (pending):
+1. `smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py` — `replicAntMultiViewPreprocessor` + `__main__` CLI. **Phase 3, NEXT.**
+2. `smal_fitter/neuralSMIL/multiview_replicant_dataset.py` — `MultiViewreplicAntSMILDataset` (Phase 2, test seam only; production reads HDF5).
 
-### Modify Existing Files:
-1. `smal_fitter/Unreal2Pytorch3D.py` — already contains the Phase 1 draft of
-   `load_SMIL_Unreal_multiview_sample()` (uncommitted). Needs cleanup +
-   reparameterisation parity with `load_SMIL_Unreal_sample()` (see Open Items).
-2. `smal_fitter/neuralSMIL/smil_datasets.py` — extend
-   `UnifiedSMILDataset.from_path()` with the flat-directory `_CAM*.json`
-   detection branch.
+### Modified Files:
+1. `smal_fitter/Unreal2Pytorch3D.py` — **Phase 1 complete.** Multi-view loader with canonical-frame storage and depth visibility refinement. See §Status for commit references.
+2. `smal_fitter/replicAnt_data/__init__.py` — created during Phase 1's depth work; advertises the planned preprocessor.
+3. `smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py` — created during Phase 1; per-view depth-occlusion diagnostic.
+4. `smal_fitter/neuralSMIL/smil_datasets.py` — **Phase 4**: extend `UnifiedSMILDataset.from_path()` with the flat-directory `_CAM*.json` detection branch.
 
 ### No Changes Needed:
-- `train_multiview_regressor.py`, `multiview_smil_regressor.py`,
-  `sleap_multiview_dataset.py` — Phase 3 produces an HDF5 that already
-  matches the SLEAP schema.
-- `train_smil_regressor.py`, `smil_image_regressor.py` — touched only when the
-  single-view sampler is added later.
+- `train_multiview_regressor.py`, `multiview_smil_regressor.py`, `sleap_multiview_dataset.py` — Phase 3 produces an HDF5 that already matches the SLEAP schema.
+- `train_smil_regressor.py`, `smil_image_regressor.py` — single-view sampler is Phase 5 (deferred).
 
 ---
 
 ## Implementation Order
 
-1. **Step 1**: Clean up the Phase 1 draft in `Unreal2Pytorch3D.py`
-   (deduplicate imports, add coord-swap comment, add reparameterisation —
-   see Open Items).
-2. **Step 2**: Add `MultiViewreplicAntSMILDataset` (test seam).
-3. **Step 3**: Implement `replicAntMultiViewPreprocessor` + CLI (matches
-   SLEAP HDF5 schema; JPEG-encoded images; optional `--include_depth_map`).
-4. **Step 4**: Extend `UnifiedSMILDataset.from_path()` auto-detection.
-5. **Step 5**: Round-trip tests
-   (load → preprocess → SLEAPMultiViewDataset → assert tensor shapes/contents).
-6. **Step 6**: Example multiview config under
-   `smal_fitter/neuralSMIL/configs/examples/`.
+1. **Step 1** — Phase 1 loader: canonical-frame storage, depth visibility refinement, in-dataset bitmap. **DONE** (see §Status).
+2. **Step 2** [NEXT] — Phase 3: implement `replicAntMultiViewPreprocessor` and `__main__` CLI.
+3. **Step 3** — Step-0 smoke test (see §"Open empirical question" near the bottom):
+   - Preprocess `--max_frames 500` to a small HDF5.
+   - HDF5 round-trip check: open via `SLEAPMultiViewDataset`, take sample 0, apply inverse `canonical_to_world` (`R_0.T`, `-t_0 @ R_0.T`) to `keypoints_3d`, assert <= 1e-3 against the loader's `keypoints_3d_world` for the same source frame.
+   - Short multi-view training run (~50 epochs on the 500-frame subset). Pass criterion: per-view reprojection loss converges normally; `trans` head behaves under direct supervision.
+4. **Step 4** — Phase 4: extend `UnifiedSMILDataset.from_path()` auto-detection.
+5. **Step 5** — Phase 2: add `MultiViewreplicAntSMILDataset` test seam (low priority; production reads HDF5).
+6. **Step 6** — Example multi-view config JSON under `smal_fitter/neuralSMIL/configs/examples/`.
+
+After Step 3 passes, the full preprocess (all 10k frames) and the production training run unblock; everything else above is wrap-up.
 
 ---
 
@@ -676,17 +700,28 @@ This convention:
   and 2D reprojections are byte-equivalent to the raw world-frame version.
 - Has a clean bridge to single-view sampling: one composition folds canonical
   cam → selected cam → model-at-origin, producing samples byte-equivalent to
-  the existing single-view `load_SMIL_Unreal_sample()` output. (Out of scope
-  for this PR, but the design supports it.)
+  the existing single-view `load_SMIL_Unreal_sample()` output. (Phase 5,
+  deferred per §Status; the design supports it.)
 
 ### Inverse transform stored for validation
 
 The canonical-camera-frame conversion is reversible. Store the per-frame
-canonical-camera-to-world rigid transform under `/auxiliary/canonical_to_world`
-(`R: (num_samples, 3, 3)`, `t: (num_samples, 3)`) so:
-- Tests can validate that round-tripping reproduces the raw extrinsics.
+**forward** world->canonical transform under
+`/auxiliary/canonical_to_world_R` and `/auxiliary/canonical_to_world_t`
+(equal to the canonical camera's row-vector extrinsics `(R_0, t_0)`).
+Consumers that need raw world coordinates apply the inverse explicitly:
+
+```python
+x_world = (x_canonical - t_0) @ R_0.T
+```
+
+We picked forward storage over storing the inverse because `(R_0, t_0)`
+is the artifact computed at the canonical site — storing it avoids
+drift from re-deriving, and the inverse is a one-liner at decode time.
+The field is used for:
+- Tests validating that round-tripping reproduces the raw extrinsics.
 - Downstream tools that *do* want absolute world coords (rendering at a
-  specific scene location, debugging procgen, etc.) can recover them.
+  specific scene location, debugging procgen, etc.) recovering them.
 - Training pipeline ignores this field; it's metadata only.
 
 For procedural replicAnt scenes the absolute world coordinates carry no
@@ -699,10 +734,10 @@ The SLEAP preprocessor currently stores camera extrinsics in the rig's
 calibration-tool-defined world frame. To keep both paths producing
 byte-equivalent on-disk conventions:
 
-- **TODO (separate change, not in this PR)**: apply canonical-camera-frame
-  normalisation in `preprocess_sleap_multiview_dataset.py` too. For SLEAP
-  this is a no-op for learning (rig is fixed, so it's a constant shift) but
-  makes the data format symmetric across the two paths.
+- **TODO (out of scope for the replicAnt preprocessor work)**: apply
+  canonical-camera-frame normalisation in `preprocess_sleap_multiview_dataset.py`
+  too. For SLEAP this is a no-op for learning (rig is fixed, so it's a
+  constant shift) but makes the data format symmetric across the two paths.
 
 ### Open empirical question (not blocking implementation)
 
@@ -736,15 +771,3 @@ gradient — not a "relearn" situation — so the risk is low.
   `trans` in the stored data (degrading to no direct supervision, matching
   past SLEAP behaviour).
 
-## Phase 1 cleanup (separate from frame convention)
-
-- Remove duplicate `from pathlib import Path` / `from typing import ...` /
-  `import re` lines inside the function body.
-- Add a comment near the `norm_x = ...['y'] / image_height` block flagging
-  that the x↔y swap matches the existing single-view convention.
-- Replace the current raw-extrinsics emission with canonical-camera-frame
-  output per the convention above. The function will compute the canonical
-  camera's `(R_0, t_0)` from the first resolved-on-disk camera index, then
-  re-express every per-view `(R_v, t_v)`, model `trans`, model `global_rot`,
-  and `keypoints_3d` relative to that frame. Store `canonical_to_world` as
-  `(R_0, t_0)` for round-trip validation.

--- a/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
+++ b/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
@@ -11,16 +11,19 @@ This document outlines the architecture for integrating multi-camera replicAnt d
 
 ---
 
-## Status (2026-06-01)
+## Status (2026-06-04)
 
 | Phase | What | State |
 |---|---|---|
 | 1 | `load_SMIL_Unreal_multiview_sample` loader | **COMPLETE** |
-| 3 | HDF5 preprocessor (`replicAntMultiViewPreprocessor`) | **NEXT** |
+| 1b | Scale unification: bake `translation_factor=0.1` into loader output | **COMPLETE (this PR)** |
+| 3 | HDF5 preprocessor (`replicAntMultiViewPreprocessor`) | **COMPLETE (this PR)** — round-trip byte-equivalent vs loader on smoke samples |
+| 6 | Example multi-view training config | **COMPLETE (this PR)** — `configs/examples/multiview_replicant_mice.json` |
 | 4 | `UnifiedSMILDataset.from_path()` auto-detection | pending |
 | 2 | `MultiViewreplicAntSMILDataset` PyTorch test seam | pending, low priority |
 | 5 | Single-view sampler | deferred per design |
-| — | Step-0 smoke test (preprocess + short training) | follows Phase 3 |
+| — | Step-0 smoke training run (short epochs on 500-frame subset) | follows preprocessor, separate session |
+| — | **Follow-up**: apply the same 0.1 rescale at load in `load_SMIL_Unreal_sample` (single-view) and flip single-view configs to `use_ue_scaling=False` | **TODO** |
 
 **Phase 1 highlights** (see commit history on `multiview-replicant-integration`):
 - Canonical-camera-frame storage (lowest CAM ID → R=I, t=0), forward-transform `canonical_to_world` for round-trip
@@ -29,7 +32,66 @@ This document outlines the architecture for integrating multi-camera replicAnt d
 - Diagnostics: `tests/validate_multiview_replicant_loader.py` (`--compare_frames`, `--named_overlay`) and `smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py`
 - Empirical: 0.00 px reprojection error on 12 cameras (frame 0), 7.6e-06 max abs round-trip on 3D keypoints, canonical-cam extrinsics R=I and t=0 to numerical precision, 328 → 259 keypoints kept after depth refinement on frame 100 (mouse model)
 
+**Phase 3 highlights** (this PR):
+- Preprocessor at `smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py`, schema identical to `SLEAPMultiViewDataset`'s expected HDF5 layout
+- Camera extrinsics stored in OpenCV form (`R_cv = Rz_180 @ R_p3d.T`, `t_cv = Rz_180 @ T_p3d`); `SLEAPMultiViewDataset._sleap_to_pytorch3d_camera` re-derives PyTorch3D values at dataset-load with byte equivalence to the loader output
+- Scale unification baked into the loader (Phase 1b), preprocessor advertises `world_scale=1.0`
+- ProcessPoolExecutor with `_worker_init` that runs `apply_smal_file_override` once per worker; per-frame failures logged and skipped, `/metadata.skipped_frame_indices` records the source indices
+- Smoke results (500 source frames, 8 workers, Falkner-conv repose mouse):
+  - 497 / 500 samples written, 3 skipped (frames 184, 435, 441 — `subject Data == []` in some camera's JSON; genuine dataset edge case where the rendered scene contained no mouse subject for that view)
+  - 545 s wall time ≈ 1.1 s / frame; HDF5 = 303 MB (~610 KB / sample, JPEG-dominated)
+  - I/O-bound at 8 workers (~20% CPU); more workers + cv2.imread switch are the cheap wins for the full 10 k preprocess
+  - **Round-trip check** at samples 0, 100, 250, 496 against fresh loader call for the same source frame: byte equivalence on `R_per_view`, `T_per_view`, `keypoints_2d`, `keypoint_visibility`, `keypoints_3d`, `parameters/{trans, global_rot, betas}`; `fov_per_view` matches to 2e-6 deg (numerical precision recomputing from K); `canonical_to_world` inverse recovers raw world frame to 1.4e-6
+  - Sample 250 maps to source frame 251 (skip-then-remap verified on the sample axis)
+
+**Known per-camera resilience gap** (out of scope for this PR): when a non-canonical camera's `subject Data` is empty (e.g. frames 435 / 441 above), the loader currently raises and the preprocessor skips the whole frame. The design called for marking just that view's `view_mask[i, v] = False` and keeping the rest of the frame (`§Phase 3 Failure handling`). Drop rate at 500 frames was 0.6%; ship as-is and refine the loader later.
+
 **Important architectural shift from the original draft** — depth handling: the depth-buffer self-occlusion check runs at load time inside the loader, not as a post-process on stored bytes. The HDF5 schema therefore does NOT include a `/multiview_depth/` group, and the preprocessor does NOT take an `--include_depth_map` flag. Depth parameters are pass-through CLI args, recorded in `/metadata` attrs for reproducibility. See §Phase 3 below.
+
+---
+
+## Scale Unification (Phase 1b — landed in this PR)
+
+The multi-view path drops the legacy split between data-side raw Unreal units
+and model-side `use_ue_scaling=True` ×10 mesh expansion. Empirical probe
+(`probe_scale.py`, see commit message) confirms a single scale factor of **0.1**
+makes mesh-native and data-frame units coincide:
+
+- SMAL mouse mesh native (Falkner-conv repose): root-centered max extent ≈ 1.38.
+- Raw replicAnt data: `‖root_loc‖ ≈ 146`, `‖cam_trans‖ ≤ 98`, `keypoints_3d`
+  bbox diag ≈ 99 — all in Unreal cm.
+- Configs `(mesh×10, data×1)` and `(mesh×1, data×0.1)` produce identical
+  per-view reprojection (max-abs deviation 0.02–0.11 normalised, ≈ 8–56 px at
+  512² — the inherent SMAL-forward noise floor, not a scale residual). Uniform
+  rescaling is projection-invariant.
+- The legacy `translation_factor=0.01` is wrong by 10×: `data×0.01` fails
+  reprojection by 700–1600 px. The 0.01 was only ever consumed by PCA
+  `betas_trans` sampling in `Render_SMAL_Model_from_Unreal_data`; it was never
+  a world-scale factor.
+
+**Multi-view convention (new):**
+- `load_SMIL_Unreal_multiview_sample(translation_factor=0.1, …)` is the new
+  default. The loader multiplies `root_loc`, `cam_trans_per_view`,
+  `keypoints_3d`, `keypoints_3d_world`, and `canonical_to_world_t` by
+  `translation_factor`. Output is in **model-world units** where
+  `mesh + trans` (no extra rescaling) projects correctly.
+- HDF5 metadata: `world_scale = 1.0`. No downstream rescaling.
+- Multi-view training configs: `use_ue_scaling: false` and the model uses the
+  `joints + trans` placement branch (no recenter-and-rescale).
+
+**Single-view convention (UNCHANGED, legacy):**
+- `load_SMIL_Unreal_sample(translation_factor=0.01, …)` returns raw Unreal
+  coords; `translation_factor` is stored but does NOT scale `root_loc` /
+  `cam_trans` / `keypoints_3d` (it only scales PCA-sampled `betas_trans`).
+- Single-view training uses `use_ue_scaling=True` so the model applies
+  `(mesh - root) * 10 + trans` at output. This compensates for the data
+  being in raw Unreal cm.
+- **TODO follow-up (out of scope for this PR)**: apply the same 0.1 rescale at
+  load in `load_SMIL_Unreal_sample`; flip single-view configs to
+  `use_ue_scaling=False`; retest `optimize_to_joints.py`,
+  `train_smil_regressor.py`, and `run_singleview_inference.py`. Verify saved
+  single-view checkpoints under the new convention (or gate via metadata).
+  Use `probe_scale.py` as the empirical template before changing anything.
 
 ---
 
@@ -209,7 +271,7 @@ def load_SMIL_Unreal_multiview_sample(
     frame_index: int,
     camera_indices: list = None,           # None -> all cameras present for that frame
     propagate_scaling: bool = True,
-    translation_factor: float = 0.01,
+    translation_factor: float = 0.1,       # Phase 1b: scale-unifies mesh + data frames
     load_images: bool = True,
     canonical_frame: bool = True,          # canonical-camera-frame storage on by default
     depth_occlusion_check: bool = True,    # depth-buffer self-occlusion refinement
@@ -226,6 +288,7 @@ def load_SMIL_Unreal_multiview_sample(
 - Maps each camera's keypoints into model `J_names` order; tracks an in-dataset bitmap so model-only joints (no dataset GT) stay invisible regardless of mask content.
 - Per-view visibility = `in_dataset AND in_bounds AND id_mask_pass AND depth_pass` (depth term skipped when `depth_occlusion_check=False` or the `_Depth_CAM{id}.png` file is missing).
 - When `canonical_frame=True` (default), re-expresses all camera extrinsics, model `root_loc`, `root_rot`, and `keypoints_3d` relative to canonical cam 0. Emits `canonical_to_world = (R_0, t_0)` as the forward transform; the inverse `x_world = (x_can - t_0) @ R_0.T` recovers the original world frame.
+- **Phase 1b scale unification**: multiplies `root_loc`, `cam_trans_per_view`, `keypoints_3d`, `keypoints_3d_world`, and `canonical_to_world_t` by `translation_factor` (default 0.1). Output lands in model-world units where downstream `mesh + trans` (no `×10` model-side rescaling) projects correctly. Pass `translation_factor=1.0` to disable.
 
 **`x_output` schema**:
 ```python
@@ -274,7 +337,7 @@ def load_SMIL_Unreal_multiview_sample(
 **Conventions to be aware of when consuming this**:
 - 2D keypoints are stored with an **intentional axis swap**: `kp[:, 0] = 2DPos.y / H`, `kp[:, 1] = 2DPos.x / W`. Downstream ID-mask and depth lookups depend on this. Don't "fix" without updating both sides.
 - All extrinsics and 3D points are in **PyTorch3D-mirrored** convention (x-axis negated vs raw Unreal). Projection: `u = -fx * X_cam.x / X_cam.z + cx`, `v = -fy * X_cam.y / X_cam.z + cy`.
-- `keypoint_in_dataset_per_view` is True iff the joint name appears in that camera's `keypoints` dict. Use it to distinguish "missing from dataset" from "present but culled by ID/depth".
+- `keypoint_in_dataset_per_view` is True if the joint name appears in that camera's `keypoints` dict. Use it to distinguish "missing from dataset" from "present but culled by ID/depth".
 
 **Backward compatibility**: `load_SMIL_Unreal_sample()` (single-view) is unchanged.
 
@@ -369,7 +432,7 @@ class MultiViewreplicAntSMILDataset(torch.utils.data.Dataset):
 
 ---
 
-### Phase 3: HDF5 preprocessor — NEXT
+### Phase 3: HDF5 preprocessor — COMPLETE (this PR)
 
 **New module**: `smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py`. Lives alongside `visualize_multiview_depth_occlusion.py` in the `replicAnt_data` package. (NOT in `sleap_data/` — the SLEAP and replicAnt code paths are siblings, not nested.)
 
@@ -398,7 +461,7 @@ class replicAntMultiViewPreprocessor:
         depth_tolerance_cm: float = 5.0,
         depth_neighborhood: int = 1,
         propagate_scaling: bool = True,
-        translation_factor: float = 0.01,
+        translation_factor: float = 0.1,      # Phase 1b: matches loader default
         debug: bool = False,
     ):
         ...
@@ -636,35 +699,47 @@ y_data = {
 
 ## Files to Create/Modify
 
-### New Files (pending):
-1. `smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py` — `replicAntMultiViewPreprocessor` + `__main__` CLI. **Phase 3, NEXT.**
-2. `smal_fitter/neuralSMIL/multiview_replicant_dataset.py` — `MultiViewreplicAntSMILDataset` (Phase 2, test seam only; production reads HDF5).
+### New Files (landed this PR):
+1. `smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py` — `replicAntMultiViewPreprocessor` + `__main__` CLI. **Phase 3 COMPLETE.**
+2. `smal_fitter/replicAnt_data/test_replicant_preprocessing.py` — manual-run round-trip check (HDF5 ↔ `SLEAPMultiViewDataset` ↔ loader byte-equivalence on per-view R, T, K, keypoints, parameters, canonical_to_world inverse).
+3. `smal_fitter/neuralSMIL/configs/examples/multiview_replicant_mice.json` — baseline production multi-view training config with `use_ue_scaling: false`. **Phase 6 COMPLETE.**
 
-### Modified Files:
-1. `smal_fitter/Unreal2Pytorch3D.py` — **Phase 1 complete.** Multi-view loader with canonical-frame storage and depth visibility refinement. See §Status for commit references.
-2. `smal_fitter/replicAnt_data/__init__.py` — created during Phase 1's depth work; advertises the planned preprocessor.
-3. `smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py` — created during Phase 1; per-view depth-occlusion diagnostic.
-4. `smal_fitter/neuralSMIL/smil_datasets.py` — **Phase 4**: extend `UnifiedSMILDataset.from_path()` with the flat-directory `_CAM*.json` detection branch.
+### New Files (still pending):
+4. `smal_fitter/neuralSMIL/multiview_replicant_dataset.py` — `MultiViewreplicAntSMILDataset` (Phase 2, test seam only; production reads HDF5).
+
+### Modified Files (this PR):
+1. `smal_fitter/Unreal2Pytorch3D.py` — **Phase 1b**: `translation_factor=0.1` default and applied through to `root_loc`, `cam_trans_per_view`, `keypoints_3d`, `keypoints_3d_world`, `canonical_to_world_t`.
+2. `tests/validate_multiview_replicant_loader.py` — `_compute_posed_smal_joints` drops the `*10` to match the new loader convention (data already scaled, so model placement is plain `(joints - root) + trans`).
+3. `smal_fitter/replicAnt_data/__init__.py` — docstring promoted preprocessor from "planned" to landed.
+4. `.gitignore` — scratch patterns for probes, smoke HDF5s, smoke output dirs.
+
+### Modified Files (Phase 1 landed earlier on this branch):
+1. `smal_fitter/Unreal2Pytorch3D.py` — multi-view loader (canonical-frame storage, depth visibility refinement, in-dataset bitmap).
+2. `smal_fitter/replicAnt_data/__init__.py` — created with depth work.
+3. `smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py` — per-view depth-occlusion diagnostic.
+
+### Modified Files (pending — out of this PR):
+1. `smal_fitter/neuralSMIL/smil_datasets.py` — **Phase 4**: extend `UnifiedSMILDataset.from_path()` with the flat-directory `_CAM*.json` detection branch.
 
 ### No Changes Needed:
-- `train_multiview_regressor.py`, `multiview_smil_regressor.py`, `sleap_multiview_dataset.py` — Phase 3 produces an HDF5 that already matches the SLEAP schema.
+- `train_multiview_regressor.py`, `multiview_smil_regressor.py`, `sleap_multiview_dataset.py` — Phase 3 produces an HDF5 that already matches the SLEAP schema; trainer reads it via the existing class. Smoke training (5 epochs on the 500-frame HDF5) confirmed `use_ue_scaling=false` train path converges normally.
 - `train_smil_regressor.py`, `smil_image_regressor.py` — single-view sampler is Phase 5 (deferred).
 
 ---
 
 ## Implementation Order
 
-1. **Step 1** — Phase 1 loader: canonical-frame storage, depth visibility refinement, in-dataset bitmap. **DONE** (see §Status).
-2. **Step 2** [NEXT] — Phase 3: implement `replicAntMultiViewPreprocessor` and `__main__` CLI.
-3. **Step 3** — Step-0 smoke test (see §"Open empirical question" near the bottom):
-   - Preprocess `--max_frames 500` to a small HDF5.
-   - HDF5 round-trip check: open via `SLEAPMultiViewDataset`, take sample 0, apply inverse `canonical_to_world` (`R_0.T`, `-t_0 @ R_0.T`) to `keypoints_3d`, assert <= 1e-3 against the loader's `keypoints_3d_world` for the same source frame.
-   - Short multi-view training run (~50 epochs on the 500-frame subset). Pass criterion: per-view reprojection loss converges normally; `trans` head behaves under direct supervision.
-4. **Step 4** — Phase 4: extend `UnifiedSMILDataset.from_path()` auto-detection.
-5. **Step 5** — Phase 2: add `MultiViewreplicAntSMILDataset` test seam (low priority; production reads HDF5).
-6. **Step 6** — Example multi-view config JSON under `smal_fitter/neuralSMIL/configs/examples/`.
+1. ✅ **Step 1** — Phase 1 loader: canonical-frame storage, depth visibility refinement, in-dataset bitmap. (Landed earlier.)
+2. ✅ **Step 2** — Phase 3: `replicAntMultiViewPreprocessor` + `__main__` CLI. (This PR.)
+3. ✅ **Step 3** — Step-0 smoke test (see §Status → "Phase 3 highlights" for numbers):
+   - 500-frame HDF5 produced (497 written, 3 skipped as `subject Data == []` edge cases).
+   - Round-trip check (samples 0, 100, 250, 496): byte-equivalent loader ↔ HDF5 on R, T, K, keypoints, parameters; canonical inverse recovers raw world to 1.4e-6.
+   - 5-epoch multi-view training run: train loss 4.34 → 2.54 monotonic ↓; per-view reprojection converges; `trans` head supervises without divergence.
+4. ⏳ **Step 4** — Phase 4: extend `UnifiedSMILDataset.from_path()` auto-detection. (Out of this PR.)
+5. ⏳ **Step 5** — Phase 2: add `MultiViewreplicAntSMILDataset` test seam (low priority; production reads HDF5). (Out of this PR.)
+6. ✅ **Step 6** — `multiview_replicant_mice.json` example config landed.
 
-After Step 3 passes, the full preprocess (all 10k frames) and the production training run unblock; everything else above is wrap-up.
+After this PR, the full 10k-frame preprocess and production training run unblock. Phase 4 + 5 + the single-view scale unification follow-up are independent next steps.
 
 ---
 
@@ -739,35 +814,36 @@ byte-equivalent on-disk conventions:
   too. For SLEAP this is a no-op for learning (rig is fixed, so it's a
   constant shift) but makes the data format symmetric across the two paths.
 
-### Open empirical question (not blocking implementation)
+### Open empirical question — ANSWERED (this PR)
 
 Past SLEAP multiview training did **not** apply direct supervision to the
 `trans` head. The `/parameters/trans = 0` placeholder in the HDF5 was never
-consumed: the dataset returns `root_loc = None`
-([sleap_multiview_dataset.py:324](smal_fitter/sleap_data/sleap_multiview_dataset.py#L324)),
-which sets `trans_mask = False`
-([multiview_smil_regressor.py:2002-2011](smal_fitter/neuralSMIL/multiview_smil_regressor.py#L2002-L2011)),
-which short-circuits the loss to an `eps` placeholder
-([multiview_smil_regressor.py:892-902](smal_fitter/neuralSMIL/multiview_smil_regressor.py#L892-L902)).
-The head has therefore only ever received **implicit gradient** through the
-2D reprojection loss (which depends on `trans`).
+consumed: the dataset returns `root_loc = None`, which sets `trans_mask =
+False`, which short-circuits the loss to an `eps` placeholder. The head had
+therefore only ever received **implicit gradient** through the 2D reprojection
+loss.
 
-For replicAnt multi-cam with canonical-camera-frame storage, `root_loc` will
-be a real value (model's position relative to canonical camera), so direct
-MSE supervision on the `trans` head turns on for the first time. This is
-purely **additive** supervision on a head that already had implicit
-gradient — not a "relearn" situation — so the risk is low.
+For replicAnt multi-cam with canonical-camera-frame storage, `root_loc` is a
+real value (model's position relative to canonical camera), so direct MSE
+supervision on the `trans` head turns on for the first time. The original
+worry was that turning on direct supervision on a head that previously only
+saw implicit gradient could destabilise training.
 
-- **Step 0 before any full preprocess run**: preprocess a small subset
-  (~100–500 frames) of the replicAnt multi-cam dataset in canonical-cam-frame
-  convention, run a short training smoke test. Primary validation goal: confirm
-  the canonical-camera-frame transformation produces geometrically consistent
-  reprojections (i.e., per-view reprojection loss converges normally —
-  this catches frame-convention bugs more reliably than testing the trans
-  head specifically). Secondary: confirm direct `trans` loss converges
-  without destabilising the rest of training.
-- Default `trans` loss weight (0.001) is a reasonable starting point. If
-  needed, options are: bump the weight, freeze the head briefly, or zero
-  `trans` in the stored data (degrading to no direct supervision, matching
-  past SLEAP behaviour).
+**Empirical result (5-epoch smoke training, 500-frame subset, ViT-large
+backbone frozen, batch=1):**
+
+- Per-view reprojection loss converges to noise floor (kp2d normalised ≈ 0.06)
+  in the first epoch — frame convention is geometrically sound, no per-view
+  loss divergence.
+- Direct `trans` supervision **does not destabilise** training. Train loss
+  decreased monotonically 4.34 → 3.01 → 2.95 → 2.73 → 2.54 over 5 epochs.
+- At epoch-3 visualization sample, predicted `trans z ≈ 13.23` vs GT `12.67` —
+  the head learned the right magnitude without any weight tuning, kept the
+  default loss weight (0.001).
+- `use_ue_scaling=false` model placement branch (`(joints - root) + trans`,
+  no `*10`) verified end-to-end on real data.
+
+**Conclusion**: scale-unified canonical-camera-frame storage + direct `trans`
+supervision is the working configuration. Full 10k-frame preprocess + production
+training run is unblocked.
 

--- a/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
+++ b/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
@@ -1,0 +1,750 @@
+# Multi-Camera replicAnt Dataset Integration Design
+
+## Overview
+
+This document outlines the architecture for integrating multi-camera replicAnt datasets into SMILify's training pipeline while maintaining backward compatibility with existing single-view replicAnt dataset handling.
+
+**Goal**: Enable loading multi-camera replicAnt data that can be:
+1. Preprocessed into HDF5 format usable by multi-view training (`train_multiview_regressor.py`)
+2. Sampled as single-view instances for single-view training (`train_smil_regressor.py`)
+3. Stored with per-view metadata (camera parameters, view indices, frame synchronization)
+
+---
+
+## Current Architecture Analysis
+
+### Single-View Data Pipeline
+
+**Data Loading Path**: 
+```
+replicAnt JSON files 
+  → load_SMIL_Unreal_sample() [Unreal2Pytorch3D.py]
+  → replicAntSMILDataset [smil_datasets.py]
+  → UnifiedSMILDataset [smil_datasets.py]
+  → HDF5 preprocessing [dataset_preprocessing.py]
+  → OptimizedSMILDataset [optimized_dataset.py]
+  → train_smil_regressor.py
+```
+
+**Key File**: `Unreal2Pytorch3D.py`
+- Parses Unreal Engine JSON format (single instance per file)
+- Extracts: camera extrinsics (R, T), intrinsics (fx, fy, cx, cy), joint angles, shape betas, keypoints
+- Transforms to PyTorch3D convention (mirroring, coordinate system changes)
+- Currently **only handles single-view per JSON file**
+
+**replicAntSMILDataset**:
+- Inherits from `torch.utils.data.Dataset`
+- `__getitem__` calls `load_SMIL_Unreal_sample()` directly
+- Returns `(x_input, y_output)` tuple with image, pose, and camera data
+- Supports rotation representation switching (axis_angle ↔ 6d)
+
+### Multi-View Architecture (SLEAP)
+
+**Multi-View Data Pipeline**:
+```
+SLEAP sessions (multiple cameras per frame)
+  → sleap_3d_loader.py (3D ground truth)
+  → preprocess_sleap_multiview_dataset.py
+  → HDF5 with multiview structure
+  → SLEAPMultiViewDataset [sleap_multiview_dataset.py]
+  → train_multiview_regressor.py
+```
+
+**SLEAPMultiViewDataset Key Features**:
+- Stores multiple views per sample in HDF5
+- Variable number of views per sample (padded to `max_views`, masked via `view_mask` + `camera_indices`)
+- Canonical camera ordering tracked in metadata as a JSON-encoded list of camera names
+- Optional backward compatibility: `return_single_view=True` extracts one view
+- Per-view: JPEG-encoded image blobs, K matrix, R, t, image size, per-keypoint visibility
+- View masking: `view_mask` (boolean per slot) + `camera_indices` (which canonical camera lives in each slot)
+
+**HDF5 Structure** (verified against `preprocess_sleap_multiview_dataset.py` + `sleap_multiview_dataset.py`):
+```
+/metadata/                                                  # attrs only
+  canonical_camera_order: JSON-encoded list[str]            # e.g. '["CAM1", "CAM2", ...]'
+  num_samples, max_views, n_joints, n_pose, n_betas
+  target_resolution, backbone_name
+  is_multiview=True
+  has_camera_parameters=True
+  world_scale=1.0
+
+/multiview_images/
+  image_jpeg_view_{v}[num_samples] (vlen uint8)             # JPEG-encoded per view slot (v=0..max_views-1)
+  view_mask[num_samples, max_views]                         # bool, 1 if slot is populated
+
+/multiview_keypoints/
+  keypoints_2d[num_samples, max_views, n_joints, 2]         # Normalised [0, 1], (x, y) per existing convention
+  keypoint_visibility[num_samples, max_views, n_joints]     # 1.0 if in-bounds AND ID mask > 0
+  camera_indices[num_samples, max_views]                    # index into canonical_camera_order, or -1 if padded
+  camera_intrinsics[num_samples, max_views, 3, 3]           # K matrix
+  camera_extrinsics_R[num_samples, max_views, 3, 3]         # rotation (note: capital R)
+  camera_extrinsics_t[num_samples, max_views, 3]            # translation
+  image_sizes[num_samples, max_views, 2]                    # (W, H) per view
+  keypoints_3d[num_samples, n_joints, 3]                    # Shared 3D keypoints in model-centred coords
+
+/parameters/                                                # shared across views (per sample)
+  global_rot[num_samples, 3]                                # axis-angle, 0 after reparameterisation
+  joint_rot[num_samples, n_pose, 3]                         # axis-angle per joint
+  betas[num_samples, n_betas]
+  trans[num_samples, 3]                                     # 0 after reparameterisation
+
+/auxiliary/
+  has_3d_data[num_samples]                                  # bool
+  has_ground_truth_betas[num_samples]                       # bool
+  num_views[num_samples]                                    # int, count of valid slots
+  frame_idx[num_samples]
+  session_name[num_samples] (vlen str)                      # replicAnt: dataset name
+  camera_names[num_samples, max_views] (vlen str)           # canonical camera name per slot
+  canonical_to_world_R[num_samples, 3, 3]                   # inverse of per-frame canonical-camera-frame
+  canonical_to_world_t[num_samples, 3]                      # ↳ enables round-trip to raw world coords
+```
+
+**Note on the frame convention**: All `R`, `t`, `trans`, `global_rot`, and
+`keypoints_3d` arrays above are stored in the **per-frame canonical-camera
+frame**, not the raw rig world frame. See "Frame Convention" section near the
+bottom for the rationale and the inverse-transform fields under `/auxiliary/`.
+
+**Critical per-camera visibility computation**:
+```python
+# For each camera and joint:
+# 1. Check if 2D keypoint is within image bounds [0, 1]
+# 2. Check if corresponding ID mask pixel (at projected location) is > 0
+# 3. Set visibility[cam_idx, joint_idx] = 1.0 if both true, else 0.0
+
+# This allows:
+# - Training loss to only count visible keypoints per camera
+# - Network to learn occlusion-aware predictions
+# - Multi-view training to weight views based on visibility
+```
+
+---
+
+## Multi-Camera replicAnt Data Structure
+
+**ACTUAL Directory Layout** (C:\replicAnt-dataset-multi-cam-mice):
+
+```
+replicAnt-dataset-multi-cam-mice/
+  ├── _BatchData_replicAnt-dataset-multi-cam-mice.json    # Global metadata (one per dataset)
+  │   - Name: dataset name
+  │   - Iterations: 10000 (number of frames)
+  │   - Number of Cameras: 12
+  │   - Image Resolution: {"x": 512, "y": 512}
+  │   - Subject Variations: {shape betas info}
+  │
+  ├── replicAnt-dataset-multi-cam-mice_00000_CAM1.json       # Camera 1, Frame 0 (metadata)
+  ├── replicAnt-dataset-multi-cam-mice_00000_CAM1.JPG        # Image
+  ├── replicAnt-dataset-multi-cam-mice_00000_ID_CAM1.png     # ID mask (always present)
+  ├── replicAnt-dataset-multi-cam-mice_00000_Depth_CAM1.png  # Depth (optional)
+  │
+  ├── replicAnt-dataset-multi-cam-mice_00000_CAM2.json       # Camera 2, Frame 0
+  ├── replicAnt-dataset-multi-cam-mice_00000_CAM2.JPG
+  ├── replicAnt-dataset-multi-cam-mice_00000_ID_CAM2.png
+  ├── replicAnt-dataset-multi-cam-mice_00000_Depth_CAM2.png  # optional
+  │
+  ├── ... (CAM3 through CAM12)
+  │
+  ├── replicAnt-dataset-multi-cam-mice_00001_CAM1.json       # Camera 1, Frame 1
+  ├── replicAnt-dataset-multi-cam-mice_00001_CAM1.JPG
+  ├── replicAnt-dataset-multi-cam-mice_00001_ID_CAM1.png
+  │
+  └── ... (more frames, continuing for all 10000 iterations)
+```
+
+**Key Features**:
+1. **Flat directory structure** - all files in one directory, no subdirectories
+2. **Naming convention**: `{dataset_name}_{frame_idx:05d}_{tag}_CAM{camera_id}.{ext}` (tag empty for `.JPG`/`.json`)
+   - Frame index: 0-padded 5-digit number (00000, 00001, ..., 09999)
+   - Camera ID: 1-N (not 0-indexed)
+   - File set per (frame, camera):
+     - `.JPG` — RGB image (always present)
+     - `.json` — per-camera metadata (always present)
+     - `_ID_CAM{id}.png` — ID/visibility mask (always present)
+     - `_Depth_CAM{id}.png` — depth map (optional; loaded only when `--include_depth_map` is set)
+3. **Per-camera metadata** (in `.json` files):
+   - Same format as single-view replicAnt JSON
+   - Contains camera parameters (view matrix, FOV, location, rotation)
+   - Contains subject data with keypoints (same structure as single-view)
+   - Shape betas, joint angles, and root pose are **per-frame, identical across all cameras**
+4. **Batch metadata** (`_BatchData_*.json`):
+   - Global image resolution
+   - Number of frames and cameras
+   - Subject variations (for loading shape betas from file if needed)
+
+---
+
+## Implementation Strategy
+
+### Phase 1: Extend Unreal2Pytorch3D.py
+
+**New Functions** (add without breaking existing ones):
+
+```python
+def load_SMIL_Unreal_multiview_sample(
+    data_path,                # Path to dataset directory
+    frame_index,              # Frame number (0-padded as needed)
+    camera_indices=None,      # List of camera indices to load (None = all)
+    plot_tests=False,
+    propagate_scaling=True,
+    translation_factor=0.01,
+    load_images=True,
+    verbose=False
+) -> Tuple[Dict, Dict]:
+    """
+    Load multi-view replicAnt data from a flat-directory dataset for a specific frame.
+    
+    Dataset structure:
+    - Flat directory: {dataset_name}_{frame_idx:05d}_CAM{cam_id}.{ext}
+    - Per-camera files: .json (metadata), .JPG (image), _ID_CAM{id}.png (visibility mask)
+    - Synchronized frames: all cameras for same frame_idx are temporally aligned
+    - Shared pose/shape: identical across all cameras (only camera params differ)
+    
+    Args:
+        data_path: Path to dataset directory
+        frame_index: Frame number to load (e.g., 0, 1, 2, ...)
+        camera_indices: List of camera IDs to load (e.g., [1, 2, 3] or None for all)
+        
+    Returns:
+        x_output: Dictionary with per-view data
+            - image_paths: List[str] - paths to images per camera
+            - image_data: List[np.ndarray] - loaded images, shape (H, W, 3)
+            - mask_data: List[np.ndarray] - per-camera ID/visibility masks, shape (H, W)
+            - mask_paths: List[str] - paths to ID map files
+            - num_views: int - number of views loaded
+            - camera_ids: List[int] - camera IDs in order
+            
+        y_output: Dictionary with shared + per-view data
+            - pose_data: dict - raw pose data (from first camera)
+            - joint_angles: np.ndarray[n_joints, 3] - shared joint rotations
+            - joint_names: list - joint names
+            - shape_betas: np.ndarray[n_betas] - shared shape
+            
+            - cam_rot_per_view: List[np.ndarray] - rotation matrices per camera [3, 3]
+            - cam_trans_per_view: List[np.ndarray] - translation vectors per camera [3]
+            - fx_per_view: List[float] - focal length X per camera
+            - fy_per_view: List[float] - focal length Y per camera
+            - cx_per_view: List[float] - principal point X per camera
+            - cy_per_view: List[float] - principal point Y per camera
+            
+            - keypoints_2d_per_view: List[np.ndarray] - normalized 2D keypoints per camera
+            - keypoint_visibility_per_view: List[np.ndarray] - **PER-CAMERA VISIBILITY**
+                                           computed as: in_bounds AND (id_mask_pixel > 0)
+    """
+    # 1. Detect camera count and dataset name from _BatchData_*.json
+    # 2. Determine which camera indices to load (all or subset)
+    # 3. Build the per-frame canonical camera list:
+    #    a. Sort the resolved camera indices ascending.
+    #    b. The lowest-index resolved camera becomes canonical slot 0
+    #       (defines the per-frame world frame: R=I, t=0).
+    #    c. Subsequent resolved cameras fill slots 1..N-1 in order.
+    # 4. From the canonical-slot-0 camera's JSON:
+    #    a. Extract shared pose, shape, joint_angles via load_SMIL_Unreal_sample()
+    #       (or its inner helpers) to get raw world-frame values.
+    #    b. Capture (R_0, t_0) as canonical_to_world for the inverse transform.
+    # 5. For each canonical slot v:
+    #    a. Parse that camera's JSON (extrinsics + intrinsics).
+    #    b. Load image and ID mask.
+    #    c. Compute per-view keypoint visibility (see below).
+    # 6. Re-express in canonical-camera frame (see "Frame Convention" section):
+    #    a. Per-view extrinsics: (R_v, t_v) → relative to (R_0, t_0).
+    #    b. Model trans, global_rot, keypoints_3d → re-expressed in canonical frame.
+    # 7. Return consolidated multi-view data + canonical_to_world for round-trip.
+```
+
+**Key Implementation Details**:
+- All output is in **canonical-camera frame** (see Frame Convention section below).
+  The raw world-frame values are computed internally then transformed; only the
+  transformed values plus `canonical_to_world = (R_0, t_0)` are returned.
+- Per-camera parameters extracted independently from each camera's JSON.
+- Per-camera ID masks loaded from `_ID_CAM{id}.png` files.
+- Per-camera visibility uses the existing `compute_keypoint_visibility()` logic:
+  ```python
+  visibility[cam] = 1.0 if (
+      keypoint within image bounds [0, 1] AND
+      id_mask[int(norm_y * H), int(norm_x * W)] > 0
+  ) else 0.0
+  ```
+- ID mask files follow pattern: `{dataset_name}_{frame_idx:05d}_ID_CAM{cam_id}.png`.
+
+**Backward Compatibility**: 
+- Keep `load_SMIL_Unreal_sample()` unchanged
+- Add `load_SMIL_Unreal_multiview_sample()` as new function
+- Both work with existing code paths
+
+---
+
+### Phase 2: Create MultiViewreplicAntDataset
+
+**New Class** in `smil_datasets.py`:
+
+```python
+class MultiViewreplicAntSMILDataset(torch.utils.data.Dataset):
+    """
+    PyTorch dataset for multi-camera replicAnt SMIL data.
+    
+    Loads all synchronized views for each frame from a flat-directory replicAnt dataset.
+    Handles variable number of cameras and optional camera subsetting.
+    """
+    
+    def __init__(self, 
+                 data_path,                    # Path to replicAnt-dataset-multi-cam-mice
+                 use_ue_scaling=True,
+                 rotation_representation='axis_angle',
+                 backbone_name='resnet152',
+                 camera_subset=None,           # List of camera IDs to load (e.g., [1,2,3])
+                 min_views_per_sample=2):
+        """
+        Initialize multi-view replicAnt dataset.
+        
+        Args:
+            data_path: Path to flat-directory replicAnt dataset
+            camera_subset: None (load all) or list of camera IDs (1-based)
+        """
+        self.data_path = data_path
+        self.use_ue_scaling = use_ue_scaling
+        self.rotation_representation = rotation_representation
+        self.backbone_name = backbone_name
+        self.camera_subset = camera_subset
+        self.min_views_per_sample = min_views_per_sample
+        
+        # Load batch metadata to determine frame count and camera count
+        self._detect_dataset_structure()
+        
+        # Detect input resolution from batch data file
+        self.original_resolution = self._detect_input_resolution()
+        
+        # Determine target resolution based on backbone
+        from backbone_factory import BackboneFactory
+        self.target_resolution = BackboneFactory.get_default_input_resolution(backbone_name)
+    
+    def _detect_dataset_structure(self):
+        """
+        Scan for batch metadata file to determine frame count and camera count.
+        Also verify that all cameras exist for all frames.
+        """
+        # Find _BatchData_*.json file
+        # Extract: num_iterations (frames), num_cameras
+        # Verify camera IDs 1-N exist for frame 0
+        
+    def _detect_input_resolution(self):
+        """Detect input resolution from batch metadata."""
+        # Load _BatchData_*.json and extract Image Resolution
+        
+    def __getitem__(self, idx):
+        """
+        Returns:
+            x_output: Dict with per-view images and masks
+            y_output: Dict with shared pose + per-view camera parameters
+        """
+        x, y = load_SMIL_Unreal_multiview_sample(
+            data_path=self.data_path,
+            frame_index=idx,
+            camera_indices=self.camera_subset,
+            propagate_scaling=True,
+            translation_factor=0.01,
+            load_images=True,
+            verbose=False
+        )
+        
+        # Convert rotation representations if needed
+        if self.rotation_representation == '6d':
+            # Convert root rotation and joint angles
+            if 'root_rot' in y:
+                y['root_rot'] = axis_angle_to_rotation_6d(y['root_rot'])
+            if 'joint_angles' in y:
+                y['joint_angles'] = axis_angle_to_rotation_6d(y['joint_angles'])
+        
+        return x, y
+        
+    def __len__(self):
+        return self.num_frames
+```
+
+---
+
+### Phase 3: Preprocessing to HDF5
+
+**New module**: `smal_fitter/sleap_data/preprocess_replicant_multiview_dataset.py` —
+sibling of `preprocess_sleap_multiview_dataset.py`, with the same output schema so
+`SLEAPMultiViewDataset` and `train_multiview_regressor.py` consume it unchanged.
+
+**Class**: `replicAntMultiViewPreprocessor`
+
+```python
+class replicAntMultiViewPreprocessor:
+    def __init__(
+        self,
+        target_resolution: int = 224,
+        backbone_name: str = 'vit_large_patch16_224',
+        jpeg_quality: int = 95,
+        chunk_size: int = 8,
+        compression: str = 'gzip',
+        compression_level: int = 6,
+        frame_skip: int = 1,
+        camera_subset: Optional[List[int]] = None,
+        include_depth_map: bool = False,        # gate for /multiview_depth/ group
+        propagate_scaling: bool = True,
+        translation_factor: float = 0.01,
+        debug: bool = False,
+    ):
+        ...
+
+    def preprocess(self, input_dir: str, output_hdf5: str, num_workers: int = 8):
+        """Produce an HDF5 file that matches the SLEAPMultiViewDataset schema."""
+```
+
+**Output schema**: identical to the schema documented in the SLEAP overview above
+(`/metadata`, `/multiview_images`, `/multiview_keypoints`, `/parameters`,
+`/auxiliary`). `canonical_camera_order` is `["CAM1", "CAM2", ...]` derived from
+the first scanned frame.
+
+**Image storage** (matches SLEAP preprocessor):
+- Per-view images are **JPEG-encoded in the HDF5** as variable-length `uint8` arrays
+  under `/multiview_images/image_jpeg_view_{v}` (one dataset per view slot).
+- `jpeg_quality` defaults to 95 (same as SLEAP path).
+- This keeps the 12-cam × 10k-frame replicAnt clip in the ~5–10 GB range rather
+  than ~90 GB raw.
+
+**Failure handling**:
+- Frames that fail to load any view (corrupt JSON, missing files, projection
+  failure, etc.) are **flagged and skipped**: the preprocessor logs the
+  `(frame_idx, reason)` and continues with the next `idx`. A summary count is
+  printed at the end and stored in `/metadata` attrs (`num_skipped_frames`,
+  `skipped_frame_indices`).
+- Per-camera failures within an otherwise-loadable frame mark just that view's
+  `view_mask[i, v] = False` and `camera_indices[i, v] = -1`; the frame is kept
+  as long as ≥1 view loads.
+
+**Optional depth (`--include_depth_map`)**:
+- When set, an additional `/multiview_depth/` group is written:
+  ```
+  /multiview_depth/
+    depth_png_view_{v}[num_samples] (vlen uint8)    # PNG-encoded raw depth
+    depth_mask[num_samples, max_views]              # 1 if depth present, 0 otherwise
+  ```
+- When unset (default), depth files are ignored even if present on disk.
+- Future self-occlusion visibility refinement will read this group when
+  available; the trainer does not require it.
+
+---
+
+### Phase 4: Unified Dataset Loading
+
+**Update**: `UnifiedSMILDataset.from_path()` in `smil_datasets.py`
+
+```python
+@staticmethod
+def from_path(data_path, **kwargs):
+    """
+    Auto-detect dataset type from a path.
+
+    Detection (in order):
+    1. .h5 / .hdf5  → inspect /metadata.is_multiview
+                       True  → SLEAPMultiViewDataset
+                       False → OptimizedSMILDataset
+    2. Directory containing _BatchData_*.json and at least one
+       {dataset}_00000_CAM*.json → MultiViewreplicAntSMILDataset
+    3. Directory containing _BatchData_*.json with {dataset}_*.json
+       (no _CAM suffix) → replicAntSMILDataset (single-view, current behaviour)
+    """
+```
+
+The multiview replicAnt PyTorch `Dataset` is only used directly for tests and
+ad-hoc validation; **production training reads the HDF5** produced by Phase 3
+through `SLEAPMultiViewDataset`. The PyTorch class is therefore primarily a
+test seam, not a hot path.
+
+---
+
+### Phase 5: Single-View Sampling — Deferred to Training Time
+
+**Decision**: The multiview HDF5 is **dataset-shape-agnostic** — it always stores
+all available views per frame. Whether downstream training is single-view or
+multi-view is a *training-time* concern, not a dataset concern.
+
+For multi-view training: feed the HDF5 directly to `SLEAPMultiViewDataset`
+(via the `UnifiedSMILDataset` factory) → `train_multiview_regressor.py`.
+
+For single-view training: a thin sampler will be added later that, per sample,
+draws one view slot at random from the populated ones and emits the same dict
+shape that `replicAntSMILDataset.__getitem__` produces today. **This sampler
+is out of scope for the initial PR**; it can be implemented incrementally on
+top of `SLEAPMultiViewDataset.return_single_view`.
+
+---
+
+## Data Format Compatibility
+
+### Single-View Training Compatibility
+
+The future single-view sampler must emit the return contract produced today by
+`load_SMIL_Unreal_sample()` in [Unreal2Pytorch3D.py:694](smal_fitter/Unreal2Pytorch3D.py#L694):
+
+```python
+x_output = {
+    'input_image': str,                 # Path to image file
+    'input_image_data': np.ndarray,     # Image data (H, W, 3) uint8
+    'input_image_mask': np.ndarray,     # Binary mask (H, W) or None
+}
+
+y_output = {
+    'pose_data': dict,                  # Raw pose dict
+    'joint_angles': np.ndarray,         # (n_joints, 3) or (n_joints, 6) after 6D
+    'joint_names': list,                # config.dd["J_names"]
+    'cam_rot': torch.Tensor,            # (3, 3) — reparameterised (see Phase 1)
+    'cam_trans': torch.Tensor,          # (3,)  — reparameterised
+    'cam_rot_orig': np.ndarray,         # (3, 3) raw Unreal extrinsics
+    'cam_trans_orig': np.ndarray,       # (3,)  raw Unreal extrinsics
+    'cx': float, 'cy': float,           # principal point (px)
+    'fx': float, 'fy': float,           # focal length  (px)
+    'cam_fov': list[float],             # [FOV degrees]
+    'scale_weights': np.ndarray|None,
+    'trans_weights': np.ndarray|None,
+    'shape_betas': np.ndarray,          # (n_betas,)
+    'root_loc': np.ndarray,             # (3,) — zero after reparam
+    'root_rot': np.ndarray,             # (3,) — zero after reparam
+    'keypoints_2d': np.ndarray,         # (n_joints, 2) normalised [0, 1]
+    'keypoint_visibility': np.ndarray,  # (n_joints,) {0.0, 1.0}
+    'keypoints_3d': np.ndarray,         # (n_joints, 3) model-centred
+    'keypoints_3d_original': np.ndarray,# (n_joints, 3) world frame, debug
+    'translation_factor': float,
+    'propagate_scaling': bool,
+}
+```
+
+### Multi-View Training Compatibility
+
+Output must match the dict returned by `SLEAPMultiViewDataset.__getitem__`
+(verified at [sleap_multiview_dataset.py:257](smal_fitter/sleap_data/sleap_multiview_dataset.py#L257)):
+
+```python
+y_data = {
+    'keypoints_2d': np.ndarray,         # (num_views, n_joints, 2)
+    'keypoint_visibility': np.ndarray,  # (num_views, n_joints)
+    'camera_intrinsics': np.ndarray,    # (num_views, 3, 3) — K
+    'camera_extrinsics_R': np.ndarray,  # (num_views, 3, 3) — capital R
+    'camera_extrinsics_t': np.ndarray,  # (num_views, 3)    — t (world_scale applied)
+    'keypoints_3d': np.ndarray,         # (n_joints, 3) when has_3d_data
+    # shared pose/shape (from /parameters/):
+    'global_rot': np.ndarray,           # (3,)   axis-angle (0 after reparam)
+    'joint_rot': np.ndarray,            # (n_pose, 3) or (n_pose, 6)
+    'betas': np.ndarray,                # (n_betas,)
+    'trans': np.ndarray,                # (3,)   (0 after reparam)
+}
+```
+
+---
+
+## Key Design Decisions
+
+### 1. **Dataset Layout Detection**
+- replicAnt multi-camera datasets are **flat directories** (no per-frame subdirs);
+  files follow `{dataset_name}_{frame:05d}_(ID_|Depth_)?CAM{id}.{ext}`.
+- Detection: presence of `_BatchData_*.json` plus at least one
+  `{dataset_name}_00000_CAM*.json` distinguishes from single-view replicAnt data
+  (which has only `{dataset_name}_*.json` without the `_CAM` suffix).
+- **Decision**: Flat-directory, name-pattern detection.
+
+### 1b. **Per-Frame Failure Handling**
+- If any frame index fails to load (corrupt JSON, missing camera file, etc.),
+  log it and continue with the next `idx`. Do not abort the whole preprocessing
+  run. The skipped indices are recorded in `/metadata` attrs.
+- Per-camera failures within a frame mark just that view slot
+  (`view_mask=False`); the frame is still emitted as long as ≥1 view loads.
+
+### 2. **Camera Indexing**
+- Store as list of views in HDF5 (order preserved)
+- Track canonical camera order in metadata for consistent training
+- Support optional subset selection during loading (camera_subset parameter)
+- **Decision**: Preserve order, allow optional filtering
+
+### 3. **Shared vs. Per-View Data**
+- **Shared** (same for all cameras): pose (joint angles, global rotation), shape (betas)
+- **Per-View**: images, masks, camera parameters (R, T, K), keypoints (projected from 3D)
+- **Decision**: Store separately in HDF5, merge in dataset `__getitem__`
+
+### 4. **Variable View Count Handling**
+- No padding; store variable number of views per sample
+- Use `valid_views_mask` to track which views are real vs. padding (if needed)
+- Training code uses masking to ignore invalid views
+- **Decision**: Match SLEAP multiview approach (no padding, masking in loss)
+
+### 5. **Backward Compatibility**
+- Ensure single-view loading still works for existing replicAnt JSON data
+- Make multiview optional (can load as single-view if needed)
+- **Decision**: Keep all existing code unchanged, add new functions/classes
+
+---
+
+## Validation Checklist
+
+✅ **VERIFIED** - Actual dataset structure confirmed:
+
+- ✅ Flat directory structure with {dataset_name}_{frame_idx:05d}_CAM{id}.{ext} naming
+- ✅ 12 cameras (CAM1 through CAM12) in dataset
+- ✅ 10000 frames (iterations) in dataset  
+- ✅ Each camera has `.json` metadata file (Unreal format)
+- ✅ Each camera has `.JPG` image file
+- ✅ Depth maps exist as `_Depth_CAM{id}.png` files
+- ✅ Batch metadata: `_BatchData_replicAnt-dataset-multi-cam-mice.json`
+  - Image resolution: 512x512
+  - Number of cameras: 12
+  - Subject variations with shape betas
+- ✅ JSON files contain same structure as single-view replicAnt:
+  - Camera parameters (view matrix, FOV, location, rotation)
+  - Subject data with keypoints (2D and 3D positions)
+  - Shape betas (same across all cameras per frame)
+  - Quaternion-based rotations
+
+---
+
+## Files to Create/Modify
+
+### New Files:
+1. `smal_fitter/sleap_data/preprocess_replicant_multiview_dataset.py` —
+   `replicAntMultiViewPreprocessor`, writes the SLEAP-compatible HDF5 schema.
+2. `smal_fitter/neuralSMIL/multiview_replicant_dataset.py` —
+   `MultiViewreplicAntSMILDataset` (test seam; thin wrapper around
+   `load_SMIL_Unreal_multiview_sample`).
+3. CLI entry, either:
+   - extend an existing `preprocess_dataset.py`, or
+   - add `smal_fitter/sleap_data/preprocess_replicant_multiview_dataset.py`'s
+     own `__main__` block (matches the SLEAP equivalent).
+
+### Modify Existing Files:
+1. `smal_fitter/Unreal2Pytorch3D.py` — already contains the Phase 1 draft of
+   `load_SMIL_Unreal_multiview_sample()` (uncommitted). Needs cleanup +
+   reparameterisation parity with `load_SMIL_Unreal_sample()` (see Open Items).
+2. `smal_fitter/neuralSMIL/smil_datasets.py` — extend
+   `UnifiedSMILDataset.from_path()` with the flat-directory `_CAM*.json`
+   detection branch.
+
+### No Changes Needed:
+- `train_multiview_regressor.py`, `multiview_smil_regressor.py`,
+  `sleap_multiview_dataset.py` — Phase 3 produces an HDF5 that already
+  matches the SLEAP schema.
+- `train_smil_regressor.py`, `smil_image_regressor.py` — touched only when the
+  single-view sampler is added later.
+
+---
+
+## Implementation Order
+
+1. **Step 1**: Clean up the Phase 1 draft in `Unreal2Pytorch3D.py`
+   (deduplicate imports, add coord-swap comment, add reparameterisation —
+   see Open Items).
+2. **Step 2**: Add `MultiViewreplicAntSMILDataset` (test seam).
+3. **Step 3**: Implement `replicAntMultiViewPreprocessor` + CLI (matches
+   SLEAP HDF5 schema; JPEG-encoded images; optional `--include_depth_map`).
+4. **Step 4**: Extend `UnifiedSMILDataset.from_path()` auto-detection.
+5. **Step 5**: Round-trip tests
+   (load → preprocess → SLEAPMultiViewDataset → assert tensor shapes/contents).
+6. **Step 6**: Example multiview config under
+   `smal_fitter/neuralSMIL/configs/examples/`.
+
+---
+
+## Frame Convention: Canonical-Camera-Frame Storage
+
+Decision (informed by the SLEAP path's choice + the procedural nature of
+replicAnt multi-cam data):
+
+- **Do NOT use the existing single-view "model-at-origin / camera-absorbs-everything"
+  reparameterisation** for multi-view storage.
+- **Do NOT use the raw rig world frame** either — procedural generation places
+  the rig at arbitrary world positions per frame, so absolute world coordinates
+  carry only procgen noise and the empirical distribution of `cam_trans`,
+  `cam_rot`, and model `trans` becomes too wide for stable regression.
+- **Use the canonical camera's frame as the per-frame world origin**:
+  - For each frame, identify the lowest-index camera that successfully resolves
+    on disk. That camera becomes **canonical index 0** for that frame, and
+    becomes the world frame origin (`R = I`, `t = 0`).
+  - All other cameras are renumbered into the canonical order they appear
+    (the next-lowest available index becomes 1, etc.). The mapping is recorded
+    in `/auxiliary/camera_names[i, v]` and `/multiview_keypoints/camera_indices`.
+  - Express **all** other quantities (other cameras' extrinsics, model
+    `global_rot`, model `trans`, `keypoints_3d`) relative to the canonical
+    camera's frame.
+
+This convention:
+- Bounds the empirical distributions across procedural variation (every frame
+  "looks at the rig" from the same notional viewpoint at the input distribution
+  level).
+- Keeps `trans` and `global_rot` as learnable, bounded signals (unlike convention
+  C where `trans` is degenerate-zero).
+- Preserves multi-view relative geometry exactly — the inter-camera transforms
+  and 2D reprojections are byte-equivalent to the raw world-frame version.
+- Has a clean bridge to single-view sampling: one composition folds canonical
+  cam → selected cam → model-at-origin, producing samples byte-equivalent to
+  the existing single-view `load_SMIL_Unreal_sample()` output. (Out of scope
+  for this PR, but the design supports it.)
+
+### Inverse transform stored for validation
+
+The canonical-camera-frame conversion is reversible. Store the per-frame
+canonical-camera-to-world rigid transform under `/auxiliary/canonical_to_world`
+(`R: (num_samples, 3, 3)`, `t: (num_samples, 3)`) so:
+- Tests can validate that round-tripping reproduces the raw extrinsics.
+- Downstream tools that *do* want absolute world coords (rendering at a
+  specific scene location, debugging procgen, etc.) can recover them.
+- Training pipeline ignores this field; it's metadata only.
+
+For procedural replicAnt scenes the absolute world coordinates carry no
+meaningful information — they're arbitrary draws from the procgen randomiser
+— so the trainer not using this field is the desired behaviour.
+
+### SLEAP path: apply the same normalisation
+
+The SLEAP preprocessor currently stores camera extrinsics in the rig's
+calibration-tool-defined world frame. To keep both paths producing
+byte-equivalent on-disk conventions:
+
+- **TODO (separate change, not in this PR)**: apply canonical-camera-frame
+  normalisation in `preprocess_sleap_multiview_dataset.py` too. For SLEAP
+  this is a no-op for learning (rig is fixed, so it's a constant shift) but
+  makes the data format symmetric across the two paths.
+
+### Open empirical question (not blocking implementation)
+
+Past SLEAP multiview training did **not** apply direct supervision to the
+`trans` head. The `/parameters/trans = 0` placeholder in the HDF5 was never
+consumed: the dataset returns `root_loc = None`
+([sleap_multiview_dataset.py:324](smal_fitter/sleap_data/sleap_multiview_dataset.py#L324)),
+which sets `trans_mask = False`
+([multiview_smil_regressor.py:2002-2011](smal_fitter/neuralSMIL/multiview_smil_regressor.py#L2002-L2011)),
+which short-circuits the loss to an `eps` placeholder
+([multiview_smil_regressor.py:892-902](smal_fitter/neuralSMIL/multiview_smil_regressor.py#L892-L902)).
+The head has therefore only ever received **implicit gradient** through the
+2D reprojection loss (which depends on `trans`).
+
+For replicAnt multi-cam with canonical-camera-frame storage, `root_loc` will
+be a real value (model's position relative to canonical camera), so direct
+MSE supervision on the `trans` head turns on for the first time. This is
+purely **additive** supervision on a head that already had implicit
+gradient — not a "relearn" situation — so the risk is low.
+
+- **Step 0 before any full preprocess run**: preprocess a small subset
+  (~100–500 frames) of the replicAnt multi-cam dataset in canonical-cam-frame
+  convention, run a short training smoke test. Primary validation goal: confirm
+  the canonical-camera-frame transformation produces geometrically consistent
+  reprojections (i.e., per-view reprojection loss converges normally —
+  this catches frame-convention bugs more reliably than testing the trans
+  head specifically). Secondary: confirm direct `trans` loss converges
+  without destabilising the rest of training.
+- Default `trans` loss weight (0.001) is a reasonable starting point. If
+  needed, options are: bump the weight, freeze the head briefly, or zero
+  `trans` in the stored data (degrading to no direct supervision, matching
+  past SLEAP behaviour).
+
+## Phase 1 cleanup (separate from frame convention)
+
+- Remove duplicate `from pathlib import Path` / `from typing import ...` /
+  `import re` lines inside the function body.
+- Add a comment near the `norm_x = ...['y'] / image_height` block flagging
+  that the x↔y swap matches the existing single-view convention.
+- Replace the current raw-extrinsics emission with canonical-camera-frame
+  output per the convention above. The function will compute the canonical
+  camera's `(R_0, t_0)` from the first resolved-on-disk camera index, then
+  re-express every per-view `(R_v, t_v)`, model `trans`, model `global_rot`,
+  and `keypoints_3d` relative to that frame. Store `canonical_to_world` as
+  `(R_0, t_0)` for round-trip validation.

--- a/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
+++ b/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
@@ -11,19 +11,22 @@ This document outlines the architecture for integrating multi-camera replicAnt d
 
 ---
 
-## Status (2026-06-04)
+## Status (2026-06-04, refreshed end-of-session)
 
 | Phase | What | State |
 |---|---|---|
 | 1 | `load_SMIL_Unreal_multiview_sample` loader | **COMPLETE** |
-| 1b | Scale unification: bake `translation_factor=0.1` into loader output | **COMPLETE (this PR)** |
-| 3 | HDF5 preprocessor (`replicAntMultiViewPreprocessor`) | **COMPLETE (this PR)** — round-trip byte-equivalent vs loader on smoke samples |
-| 6 | Example multi-view training config | **COMPLETE (this PR)** — `configs/examples/multiview_replicant_mice.json` |
-| 4 | `UnifiedSMILDataset.from_path()` auto-detection | pending |
+| 1b | Scale unification: bake `translation_factor=0.1` into loader output | **COMPLETE** |
+| 1c | `(0,0,0)` sentinel for joints without dataset GT (post-canonical, post-scale) | **COMPLETE** |
+| 3 | HDF5 preprocessor (`replicAntMultiViewPreprocessor`) | **COMPLETE** — round-trip byte-equivalent vs loader on smoke samples |
+| 4 | `UnifiedSMILDataset.from_path()` auto-detection | **COMPLETE (this session)** — `/metadata`-attr dispatch + flat-dir branch, SLEAP monkey-patch retired (`a9d68a1`) |
+| 6 | Example multi-view training config | **COMPLETE** — `configs/examples/multiview_replicant_mice.json` |
+| — | cv2/imageio loader hybrid (JPG + depth via cv2; ID mask kept on imageio) | **COMPLETE (this session)** — projected 38% decode-time reduction, byte-equivalent round-trip (`aefb06d`) |
+| — | Per-camera resilience (`--min_views` + `view_valid_per_view`) | **COMPLETE (this session)** — frames with one bad camera kept with `view_mask=False` on that slot; full round-trip + full-coverage SMOKE training PASS (`3de0f55`) |
 | 2 | `MultiViewreplicAntSMILDataset` PyTorch test seam | pending, low priority |
 | 5 | Single-view sampler | deferred per design |
-| — | Step-0 smoke training run (short epochs on 500-frame subset) | follows preprocessor, separate session |
-| — | **Follow-up**: apply the same 0.1 rescale at load in `load_SMIL_Unreal_sample` (single-view) and flip single-view configs to `use_ue_scaling=False` | **TODO** |
+| — | **Follow-up**: apply the same 0.1 rescale at load in `load_SMIL_Unreal_sample` (single-view) and flip single-view configs to `use_ue_scaling=False` | **TODO** (separate PR) |
+| — | **Follow-up**: package-import refactor + ruff | **TODO** (separate mechanical PR) |
 
 **Phase 1 highlights** (see commit history on `multiview-replicant-integration`):
 - Canonical-camera-frame storage (lowest CAM ID → R=I, t=0), forward-transform `canonical_to_world` for round-trip
@@ -38,13 +41,13 @@ This document outlines the architecture for integrating multi-camera replicAnt d
 - Scale unification baked into the loader (Phase 1b), preprocessor advertises `world_scale=1.0`
 - ProcessPoolExecutor with `_worker_init` that runs `apply_smal_file_override` once per worker; per-frame failures logged and skipped, `/metadata.skipped_frame_indices` records the source indices
 - Smoke results (500 source frames, 8 workers, Falkner-conv repose mouse):
-  - 497 / 500 samples written, 3 skipped (frames 184, 435, 441 — `subject Data == []` in some camera's JSON; genuine dataset edge case where the rendered scene contained no mouse subject for that view)
-  - 545 s wall time ≈ 1.1 s / frame; HDF5 = 303 MB (~610 KB / sample, JPEG-dominated)
-  - I/O-bound at 8 workers (~20% CPU); more workers + cv2.imread switch are the cheap wins for the full 10 k preprocess
-  - **Round-trip check** at samples 0, 100, 250, 496 against fresh loader call for the same source frame: byte equivalence on `R_per_view`, `T_per_view`, `keypoints_2d`, `keypoint_visibility`, `keypoints_3d`, `parameters/{trans, global_rot, betas}`; `fov_per_view` matches to 2e-6 deg (numerical precision recomputing from K); `canonical_to_world` inverse recovers raw world frame to 1.4e-6
-  - Sample 250 maps to source frame 251 (skip-then-remap verified on the sample axis)
+  - Initial run: 497 / 500 samples written, 3 skipped (frames 184, 435, 441 — `subject Data == []` in some camera's JSON; the rendered scene contained no mouse subject for that one view). **Post per-camera resilience (Step 7 below): 500 / 500 written, those frames retained with `view_mask=False` on the offending slot.**
+  - Wall time: 545 s on initial loader → 513 s after cv2 swap → 469 s after per-camera-resilience (pre-loading JSONs once instead of twice). ≈ 1.0 s / frame; HDF5 = 303 MB (~610 KB / sample, JPEG-dominated).
+  - I/O-bound at 8 workers (~20% CPU); more workers is the remaining cheap win for the full 10 k preprocess.
+  - **Round-trip check** at samples 0, 100, 250, 496 (initial) and 0, 184, 435, 441, 499 (post-resilience) against fresh loader call for the same source frame: byte equivalence on `R_per_view`, `T_per_view`, `keypoints_2d`, `keypoint_visibility`, `keypoints_3d`, `parameters/{trans, global_rot, betas}`; `fov_per_view` matches to 2e-6 deg (numerical precision recomputing from K); `canonical_to_world` inverse recovers raw world frame to 1.4e-6.
+  - With the resilient loader, sample index now equals source frame index for all 500 samples (no skips).
 
-**Known per-camera resilience gap** (out of scope for this PR): when a non-canonical camera's `subject Data` is empty (e.g. frames 435 / 441 above), the loader currently raises and the preprocessor skips the whole frame. The design called for marking just that view's `view_mask[i, v] = False` and keeping the rest of the frame (`§Phase 3 Failure handling`). Drop rate at 500 frames was 0.6%; ship as-is and refine the loader later.
+**Per-camera resilience — RESOLVED** (`3de0f55`): when one or more cameras have empty `subject Data` (animal absent from that view's render), the loader now marks the view via `view_valid_per_view[v] = False`, the preprocessor writes `view_mask[i, v] = False` + `camera_indices[i, v] = -1` for that slot, and `SLEAPMultiViewDataset` drops the slot at `__getitem__`. Frames are kept as long as `>= --min_views` cameras have valid subject data (default 2). Shared pose/shape extraction also falls back from the canonical camera to the first valid one when canonical itself is empty (frame 435 here: CAM1 was the canonical-and-empty case; the loader uses CAM1's geometry as canonical anchor and CAM2's `subject Data` for shared pose, and the canonical-frame inverse round-trips to 7e-7). 500/500 samples now write (was 497/500); full-coverage SMOKE training over all 500 samples completes cleanly.
 
 **Important architectural shift from the original draft** — depth handling: the depth-buffer self-occlusion check runs at load time inside the loader, not as a post-process on stored bytes. The HDF5 schema therefore does NOT include a `/multiview_depth/` group, and the preprocessor does NOT take an `--include_depth_map` flag. Depth parameters are pass-through CLI args, recorded in `/metadata` attrs for reproducibility. See §Phase 3 below.
 
@@ -297,9 +300,10 @@ def load_SMIL_Unreal_multiview_sample(
 
 **Behaviour**:
 - Auto-detects `dataset_name` and frame count from `_BatchData_*.json`.
-- Builds canonical camera ordering from `sorted(camera_indices)`; the lowest-numbered camera present this frame becomes canonical slot 0.
-- Maps each camera's keypoints into model `J_names` order; tracks an in-dataset bitmap so model-only joints (no dataset GT) stay invisible regardless of mask content.
-- Per-view visibility = `in_dataset AND in_bounds AND id_mask_pass AND depth_pass` (depth term skipped when `depth_occlusion_check=False` or the `_Depth_CAM{id}.png` file is missing).
+- Pre-loads every camera's JSON into memory once (small files), then probes each for valid `subject Data` to build `view_valid_per_view: List[bool]`. Slots with empty `subject Data` are marked False but their camera geometry (R/T/K/FOV) is still extracted — the slot remains usable for the canonical-frame transform.
+- Builds canonical camera ordering from `sorted(camera_indices)`; the lowest-numbered camera present this frame becomes canonical slot 0. **When canonical itself has empty `subject Data`**, the loader still uses its geometry as the canonical-frame anchor but falls back to the first valid camera (in sorted order) for shared pose/shape extraction. **Raises only if no camera in the frame has valid subject data.**
+- Maps each (valid) camera's keypoints into model `J_names` order; tracks an in-dataset bitmap so model-only joints (no dataset GT) stay invisible regardless of mask content. Invalid views get all-zero `keypoints_2d_per_view[v]` and all-False `keypoint_in_dataset_per_view[v]`.
+- Per-view visibility = `in_dataset AND in_bounds AND id_mask_pass AND depth_pass` (depth term skipped when `depth_occlusion_check=False` or the `_Depth_CAM{id}.png` file is missing). For invalid views this short-circuits to all zeros via the initial `in_dataset_this_view = 0` state.
 - When `canonical_frame=True` (default), re-expresses all camera extrinsics, model `root_loc`, `root_rot`, and `keypoints_3d` relative to canonical cam 0. Emits `canonical_to_world = (R_0, t_0)` as the forward transform; the inverse `x_world = (x_can - t_0) @ R_0.T` recovers the original world frame.
 - **Phase 1b scale unification**: multiplies `root_loc`, `cam_trans_per_view`, `keypoints_3d`, `keypoints_3d_world`, and `canonical_to_world_t` by `translation_factor` (default 0.1). Output lands in model-world units where downstream `mesh + trans` (no `×10` model-side rescaling) projects correctly. Pass `translation_factor=1.0` to disable.
 
@@ -336,14 +340,15 @@ def load_SMIL_Unreal_multiview_sample(
     "canonical_cam_id":   int,                       # canonical cam ID, or -1 when canonical_frame=False
 
     # Per-view (V entries each)
-    "keypoints_2d_per_view":        List[np.ndarray],   # V x (n_joints, 2) [y/H, x/W] axis-swapped
-    "keypoint_visibility_per_view": List[np.ndarray],   # V x (n_joints,) float {0, 1}
-    "keypoint_in_dataset_per_view": List[np.ndarray],   # V x (n_joints,) bool — has dataset GT
-    "cam_rot_per_view":             List[torch.Tensor], # V x (3, 3) row-vector world->cam
-    "cam_trans_per_view":           List[torch.Tensor], # V x (3,)
-    "fx_per_view", "fy_per_view":   List[float],        # V
-    "cx_per_view", "cy_per_view":   List[float],        # V
-    "fov_per_view":                 List[float],        # V (degrees, from camera JSON)
+    "keypoints_2d_per_view":        List[np.ndarray],   # V x (n_joints, 2) [y/H, x/W] axis-swapped — zeros when view invalid
+    "keypoint_visibility_per_view": List[np.ndarray],   # V x (n_joints,) float {0, 1} — zeros when view invalid
+    "keypoint_in_dataset_per_view": List[np.ndarray],   # V x (n_joints,) bool — has dataset GT; all False when view invalid
+    "view_valid_per_view":          List[bool],         # V — False when camera's `subject Data` is empty
+    "cam_rot_per_view":             List[torch.Tensor], # V x (3, 3) row-vector world->cam (always valid)
+    "cam_trans_per_view":           List[torch.Tensor], # V x (3,) (always valid)
+    "fx_per_view", "fy_per_view":   List[float],        # V (always valid)
+    "cx_per_view", "cy_per_view":   List[float],        # V (always valid)
+    "fov_per_view":                 List[float],        # V (degrees, from camera JSON, always valid)
 }
 ```
 
@@ -351,6 +356,7 @@ def load_SMIL_Unreal_multiview_sample(
 - 2D keypoints are stored with an **intentional axis swap**: `kp[:, 0] = 2DPos.y / H`, `kp[:, 1] = 2DPos.x / W`. Downstream ID-mask and depth lookups depend on this. Don't "fix" without updating both sides.
 - All extrinsics and 3D points are in **PyTorch3D-mirrored** convention (x-axis negated vs raw Unreal). Projection: `u = -fx * X_cam.x / X_cam.z + cx`, `v = -fy * X_cam.y / X_cam.z + cy`.
 - `keypoint_in_dataset_per_view` is True if the joint name appears in that camera's `keypoints` dict. Use it to distinguish "missing from dataset" from "present but culled by ID/depth".
+- `view_valid_per_view[v]` is False when camera `v` had empty `subject Data` (animal absent from that view's render). Keypoints and visibility are zero-sentinels for those slots; camera geometry is still valid. Downstream the preprocessor maps this to `view_mask[i, v]=False` + `camera_indices[i, v]=-1`, and `SLEAPMultiViewDataset` drops the slot at `__getitem__`.
 
 **Backward compatibility**: `load_SMIL_Unreal_sample()` (single-view) is unchanged.
 
@@ -467,6 +473,7 @@ class replicAntMultiViewPreprocessor:
         compression_level: int = 6,
         frame_skip: int = 1,
         camera_subset: Optional[List[int]] = None,
+        min_views_per_sample: int = 2,        # per-camera resilience: drop frame if fewer valid views
         # Depth visibility-refinement passthrough to the loader.
         # Defaults match load_SMIL_Unreal_multiview_sample.
         depth_occlusion_check: bool = True,
@@ -505,7 +512,8 @@ class replicAntMultiViewPreprocessor:
 
 **Failure handling**:
 - Per-frame: load failures (corrupt JSON, missing image, projection failure, etc.) are caught, logged as `(frame_idx, reason)`, and skipped. A summary count plus the skipped index list are written to `/metadata` attrs (`num_skipped_frames`, `skipped_frame_indices`).
-- Per-camera within a kept frame: failures mark just that view's `view_mask[i, v] = False` and `camera_indices[i, v] = -1`. Frame kept as long as >= 1 view loads.
+- Per-camera within a kept frame: a camera with empty `subject Data` (animal absent from that view's render) is detected up-front in the loader's pre-scan. The loader emits `view_valid_per_view[v] = False` for that slot; the preprocessor in turn writes `view_mask[i, v] = False` + `camera_indices[i, v] = -1`. `/auxiliary/num_views[i]` stores the count of valid (supervisable) slots only. Frames are kept as long as `>= --min_views` cameras have valid subject data (default 2); below that, the frame is added to the skipped ledger with reason `only N/M views have valid subject data`.
+- Shared pose/shape fallback: when the canonical camera (lowest CAM ID) itself has empty subject data, the loader keeps it as the canonical-frame anchor (its geometry is always valid) but reads shared pose/shape from the first other valid camera in canonical order. The canonical-frame inverse still round-trips cleanly (7e-7 on frame 435).
 - HDF5 uses **contiguous sample slots**: `num_samples = number of successfully preprocessed frames`. The mapping back to source frame numbers is via `/auxiliary/frame_idx[sample_idx]`. There are no gaps in the sample axis.
 
 **Parallelism**:
@@ -531,40 +539,52 @@ class replicAntMultiViewPreprocessor:
 --frame_skip         1
 --camera_subset                   optional, list of ints
 --max_frames                      optional; for Step-0 smoke testing
+--min_views          2            minimum cameras with valid subject data; frames below this are skipped
 --depth_occlusion_check           default True; --no_depth_occlusion_check to disable
 --depth_max_cm       1000.0
 --depth_tolerance_cm 5.0
 --depth_neighborhood 1
+--target_resolution  512          stored image resolution (native); dataset class resizes at load
+--translation_factor 0.1          loader-side uniform world scale (Phase 1b)
 --debug              flag
 ```
 
 ---
 
-### Phase 4: Unified Dataset Loading
+### Phase 4: Unified Dataset Loading — COMPLETE (`a9d68a1`)
 
-**Update**: `UnifiedSMILDataset.from_path()` in `smil_datasets.py`
+`UnifiedSMILDataset.from_path()` in `smal_fitter/neuralSMIL/smil_datasets.py`
+now does a real dispatch driven by HDF5 `/metadata` attrs:
 
 ```python
 @staticmethod
 def from_path(data_path, **kwargs):
     """
-    Auto-detect dataset type from a path.
+    Dispatch:
 
-    Detection (in order):
-    1. .h5 / .hdf5  → inspect /metadata.is_multiview
-                       True  → SLEAPMultiViewDataset
-                       False → OptimizedSMILDataset
-    2. Directory containing _BatchData_*.json and at least one
-       {dataset}_00000_CAM*.json → MultiViewreplicAntSMILDataset
-    3. Directory containing _BatchData_*.json with {dataset}_*.json
-       (no _CAM suffix) → replicAntSMILDataset (single-view, current behaviour)
+    - .h5 / .hdf5 → read /metadata attrs:
+        * is_multiview=True (replicAnt or SLEAP multi-view) → SLEAPMultiViewDataset
+        * dataset_type='sleap' (single-view SLEAP)          → SLEAPDataset
+        * otherwise (legacy single-view replicAnt HDF5)     → OptimizedSMILDataset
+
+    - directory:
+        * has _BatchData_*.json AND any *_CAM*.json → replicAnt multi-view flat-dir
+          (raises NotImplementedError → preprocess via Phase 3 first; Phase 2 PyTorch
+          class is intentionally deferred since production reads HDF5)
+        * otherwise → replicAntSMILDataset (single-view JSON layout)
     """
 ```
 
-The multiview replicAnt PyTorch `Dataset` is only used directly for tests and
-ad-hoc validation; **production training reads the HDF5** produced by Phase 3
-through `SLEAPMultiViewDataset`. The PyTorch class is therefore primarily a
-test seam, not a hot path.
+This replaces the runtime monkey-patch that lived in
+`sleap_data/sleap_dataset.py::_patch_unified_dataset` (which had no
+multi-view branch and silently mis-routed multi-view HDF5s to
+`OptimizedSMILDataset`). All four HDF5 flavours and the flat-dir error
+path are verified.
+
+The multiview replicAnt PyTorch `Dataset` (Phase 2) is only useful as a
+test seam — **production training reads the HDF5** produced by Phase 3
+through `SLEAPMultiViewDataset`. The PyTorch class is therefore
+deferred, not blocking.
 
 ---
 
@@ -712,47 +732,49 @@ y_data = {
 
 ## Files to Create/Modify
 
-### New Files (landed this PR):
+### New Files (landed):
 1. `smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py` — `replicAntMultiViewPreprocessor` + `__main__` CLI. **Phase 3 COMPLETE.**
-2. `smal_fitter/replicAnt_data/test_replicant_preprocessing.py` — manual-run round-trip check (HDF5 ↔ `SLEAPMultiViewDataset` ↔ loader byte-equivalence on per-view R, T, K, keypoints, parameters, canonical_to_world inverse).
+2. `smal_fitter/replicAnt_data/test_replicant_preprocessing.py` — manual-run round-trip check (HDF5 ↔ `SLEAPMultiViewDataset` ↔ loader byte-equivalence on per-view R, T, K, keypoints, parameters, canonical_to_world inverse). Handles the per-camera-resilience case (loader emits 12 view slots with `view_valid_per_view[v]` flagging invalid ones, dataset drops the bad slots; the check pairs dataset-active views with the loader's *valid* slots in canonical order).
 3. `smal_fitter/neuralSMIL/configs/examples/multiview_replicant_mice.json` — baseline production multi-view training config with `use_ue_scaling: false`. **Phase 6 COMPLETE.**
 
 ### New Files (still pending):
 4. `smal_fitter/neuralSMIL/multiview_replicant_dataset.py` — `MultiViewreplicAntSMILDataset` (Phase 2, test seam only; production reads HDF5).
 
-### Modified Files (this PR):
-1. `smal_fitter/Unreal2Pytorch3D.py` — **Phase 1b**: `translation_factor=0.1` default and applied through to `root_loc`, `cam_trans_per_view`, `keypoints_3d`, `keypoints_3d_world`, `canonical_to_world_t`.
-2. `tests/validate_multiview_replicant_loader.py` — `_compute_posed_smal_joints` drops the `*10` to match the new loader convention (data already scaled, so model placement is plain `(joints - root) + trans`).
-3. `smal_fitter/replicAnt_data/__init__.py` — docstring promoted preprocessor from "planned" to landed.
-4. `.gitignore` — scratch patterns for probes, smoke HDF5s, smoke output dirs.
+### Modified Files (landed):
+1. `smal_fitter/Unreal2Pytorch3D.py` — multi-view loader: canonical-frame storage, depth visibility refinement, in-dataset bitmap (Phase 1); `translation_factor=0.1` default through `root_loc` / `cam_trans_per_view` / `keypoints_3d` / `keypoints_3d_world` / `canonical_to_world_t` (Phase 1b); `(0,0,0)` sentinel re-applied after canonical+scale (Phase 1c); cv2 fast-path for JPG and depth (`aefb06d`); per-camera validity pre-scan emitting `view_valid_per_view`, shared pose/shape fallback to first valid camera (`3de0f55`).
+2. `smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py` — `--min_views` CLI arg, per-view `view_mask` driven by `view_valid_per_view`, `/auxiliary/num_views[i]` now counts valid slots, `/metadata/min_views_per_sample` reflects the actual policy (`3de0f55`).
+3. `smal_fitter/neuralSMIL/smil_datasets.py` — **Phase 4**: real `from_path` dispatch driven by `/metadata` attrs, plus flat-dir `_CAM*.json` detection (`a9d68a1`).
+4. `smal_fitter/neuralSMIL/train_smil_regressor.py` — drops the `_patch_unified_dataset` call (no longer needed) (`a9d68a1`).
+5. `smal_fitter/sleap_data/sleap_dataset.py` — `_patch_unified_dataset` removed; documents that dispatch now lives in `smil_datasets.from_path` (`a9d68a1`).
+6. `tests/validate_multiview_replicant_loader.py` — `_compute_posed_smal_joints` drops the `*10` to match the new loader convention.
+7. `smal_fitter/replicAnt_data/__init__.py` — docstring promoted preprocessor from "planned" to landed.
+8. `.gitignore` — scratch patterns for probes, smoke HDF5s, smoke output dirs.
 
-### Modified Files (Phase 1 landed earlier on this branch):
-1. `smal_fitter/Unreal2Pytorch3D.py` — multi-view loader (canonical-frame storage, depth visibility refinement, in-dataset bitmap).
-2. `smal_fitter/replicAnt_data/__init__.py` — created with depth work.
-3. `smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py` — per-view depth-occlusion diagnostic.
-
-### Modified Files (pending — out of this PR):
-1. `smal_fitter/neuralSMIL/smil_datasets.py` — **Phase 4**: extend `UnifiedSMILDataset.from_path()` with the flat-directory `_CAM*.json` detection branch.
+### Modified Files (pending — out of this branch):
+1. *(none blocking)* — Phase 2 single-view direct-load class, Phase 5 single-view sampler, and the single-view scale-unification follow-up are all independent next steps.
 
 ### No Changes Needed:
-- `train_multiview_regressor.py`, `multiview_smil_regressor.py`, `sleap_multiview_dataset.py` — Phase 3 produces an HDF5 that already matches the SLEAP schema; trainer reads it via the existing class. Smoke training (5 epochs on the 500-frame HDF5) confirmed `use_ue_scaling=false` train path converges normally.
+- `train_multiview_regressor.py`, `multiview_smil_regressor.py`, `sleap_multiview_dataset.py` — Phase 3 produces an HDF5 that already matches the SLEAP schema; trainer reads it via the existing class. Smoke training (1 epoch on the full 500-frame HDF5 with all per-camera-resilient samples) confirmed the `use_ue_scaling=false` train path is stable end-to-end.
 - `train_smil_regressor.py`, `smil_image_regressor.py` — single-view sampler is Phase 5 (deferred).
 
 ---
 
 ## Implementation Order
 
-1. ✅ **Step 1** — Phase 1 loader: canonical-frame storage, depth visibility refinement, in-dataset bitmap. (Landed earlier.)
-2. ✅ **Step 2** — Phase 3: `replicAntMultiViewPreprocessor` + `__main__` CLI. (This PR.)
-3. ✅ **Step 3** — Step-0 smoke test (see §Status → "Phase 3 highlights" for numbers):
-   - 500-frame HDF5 produced (497 written, 3 skipped as `subject Data == []` edge cases).
+1. ✅ **Step 1** — Phase 1 loader: canonical-frame storage, depth visibility refinement, in-dataset bitmap.
+2. ✅ **Step 2** — Phase 3: `replicAntMultiViewPreprocessor` + `__main__` CLI.
+3. ✅ **Step 3** — Step-0 smoke test:
+   - 500-frame HDF5 produced (497 written, 3 skipped as `subject Data == []` edge cases — later RESOLVED by per-camera resilience, see Step 8).
    - Round-trip check (samples 0, 100, 250, 496): byte-equivalent loader ↔ HDF5 on R, T, K, keypoints, parameters; canonical inverse recovers raw world to 1.4e-6 (excluding (0,0,0) sentinel entries).
    - 5-epoch multi-view training run (post-sentinel-fix): train loss **2.27 → 0.49** monotonic ↓, best val 0.49; `keypoint_3d` train 8.35 → 1.83 (5.4× drop vs the initial ghost-joint run); per-view reprojection converges; `trans` head supervises without divergence. Visualisation reports `Plotted joints: 31, Suppressed: 9` confirming the (0,0,0) sentinel is respected end-to-end.
-4. ⏳ **Step 4** — Phase 4: extend `UnifiedSMILDataset.from_path()` auto-detection. (Out of this PR.)
-5. ⏳ **Step 5** — Phase 2: add `MultiViewreplicAntSMILDataset` test seam (low priority; production reads HDF5). (Out of this PR.)
+4. ✅ **Step 4** — Phase 4: `UnifiedSMILDataset.from_path()` real dispatch (`a9d68a1`). Replaces the SLEAP runtime monkey-patch.
+5. ✅ **Step 5** — cv2/imageio loader hybrid (`aefb06d`). cv2 for JPG + depth (the ~80% slower ID-mask PNG path stays on imageio); projected 38% decode-time reduction.
 6. ✅ **Step 6** — `multiview_replicant_mice.json` example config landed.
+7. ✅ **Step 7** — Per-camera resilience (`3de0f55`): `--min_views` + `view_valid_per_view`. The 3 previously-skipped smoke frames are now retained with `view_mask=False` on the bad slot; full-coverage SMOKE training over all 500 samples (1 epoch, ViT-large frozen, 8m19s wall) completes cleanly.
+8. ⏳ **Step 8** — Phase 2: add `MultiViewreplicAntSMILDataset` test seam (low priority; production reads HDF5).
+9. ⏳ **Step 9** — Single-view scale unification follow-up (separate PR): apply `0.1` rescale in `load_SMIL_Unreal_sample`, flip single-view configs to `use_ue_scaling=False`.
 
-After this PR, the full 10k-frame preprocess and production training run unblock. Phase 4 + 5 + the single-view scale unification follow-up are independent next steps.
+The integration is now production-ready: the full 10k-frame preprocess and production training run are unblocked, and the only deferred items (test seam, single-view scale unification, ruff/import refactor) are independent next steps that don't gate this branch.
 
 ---
 

--- a/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
+++ b/MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md
@@ -78,6 +78,19 @@ makes mesh-native and data-frame units coincide:
 - HDF5 metadata: `world_scale = 1.0`. No downstream rescaling.
 - Multi-view training configs: `use_ue_scaling: false` and the model uses the
   `joints + trans` placement branch (no recenter-and-rescale).
+- **(0,0,0) sentinel for missing 3D GT**: joints in `config.dd["J_names"]`
+  that don't appear in the dataset's `pose_data` keypoints dict (e.g. for the
+  Falkner-conv mouse: `head_top`, `Eye_L/R`, `paw_L_tip`, `paw_R_tip`, `Spine`,
+  `Trunk`, `Foot_L_lower`, `Foot_R_lower`) get zero-padded into
+  `keypoints_3d_world` initially. After the canonical-frame transform a zero
+  row maps to `t_0` and lands at the canonical camera's position — a
+  meaningless 3D target ~10 units from the mesh cluster. The loader therefore
+  **re-zeros these rows AFTER all transforms** (canonical-frame + scale), so
+  both `keypoints_3d` and `keypoints_3d_world` carry `(0,0,0)` for unmapped
+  joints — the SLEAP convention. Downstream consumers detect missing joints
+  via `~np.all(kp3d == 0, axis=1)` (the validation harness and trainer
+  visualisation already use this pattern; epoch viz reports
+  `Plotted joints: 31, Suppressed: 9` on the mouse dataset).
 
 **Single-view convention (UNCHANGED, legacy):**
 - `load_SMIL_Unreal_sample(translation_factor=0.01, …)` returns raw Unreal
@@ -733,8 +746,8 @@ y_data = {
 2. ✅ **Step 2** — Phase 3: `replicAntMultiViewPreprocessor` + `__main__` CLI. (This PR.)
 3. ✅ **Step 3** — Step-0 smoke test (see §Status → "Phase 3 highlights" for numbers):
    - 500-frame HDF5 produced (497 written, 3 skipped as `subject Data == []` edge cases).
-   - Round-trip check (samples 0, 100, 250, 496): byte-equivalent loader ↔ HDF5 on R, T, K, keypoints, parameters; canonical inverse recovers raw world to 1.4e-6.
-   - 5-epoch multi-view training run: train loss 4.34 → 2.54 monotonic ↓; per-view reprojection converges; `trans` head supervises without divergence.
+   - Round-trip check (samples 0, 100, 250, 496): byte-equivalent loader ↔ HDF5 on R, T, K, keypoints, parameters; canonical inverse recovers raw world to 1.4e-6 (excluding (0,0,0) sentinel entries).
+   - 5-epoch multi-view training run (post-sentinel-fix): train loss **2.27 → 0.49** monotonic ↓, best val 0.49; `keypoint_3d` train 8.35 → 1.83 (5.4× drop vs the initial ghost-joint run); per-view reprojection converges; `trans` head supervises without divergence. Visualisation reports `Plotted joints: 31, Suppressed: 9` confirming the (0,0,0) sentinel is respected end-to-end.
 4. ⏳ **Step 4** — Phase 4: extend `UnifiedSMILDataset.from_path()` auto-detection. (Out of this PR.)
 5. ⏳ **Step 5** — Phase 2: add `MultiViewreplicAntSMILDataset` test seam (low priority; production reads HDF5). (Out of this PR.)
 6. ✅ **Step 6** — `multiview_replicant_mice.json` example config landed.
@@ -832,18 +845,22 @@ saw implicit gradient could destabilise training.
 **Empirical result (5-epoch smoke training, 500-frame subset, ViT-large
 backbone frozen, batch=1):**
 
-- Per-view reprojection loss converges to noise floor (kp2d normalised ≈ 0.06)
+- Per-view reprojection loss converges to noise floor (kp2d normalised ≈ 0.05)
   in the first epoch — frame convention is geometrically sound, no per-view
   loss divergence.
-- Direct `trans` supervision **does not destabilise** training. Train loss
-  decreased monotonically 4.34 → 3.01 → 2.95 → 2.73 → 2.54 over 5 epochs.
-- At epoch-3 visualization sample, predicted `trans z ≈ 13.23` vs GT `12.67` —
-  the head learned the right magnitude without any weight tuning, kept the
-  default loss weight (0.001).
+- Direct `trans` supervision **does not destabilise** training. After the
+  (0,0,0)-sentinel fix for missing 3D GT (see "Multi-view convention" above),
+  train loss decreased monotonically 2.27 → 1.00 → 0.84 → 0.59 → 0.49 over
+  5 epochs (5.2× lower than the ghost-joint pre-fix run).
+- `keypoint_3d` train loss dropped 5.4× (8.35 → 1.83) after fixing the
+  ghost-joint sentinel; the 9 unmapped J_names (no replicAnt GT) had been
+  contributing meaningless target positions at the canonical-camera location
+  before the fix.
 - `use_ue_scaling=false` model placement branch (`(joints - root) + trans`,
   no `*10`) verified end-to-end on real data.
 
-**Conclusion**: scale-unified canonical-camera-frame storage + direct `trans`
-supervision is the working configuration. Full 10k-frame preprocess + production
-training run is unblocked.
+**Conclusion**: scale-unified canonical-camera-frame storage + (0,0,0)
+sentinel for missing 3D GT + direct `trans` supervision is the working
+configuration. Full 10k-frame preprocess + production training run is
+unblocked.
 

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -1399,6 +1399,7 @@ def load_SMIL_Unreal_multiview_sample(
 
     keypoints_2d_per_view = []
     keypoint_visibility_per_view = []
+    keypoint_in_dataset_per_view = []
     cam_rot_per_view = []
     cam_trans_per_view = []
     fx_per_view = []
@@ -1473,20 +1474,31 @@ def load_SMIL_Unreal_multiview_sample(
                 norm_y = 0.5
             keypoints_2d.append([norm_x, norm_y])
 
-        # Map to SMIL joint order
+        # Map to SMIL joint order. Track which model J_names actually
+        # have a matching dataset entry this view; model-only joints
+        # have no GT 2D (left at the [0, 0] sentinel) and must NOT be
+        # treated as visible — see the visibility initialisation below.
         mapped_keypoints_2d = np.zeros((len(config.dd["J_names"]), 2), float)
+        in_dataset_this_view = np.zeros(len(config.dd["J_names"]), dtype=bool)
         for o, orig_joint in enumerate(config.dd["J_names"]):
             for m, mapped_joint in enumerate(keypoint_names):
                 if orig_joint == mapped_joint:
                     mapped_keypoints_2d[o] = keypoints_2d[m]
+                    in_dataset_this_view[o] = True
 
         keypoints_2d_per_view.append(mapped_keypoints_2d)
+        keypoint_in_dataset_per_view.append(in_dataset_this_view)
 
-        # Compute per-camera visibility using ID mask
-        visibility = np.ones(len(config.dd["J_names"]))
+        # Initialise visibility from the in-dataset bitmap so model-only
+        # joints stay invisible regardless of where their [0, 0]
+        # sentinel happens to land on the ID/depth pass. The bounds /
+        # mask / depth steps below can only ever decrease visibility.
+        visibility = in_dataset_this_view.astype(np.float64)
         if mask_data[-1] is not None:
             id_mask = mask_data[-1]
             for i, (norm_x, norm_y) in enumerate(mapped_keypoints_2d):
+                if visibility[i] == 0.0:
+                    continue  # not in dataset — never visible
                 # Check bounds
                 if not (0 <= norm_x <= 1.0 and 0 <= norm_y <= 1.0):
                     visibility[i] = 0.0
@@ -1499,6 +1511,8 @@ def load_SMIL_Unreal_multiview_sample(
         else:
             # Fallback: only check bounds
             for i, (norm_x, norm_y) in enumerate(mapped_keypoints_2d):
+                if visibility[i] == 0.0:
+                    continue  # not in dataset — never visible
                 if not (0 <= norm_x <= 1.0 and 0 <= norm_y <= 1.0):
                     visibility[i] = 0.0
 
@@ -1654,6 +1668,7 @@ def load_SMIL_Unreal_multiview_sample(
     # Populate y_output with per-view data
     y_output["keypoints_2d_per_view"] = keypoints_2d_per_view
     y_output["keypoint_visibility_per_view"] = keypoint_visibility_per_view
+    y_output["keypoint_in_dataset_per_view"] = keypoint_in_dataset_per_view
     y_output["cam_rot_per_view"] = cam_rot_per_view
     y_output["cam_trans_per_view"] = cam_trans_per_view
     y_output["fx_per_view"] = fx_per_view

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -671,16 +671,118 @@ def create_sphere_meshes_at_points(
     return spheres_mesh
 
 
+def refine_visibility_with_depth(
+    visibility,
+    keypoints_2d_normalized,
+    keypoints_3d_world_raw,
+    camera_location_world_raw,
+    depth_image,
+    image_width,
+    image_height,
+    depth_max_cm=1000.0,
+    depth_tolerance_cm=5.0,
+    depth_neighborhood=1,
+):
+    """
+    Refine a per-joint visibility array with a replicAnt depth-buffer
+    self-occlusion check. Mirrors the convention used in the sungaya
+    pipeline so the two stay byte-equivalent.
+
+    Encoding: replicAnt's depth pass packs a Euclidean camera-to-surface
+    distance (in cm) into the RED channel of an RGBA uint8 PNG via a
+    linear map `surface_cm = (R / 255) * depth_max_cm`. A joint is
+    occluded when the keypoint's true distance to the camera exceeds
+    the front-most surface distance (over a small neighborhood) by more
+    than `depth_tolerance_cm`.
+
+    Coordinates here are in raw Unreal world frame (cm, no PyTorch3D
+    x-mirror). The (R/255)*range mapping is preserved, and distances
+    are coordinate-frame agnostic as long as keypoint and camera live
+    in the same frame.
+
+    The refinement is monotone: it can only turn 1.0 -> 0.0, never the
+    other way. Joints already at 0.0 and joints whose 3D ground truth
+    is missing (NaN) are skipped.
+
+    Args:
+        visibility (np.array): Current visibility per joint (1.0 or 0.0). Refined in place AND returned.
+        keypoints_2d_normalized (np.array): (n_joints, 2) — same axis-swapped
+            (norm_x = 2DPos.y / H, norm_y = 2DPos.x / W) convention as the
+            rest of this module. (row_idx, col_idx) = (norm_x * H, norm_y * W).
+        keypoints_3d_world_raw (np.array): (n_joints, 3) — raw Unreal 3DPos
+            in cm. NaN for joints with no ground-truth 3D position.
+        camera_location_world_raw (np.array): (3,) — raw Unreal camera
+            `Location` in cm.
+        depth_image (np.array): (H, W, 4) uint8 RGBA loaded via imageio. Depth
+            is in channel 0. Pass None to skip the refinement (visibility
+            returned unchanged).
+        image_width (int), image_height (int): Reference resolution that
+            `keypoints_2d_normalized` was normalised against.
+        depth_max_cm (float): Encoded range for the depth pass (cm).
+        depth_tolerance_cm (float): Margin added to the surface distance
+            before declaring a keypoint occluded. NB the depth pass is
+            8-bit over `depth_max_cm` so one LSB ≈ depth_max_cm/255 cm
+            (~3.92 cm at the 1000 cm default) — set tolerance to at
+            least one LSB plus the expected interior-joint offset, or
+            interior skeletal joints will get clipped.
+        depth_neighborhood (int): Half-window in pixels for the surface
+            min-depth lookup. `0` samples exactly one pixel; `1` uses 3x3.
+
+    Returns:
+        np.array: Updated visibility array (same object as input).
+    """
+    if depth_image is None:
+        return visibility
+    if depth_image.ndim != 3 or depth_image.shape[2] < 1:
+        return visibility
+    if (
+        depth_image.shape[0] != image_height
+        or depth_image.shape[1] != image_width
+    ):
+        return visibility
+
+    cam_loc = np.asarray(camera_location_world_raw, dtype=np.float64)
+
+    for j in range(len(visibility)):
+        if visibility[j] == 0.0:
+            continue
+        p3 = keypoints_3d_world_raw[j]
+        if not np.isfinite(p3).all():
+            continue
+
+        norm_x, norm_y = keypoints_2d_normalized[j]
+        if not (0.0 <= norm_x <= 1.0 and 0.0 <= norm_y <= 1.0):
+            continue
+        pixel_row = int(np.clip(norm_x * image_height, 0, image_height - 1))
+        pixel_col = int(np.clip(norm_y * image_width, 0, image_width - 1))
+
+        if depth_neighborhood <= 0:
+            r_val = int(depth_image[pixel_row, pixel_col, 0])
+        else:
+            r0 = max(0, pixel_row - depth_neighborhood)
+            r1 = min(image_height, pixel_row + depth_neighborhood + 1)
+            c0 = max(0, pixel_col - depth_neighborhood)
+            c1 = min(image_width, pixel_col + depth_neighborhood + 1)
+            r_val = int(depth_image[r0:r1, c0:c1, 0].min())
+
+        surface_cm = (r_val / 255.0) * depth_max_cm
+        dist_cm = float(np.linalg.norm(p3.astype(np.float64) - cam_loc))
+        if dist_cm > (surface_cm + depth_tolerance_cm):
+            visibility[j] = 0.0
+
+    return visibility
+
+
 def compute_keypoint_visibility(keypoints_2d, mask, image_width, image_height):
     """
     Compute keypoint visibility based on mask and image bounds.
-    
+
     Args:
         keypoints_2d (np.array): Normalized 2D keypoint coordinates [0, 1]
         mask (np.array): Binary mask of the object (None if not available, already dilated when loaded)
         image_width (int): Image width in pixels
         image_height (int): Image height in pixels
-        
+
     Returns:
         np.array: Visibility array (1 for visible, 0 for not visible)
     """
@@ -1087,6 +1189,10 @@ def load_SMIL_Unreal_multiview_sample(
     translation_factor: float = 0.01,
     load_images: bool = True,
     canonical_frame: bool = True,
+    depth_occlusion_check: bool = True,
+    depth_max_cm: float = 1000.0,
+    depth_tolerance_cm: float = 5.0,
+    depth_neighborhood: int = 1,
     verbose: bool = False
 ):
     """
@@ -1103,6 +1209,22 @@ def load_SMIL_Unreal_multiview_sample(
         propagate_scaling (bool): Whether to propagate scaling to child joints
         translation_factor (float): Factor to multiply translation by
         load_images (bool): Whether to load image data
+        depth_occlusion_check (bool): If True (default), refine per-view
+            visibility with the replicAnt depth-buffer self-occlusion test.
+            AND-composed with the existing ID-mask check. Falls back
+            silently to id-mask-only visibility for any view whose
+            `_Depth_CAM{id}.png` is absent.
+        depth_max_cm (float): Encoded range of the depth pass in cm.
+            replicAnt defaults to 1000 cm; tune only if the depth pass was
+            re-exported with a different range.
+        depth_tolerance_cm (float): Margin added to the surface distance
+            before declaring a joint occluded. Default of 5 cm is one
+            depth-LSB (~3.92 cm at the 1000 cm range) plus ~1 cm
+            interior-joint slack; bump if interior joints still get
+            clipped.
+        depth_neighborhood (int): Half-window in pixels for the surface
+            min-depth sample. 0 = exact pixel; 1 = 3x3 patch (default,
+            matches sungaya).
         canonical_frame (bool): If True (default), re-express all camera
             extrinsics and model pose in the canonical camera's frame
             (lowest CAM ID -> R=I, t=0). If False, leave everything in
@@ -1249,11 +1371,31 @@ def load_SMIL_Unreal_multiview_sample(
     y_output["root_rot"] = global_rotation_np
     y_output["pose_data"] = pose_data  # Keep raw pose data for compatibility
 
+    # Raw-Unreal-frame 3D keypoints (no x-mirror). Needed for the depth
+    # occlusion check, where the camera Location is read from the JSON
+    # un-mirrored and distances must be computed in a consistent frame.
+    # Missing joints stay NaN so the depth helper skips them.
+    keypoints_3d_unreal_raw = np.full(
+        (len(config.dd["J_names"]), 3), np.nan, dtype=np.float32
+    )
+    if depth_occlusion_check:
+        kp3d_raw_by_name = {}
+        for k, kp in pose_data.items():
+            p3 = kp.get("3DPos")
+            if p3 is not None:
+                kp3d_raw_by_name[k] = np.array(
+                    [p3["x"], p3["y"], p3["z"]], dtype=np.float32
+                )
+        for o, j in enumerate(config.dd["J_names"]):
+            if j in kp3d_raw_by_name:
+                keypoints_3d_unreal_raw[o] = kp3d_raw_by_name[j]
+
     # Per-camera lists
     image_data = []
     image_paths = []
     mask_data = []
     mask_paths = []
+    depth_paths = []
 
     keypoints_2d_per_view = []
     keypoint_visibility_per_view = []
@@ -1298,6 +1440,17 @@ def load_SMIL_Unreal_multiview_sample(
         else:
             mask_data.append(None)
         mask_paths.append(str(mask_path))
+
+        # Load depth pass for the self-occlusion refinement. Optional —
+        # if the file is missing we fall back to id-mask-only visibility
+        # for this view per the design decision.
+        depth_path = json_path.with_name(
+            f"{dataset_name}_{frame_index:05d}_Depth_CAM{cam_id}.png"
+        )
+        depth_paths.append(str(depth_path))
+        depth_image = None
+        if depth_occlusion_check and depth_path.exists():
+            depth_image = imageio.v2.imread(str(depth_path))
 
         # Extract per-camera 2D keypoints. The shared `pose_data` above was
         # read from the first camera's JSON; 2DPos is per-camera, so we re-
@@ -1348,6 +1501,30 @@ def load_SMIL_Unreal_multiview_sample(
             for i, (norm_x, norm_y) in enumerate(mapped_keypoints_2d):
                 if not (0 <= norm_x <= 1.0 and 0 <= norm_y <= 1.0):
                     visibility[i] = 0.0
+
+        # Depth-buffer self-occlusion refinement (AND with id-mask result).
+        # No-op when depth_image is None (missing file or check disabled).
+        if depth_occlusion_check and depth_image is not None:
+            cam_loc_unreal_raw = np.array(
+                [
+                    cam_data["iterationData"]["camera"]["Location"]["x"],
+                    cam_data["iterationData"]["camera"]["Location"]["y"],
+                    cam_data["iterationData"]["camera"]["Location"]["z"],
+                ],
+                dtype=np.float32,
+            )
+            refine_visibility_with_depth(
+                visibility=visibility,
+                keypoints_2d_normalized=mapped_keypoints_2d,
+                keypoints_3d_world_raw=keypoints_3d_unreal_raw,
+                camera_location_world_raw=cam_loc_unreal_raw,
+                depth_image=depth_image,
+                image_width=image_width,
+                image_height=image_height,
+                depth_max_cm=depth_max_cm,
+                depth_tolerance_cm=depth_tolerance_cm,
+                depth_neighborhood=depth_neighborhood,
+            )
 
         keypoint_visibility_per_view.append(visibility)
 
@@ -1470,6 +1647,7 @@ def load_SMIL_Unreal_multiview_sample(
     x_output["image_paths"] = image_paths
     x_output["input_image_mask"] = mask_data
     x_output["mask_paths"] = mask_paths
+    x_output["depth_paths"] = depth_paths
     x_output["num_views"] = len(camera_indices)
     x_output["camera_ids"] = camera_indices
 

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -1086,6 +1086,7 @@ def load_SMIL_Unreal_multiview_sample(
     propagate_scaling: bool = True,
     translation_factor: float = 0.01,
     load_images: bool = True,
+    canonical_frame: bool = True,
     verbose: bool = False
 ):
     """
@@ -1102,6 +1103,13 @@ def load_SMIL_Unreal_multiview_sample(
         propagate_scaling (bool): Whether to propagate scaling to child joints
         translation_factor (float): Factor to multiply translation by
         load_images (bool): Whether to load image data
+        canonical_frame (bool): If True (default), re-express all camera
+            extrinsics and model pose in the canonical camera's frame
+            (lowest CAM ID -> R=I, t=0). If False, leave everything in
+            raw PyTorch3D-mirrored world frame. See the canonical-frame
+            block below for the transformation, conventions, and the
+            decision to store the FORWARD transform under
+            `canonical_to_world`.
         verbose (bool): Whether to print verbose output
 
     Returns:
@@ -1116,6 +1124,17 @@ def load_SMIL_Unreal_multiview_sample(
             - y_output (dict): Shared and per-view parameters
                 - Shared data (identical across cameras):
                   - joint_angles, shape_betas, root_loc, root_rot, etc.
+                  - keypoints_3d: (n_joints, 3) GT 3D in canonical frame
+                    when canonical_frame=True, otherwise world frame.
+                    Mapped to model J_names order; zeros for missing.
+                  - keypoints_3d_world: same shape; always raw
+                    PyTorch3D-mirrored world frame (kept for round-trip
+                    checks and convention-switch flexibility).
+                  - canonical_to_world: tuple (R_0, t_0) — the FORWARD
+                    transform world -> canonical (x_can = x_w @ R_0 + t_0).
+                    Invert at decode time: x_w = (x_can - t_0) @ R_0.T.
+                  - canonical_cam_id: int — CAM ID used as canonical, or
+                    -1 when canonical_frame=False.
                 - Per-camera data:
                   - keypoints_2d_per_view: List of [n_joints, 2] arrays
                   - keypoint_visibility_per_view: List of [n_joints] visibility arrays
@@ -1353,6 +1372,98 @@ def load_SMIL_Unreal_multiview_sample(
 
         if verbose:
             print(f"  CAM{cam_id}: fx={fx:.2f}, fy={fy:.2f}, visible_joints={int(np.sum(visibility))}/{len(visibility)}")
+
+    # ------------------------------------------------------------------
+    # 3D ground-truth keypoints in raw world frame (PyTorch3D-mirrored,
+    # same convention as cam_rot_per_view / cam_trans_per_view / model_loc).
+    # ------------------------------------------------------------------
+    kp3d_by_name = {}
+    for k, kp in pose_data.items():
+        p3 = kp.get("3DPos")
+        if p3 is not None:
+            kp3d_by_name[k] = np.array(
+                [-p3["x"], p3["y"], p3["z"]], dtype=np.float32
+            )
+    keypoints_3d_world = np.zeros(
+        (len(config.dd["J_names"]), 3), dtype=np.float32
+    )
+    for o, j in enumerate(config.dd["J_names"]):
+        if j in kp3d_by_name:
+            keypoints_3d_world[o] = kp3d_by_name[j]
+
+    # ------------------------------------------------------------------
+    # Canonical-camera-frame transformation.
+    #
+    # Pick the lowest CAM ID (camera_indices[0] after the sort above) as
+    # the canonical camera. Define a new world frame in which that
+    # camera's extrinsics are identity — i.e. the canonical frame IS
+    # cam-0's view — and re-express everything relative to it.
+    #
+    # Forward transform world -> canonical:
+    #     x_can = x_world @ R_0 + t_0
+    # where (R_0, t_0) are cam-0's row-vector PyTorch3D-mirrored
+    # extrinsics. Derivation (row-vector convention throughout):
+    #     R_v'                  = R_0.T @ R_v
+    #     t_v'                  = t_v - t_0 @ R_v'
+    #     root_loc'             = root_loc @ R_0 + t_0
+    #     R_root_can_col        = R_0.T @ R_root_col   (scipy col-vec form)
+    #     keypoints_3d_can      = keypoints_3d_world @ R_0 + t_0
+    #
+    # Storage choice: y_output emits `canonical_to_world = (R_0, t_0)`
+    # as the FORWARD transform — not its inverse. We picked forward
+    # because (R_0, t_0) IS the artifact computed at the canonical site,
+    # storing it avoids drift from re-deriving, and the canonical
+    # frame's definition stays visible at the storage point. Consumers
+    # that need world-frame coordinates apply the inverse explicitly:
+    #     x_world = (x_canonical - t_0) @ R_0.T
+    # ------------------------------------------------------------------
+    if canonical_frame:
+        canonical_cam_idx = 0  # lowest CAM ID, first in sorted camera_indices
+        R_0 = cam_rot_per_view[canonical_cam_idx].clone()
+        t_0 = cam_trans_per_view[canonical_cam_idx].clone()
+        R_0_np = R_0.numpy()
+        t_0_np = t_0.numpy()
+
+        for v in range(len(camera_indices)):
+            R_v = cam_rot_per_view[v]
+            t_v = cam_trans_per_view[v]
+            R_v_can = R_0.T @ R_v
+            t_v_can = t_v - t_0 @ R_v_can
+            cam_rot_per_view[v] = R_v_can
+            cam_trans_per_view[v] = t_v_can
+
+        model_loc = (model_loc @ R_0_np + t_0_np).astype(np.float32)
+
+        R_root_col = Rotation.from_rotvec(global_rotation_np).as_matrix()
+        R_root_can_col = R_0_np.T @ R_root_col
+        global_rotation_np = (
+            Rotation.from_matrix(R_root_can_col).as_rotvec().astype(np.float32)
+        )
+
+        keypoints_3d = (keypoints_3d_world @ R_0_np + t_0_np).astype(np.float32)
+
+        canonical_to_world = (
+            R_0_np.astype(np.float32),
+            t_0_np.astype(np.float32),
+        )
+        canonical_cam_id = int(camera_indices[canonical_cam_idx])
+    else:
+        keypoints_3d = keypoints_3d_world.copy()
+        canonical_to_world = (
+            np.eye(3, dtype=np.float32),
+            np.zeros(3, dtype=np.float32),
+        )
+        canonical_cam_id = -1  # sentinel: no canonical frame applied
+
+    # Overwrite the earlier raw-frame assignments with (possibly)
+    # canonical-frame values. pose_data is left untouched for
+    # backwards compatibility with consumers that re-derive from it.
+    y_output["root_loc"] = model_loc
+    y_output["root_rot"] = global_rotation_np
+    y_output["keypoints_3d"] = keypoints_3d
+    y_output["keypoints_3d_world"] = keypoints_3d_world
+    y_output["canonical_to_world"] = canonical_to_world
+    y_output["canonical_cam_id"] = canonical_cam_id
 
     # Populate x_output
     x_output["image_data"] = image_data

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -1186,7 +1186,7 @@ def load_SMIL_Unreal_multiview_sample(
     frame_index: int,
     camera_indices: list = None,
     propagate_scaling: bool = True,
-    translation_factor: float = 0.01,
+    translation_factor: float = 0.1,
     load_images: bool = True,
     canonical_frame: bool = True,
     depth_occlusion_check: bool = True,
@@ -1207,7 +1207,13 @@ def load_SMIL_Unreal_multiview_sample(
         camera_indices (list, optional): List of camera IDs to load (e.g., [1,2,3]).
                                         If None, loads all 12 cameras.
         propagate_scaling (bool): Whether to propagate scaling to child joints
-        translation_factor (float): Factor to multiply translation by
+        translation_factor (float): Uniform scale applied at load time to all
+            world-frame translations (`root_loc`, `cam_trans_per_view`,
+            `keypoints_3d`, `keypoints_3d_world`, `canonical_to_world_t`).
+            Default 0.1 matches the SMAL mouse mesh's native size to the
+            Unreal data frame, so trainer-side `mesh + trans` (no extra
+            rescaling) projects correctly with `use_ue_scaling=False`.
+            See "Scale Unification" in MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md.
         load_images (bool): Whether to load image data
         depth_occlusion_check (bool): If True (default), refine per-view
             visibility with the replicAnt depth-buffer self-occlusion test.
@@ -1645,6 +1651,28 @@ def load_SMIL_Unreal_multiview_sample(
             np.zeros(3, dtype=np.float32),
         )
         canonical_cam_id = -1  # sentinel: no canonical frame applied
+
+    # ------------------------------------------------------------------
+    # Scale unification (Phase 1b). Apply `translation_factor` uniformly
+    # to all world-frame translations and 3D coordinates. Default 0.1
+    # makes mesh-native and data-frame units coincide so that downstream
+    # consumers can use `mesh + trans` (no `(mesh - root) * 10 + trans`
+    # hack). Rotations are scale-invariant and untouched. All canonical-
+    # frame relationships are preserved because uniform scaling commutes
+    # with the canonical-frame transform.
+    # See "Scale Unification" in MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md.
+    # ------------------------------------------------------------------
+    s = float(translation_factor)
+    if s != 1.0:
+        model_loc = (model_loc * s).astype(np.float32)
+        keypoints_3d = (keypoints_3d * s).astype(np.float32)
+        keypoints_3d_world = (keypoints_3d_world * s).astype(np.float32)
+        canonical_to_world = (
+            canonical_to_world[0],
+            (canonical_to_world[1] * s).astype(np.float32),
+        )
+        for v in range(len(camera_indices)):
+            cam_trans_per_view[v] = cam_trans_per_view[v] * s
 
     # Overwrite the earlier raw-frame assignments with (possibly)
     # canonical-frame values. pose_data is left untouched for

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -6,6 +6,8 @@ import torch
 import os
 import imageio
 import sys
+from pathlib import Path
+from typing import List, Tuple, Dict, Optional
 from scipy.spatial.transform import Rotation
 
 sys.path.append(os.path.dirname(sys.path[0]))
@@ -154,6 +156,23 @@ def sample_pca_transforms_from_dirs(dd: dict, scale_weights, trans_weights, bone
 """
 Unreal data parsing functions
 """
+
+
+def _detect_pose_root(pose_data):
+    """Return the name of the hierarchical root joint in a replicAnt pose_data dict.
+
+    Strategy:
+      1. If ``config.ROOT_JOINT`` is a key in pose_data, use it (legacy
+         bug-skeleton datasets generated against the active SMAL model rely
+         on this — preserves backwards compatibility).
+      2. Otherwise fall back to the first key, which by Unreal serialisation
+         convention is the root of the skeleton hierarchy (e.g. ``'Mskel'``
+         for the mouse rig, ``'b_t'`` for the bug rig). This makes the loader
+         independent of which SMAL model happens to be loaded in ``config``.
+    """
+    if config.ROOT_JOINT in pose_data:
+        return config.ROOT_JOINT
+    return next(iter(pose_data))
 
 
 def parse_projection_components(iteration_data_file):
@@ -368,6 +387,7 @@ def get_joint_angles_from_pose_data(pose_data):
 
     joint_angles = []
     joint_names = []
+    root_key = _detect_pose_root(pose_data)
 
     for key in pose_data:
         joint_names.append(key)
@@ -385,7 +405,7 @@ def get_joint_angles_from_pose_data(pose_data):
         rot_eul = rot.as_euler("zyx", degrees=False)
 
         # ignore root bone:
-        if key != config.ROOT_JOINT:
+        if key != root_key:
             theta, vector = eulerangles.euler2angle_axis(
                 z=-rot_eul[0], y=rot_eul[1], x=-rot_eul[2]
             )
@@ -888,21 +908,22 @@ def load_SMIL_Unreal_sample(json_file_path,
     y_output["cam_trans"] = T
 
     # get the model location
+    root_key = _detect_pose_root(pose_data)
     model_loc = np.array(
         [
-            -pose_data[config.ROOT_JOINT]["3DPos"]["x"],
-            pose_data[config.ROOT_JOINT]["3DPos"]["y"],
-            pose_data[config.ROOT_JOINT]["3DPos"]["z"],
+            -pose_data[root_key]["3DPos"]["x"],
+            pose_data[root_key]["3DPos"]["y"],
+            pose_data[root_key]["3DPos"]["z"],
         ],
         dtype=np.float32,
     )
 
     rot = Rotation.from_quat(
         [
-            pose_data[config.ROOT_JOINT]["globalRotation"]["x"],
-            pose_data[config.ROOT_JOINT]["globalRotation"]["y"],
-            pose_data[config.ROOT_JOINT]["globalRotation"]["z"],
-            pose_data[config.ROOT_JOINT]["globalRotation"]["w"],
+            pose_data[root_key]["globalRotation"]["x"],
+            pose_data[root_key]["globalRotation"]["y"],
+            pose_data[root_key]["globalRotation"]["z"],
+            pose_data[root_key]["globalRotation"]["w"],
         ],
         scalar_first=False,
     )
@@ -995,10 +1016,10 @@ def load_SMIL_Unreal_sample(json_file_path,
     # Derive model rotation directly from Unreal quaternion and mirror to PyTorch3D
     rot_model_ue = Rotation.from_quat(
         [
-            -pose_data[config.ROOT_JOINT]["globalRotation"]["x"],
-            -pose_data[config.ROOT_JOINT]["globalRotation"]["y"],
-            -pose_data[config.ROOT_JOINT]["globalRotation"]["z"],
-            pose_data[config.ROOT_JOINT]["globalRotation"]["w"],
+            -pose_data[root_key]["globalRotation"]["x"],
+            -pose_data[root_key]["globalRotation"]["y"],
+            -pose_data[root_key]["globalRotation"]["z"],
+            pose_data[root_key]["globalRotation"]["w"],
         ],
         scalar_first=False,
     )
@@ -1053,6 +1074,306 @@ def load_SMIL_Unreal_sample(json_file_path,
 
     if verbose:
         print("\nINFO: Sucessfully loaded data from", json_file_path)
+
+    return x_output, y_output
+
+
+def load_SMIL_Unreal_multiview_sample(
+    data_path: str,
+    frame_index: int,
+    camera_indices: list = None,
+    propagate_scaling: bool = True,
+    translation_factor: float = 0.01,
+    load_images: bool = True,
+    verbose: bool = False
+):
+    """
+    Load a multi-view SMIL sample from replicAnt flat-directory dataset.
+
+    Handles multi-camera replicAnt data where each frame/camera has separate JSON and image files.
+    File naming: {dataset_name}_{frame_idx:05d}_CAM{camera_id}.{ext}
+
+    Args:
+        data_path (str): Root directory of the multi-camera dataset
+        frame_index (int): Frame index to load (0-9999)
+        camera_indices (list, optional): List of camera IDs to load (e.g., [1,2,3]).
+                                        If None, loads all 12 cameras.
+        propagate_scaling (bool): Whether to propagate scaling to child joints
+        translation_factor (float): Factor to multiply translation by
+        load_images (bool): Whether to load image data
+        verbose (bool): Whether to print verbose output
+
+    Returns:
+        tuple: (x_output, y_output)
+            - x_output (dict): Per-camera input data
+                - image_data: List of image arrays per camera
+                - image_paths: List of image file paths
+                - input_image_mask: List of ID mask arrays per camera
+                - mask_paths: List of mask file paths
+                - num_views: Number of valid cameras loaded
+                - camera_ids: List of camera IDs loaded
+            - y_output (dict): Shared and per-view parameters
+                - Shared data (identical across cameras):
+                  - joint_angles, shape_betas, root_loc, root_rot, etc.
+                - Per-camera data:
+                  - keypoints_2d_per_view: List of [n_joints, 2] arrays
+                  - keypoint_visibility_per_view: List of [n_joints] visibility arrays
+                  - cam_rot_per_view: List of rotation matrices
+                  - cam_trans_per_view: List of translation vectors
+                  - fx_per_view, fy_per_view, cx_per_view, cy_per_view: Lists of intrinsics
+    """
+    from pathlib import Path
+    from typing import List, Tuple, Dict, Optional
+    import re
+
+    import re
+
+    x_output = {}
+    y_output = {}
+
+    data_path = Path(data_path)
+
+    # Detect dataset name from _BatchData_*.json files
+    batch_files = list(data_path.glob("_BatchData_*.json"))
+    if not batch_files:
+        raise FileNotFoundError(f"No _BatchData_*.json found in {data_path}")
+
+    batch_data_path = batch_files[0]
+    dataset_name = batch_data_path.stem.replace("_BatchData_", "")
+
+    with open(batch_data_path, "r") as f:
+        batch_data_file = json.load(f)
+
+    # Determine camera indices to load
+    if camera_indices is None:
+        # Auto-detect: look for CAM files for this frame
+        cam_files = list(data_path.glob(f"{dataset_name}_{frame_index:05d}_CAM*.json"))
+        camera_indices = sorted([
+            int(re.search(r'CAM(\d+)', f.name).group(1))
+            for f in cam_files
+        ])
+
+    if not camera_indices:
+        raise FileNotFoundError(
+            f"No camera files found for frame {frame_index:05d} in {data_path}"
+        )
+
+    if verbose:
+        print(f"Loading frame {frame_index:05d} with cameras: {camera_indices}")
+
+    # Load shared data from first camera (pose/shape identical across all cameras)
+    first_camera_json = data_path / f"{dataset_name}_{frame_index:05d}_CAM{camera_indices[0]}.json"
+    with open(first_camera_json, "r") as f:
+        first_camera_data = json.load(f)
+
+    # Extract shared pose and shape data
+    pose_data = first_camera_data["iterationData"]["subject Data"][0]["1"]["keypoints"]
+
+    # Extract shape betas (same across all cameras)
+    try:
+        shape_betas = first_camera_data["iterationData"]["subject Data"][0]["1"]["shape betas"]
+        if isinstance(shape_betas, dict):
+            shape_betas = [v for v in shape_betas.values()]
+    except KeyError:
+        shape_betas = []
+
+    if len(shape_betas) == 0:
+        shape_betas = np.zeros(config.dd["shapedirs"].shape[2])
+    else:
+        shape_betas = np.array(shape_betas)
+
+    y_output["shape_betas"] = shape_betas
+
+    # Extract joint angles from pose data (same across cameras)
+    joint_angles, joint_names = get_joint_angles_from_pose_data(pose_data)
+    np_joint_angles_mapped = map_joint_order(
+        config.dd["J_names"], joint_names, joint_angles
+    )
+    y_output["joint_angles"] = np_joint_angles_mapped
+    y_output["joint_names"] = config.dd["J_names"]
+
+    # Extract scale and translation weights if available
+    try:
+        scale_weights = first_camera_data["iterationData"]["subject Data"][0]["1"]["ScaleWeights"]
+        trans_weights = first_camera_data["iterationData"]["subject Data"][0]["1"]["TranslationWeights"]
+    except KeyError:
+        scale_weights = None
+        trans_weights = None
+
+    y_output["scale_weights"] = scale_weights
+    y_output["trans_weights"] = trans_weights
+    y_output["translation_factor"] = translation_factor
+    y_output["propagate_scaling"] = propagate_scaling
+
+    # Extract shared global rotation and translation from pose data
+    root_key = _detect_pose_root(pose_data)
+    model_loc = np.array(
+        [
+            -pose_data[root_key]["3DPos"]["x"],
+            pose_data[root_key]["3DPos"]["y"],
+            pose_data[root_key]["3DPos"]["z"],
+        ],
+        dtype=np.float32,
+    )
+
+    rot = Rotation.from_quat(
+        [
+            pose_data[root_key]["globalRotation"]["x"],
+            pose_data[root_key]["globalRotation"]["y"],
+            pose_data[root_key]["globalRotation"]["z"],
+            pose_data[root_key]["globalRotation"]["w"],
+        ],
+        scalar_first=False,
+    )
+    rot_eul = rot.as_euler("zyx", degrees=False)
+    theta, vector = eulerangles.euler2angle_axis(
+        z=-rot_eul[0] + np.pi, y=-rot_eul[1], x=rot_eul[2]
+    )
+    global_rotation_np = vector * theta
+
+    y_output["root_loc"] = model_loc
+    y_output["root_rot"] = global_rotation_np
+    y_output["pose_data"] = pose_data  # Keep raw pose data for compatibility
+
+    # Per-camera lists
+    image_data = []
+    image_paths = []
+    mask_data = []
+    mask_paths = []
+
+    keypoints_2d_per_view = []
+    keypoint_visibility_per_view = []
+    cam_rot_per_view = []
+    cam_trans_per_view = []
+    fx_per_view = []
+    fy_per_view = []
+    cx_per_view = []
+    cy_per_view = []
+    fov_per_view = []
+
+    image_width = batch_data_file["Image Resolution"]["x"]
+    image_height = batch_data_file["Image Resolution"]["y"]
+
+    # Load per-camera data
+    for cam_id in camera_indices:
+        json_path = data_path / f"{dataset_name}_{frame_index:05d}_CAM{cam_id}.json"
+
+        with open(json_path, "r") as f:
+            cam_data = json.load(f)
+
+        # Load image
+        image_path = json_path.with_suffix(".JPG")
+        if load_images and image_path.exists():
+            img = imageio.v2.imread(str(image_path))
+            image_data.append(img)
+        else:
+            image_data.append(None)
+        image_paths.append(str(image_path))
+
+        # Load ID mask for visibility computation
+        mask_path = json_path.with_name(
+            f"{dataset_name}_{frame_index:05d}_ID_CAM{cam_id}.png"
+        )
+        if mask_path.exists():
+            id_mask = imageio.v2.imread(str(mask_path))
+            # Convert to binary mask
+            if len(id_mask.shape) > 2:
+                id_mask = id_mask[:, :, 0]
+            id_mask = cv2.threshold(id_mask, 0, 255, cv2.THRESH_BINARY)[1]
+            mask_data.append(id_mask)
+        else:
+            mask_data.append(None)
+        mask_paths.append(str(mask_path))
+
+        # Extract per-camera 2D keypoints
+        keypoints_2d = []
+        keypoint_names = []
+        for key in pose_data.keys():
+            keypoint_names.append(key)
+            # Extract from current camera's JSON (2D positions are per-camera)
+            try:
+                norm_x = pose_data[key]["2DPos"]["y"] / image_height
+                norm_y = pose_data[key]["2DPos"]["x"] / image_width
+            except (KeyError, TypeError):
+                # Fallback if 2D positions not in this camera's data
+                norm_x = 0.5
+                norm_y = 0.5
+            keypoints_2d.append([norm_x, norm_y])
+
+        # Map to SMIL joint order
+        mapped_keypoints_2d = np.zeros((len(config.dd["J_names"]), 2), float)
+        for o, orig_joint in enumerate(config.dd["J_names"]):
+            for m, mapped_joint in enumerate(keypoint_names):
+                if orig_joint == mapped_joint:
+                    mapped_keypoints_2d[o] = keypoints_2d[m]
+
+        keypoints_2d_per_view.append(mapped_keypoints_2d)
+
+        # Compute per-camera visibility using ID mask
+        visibility = np.ones(len(config.dd["J_names"]))
+        if mask_data[-1] is not None:
+            id_mask = mask_data[-1]
+            for i, (norm_x, norm_y) in enumerate(mapped_keypoints_2d):
+                # Check bounds
+                if not (0 <= norm_x <= 1.0 and 0 <= norm_y <= 1.0):
+                    visibility[i] = 0.0
+                    continue
+                # Check ID mask at keypoint location
+                pixel_x = int(np.clip(norm_x * image_height, 0, image_height - 1))
+                pixel_y = int(np.clip(norm_y * image_width, 0, image_width - 1))
+                if id_mask[pixel_x, pixel_y] == 0:
+                    visibility[i] = 0.0
+        else:
+            # Fallback: only check bounds
+            for i, (norm_x, norm_y) in enumerate(mapped_keypoints_2d):
+                if not (0 <= norm_x <= 1.0 and 0 <= norm_y <= 1.0):
+                    visibility[i] = 0.0
+
+        keypoint_visibility_per_view.append(visibility)
+
+        # Extract per-camera camera parameters
+        cam_rot, cam_trans = parse_projection_components(cam_data)
+        cx, cy, fx, fy = parse_camera_intrinsics(batch_data_file, cam_data)
+        fov = cam_data["iterationData"]["camera"]["FOV"]
+
+        # Mirror rotation matrix for PyTorch3D
+        mirror_matrix = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        mirrored_rot = mirror_matrix @ cam_rot.T @ mirror_matrix.T
+        R = torch.tensor(mirrored_rot, dtype=torch.float32)
+        T = torch.tensor([-cam_trans[0], cam_trans[1], cam_trans[2]], dtype=torch.float32)
+
+        cam_rot_per_view.append(R)
+        cam_trans_per_view.append(T)
+        fx_per_view.append(fx)
+        fy_per_view.append(fy)
+        cx_per_view.append(cx)
+        cy_per_view.append(cy)
+        fov_per_view.append(fov)
+
+        if verbose:
+            print(f"  CAM{cam_id}: fx={fx:.2f}, fy={fy:.2f}, visible_joints={int(np.sum(visibility))}/{len(visibility)}")
+
+    # Populate x_output
+    x_output["image_data"] = image_data
+    x_output["image_paths"] = image_paths
+    x_output["input_image_mask"] = mask_data
+    x_output["mask_paths"] = mask_paths
+    x_output["num_views"] = len(camera_indices)
+    x_output["camera_ids"] = camera_indices
+
+    # Populate y_output with per-view data
+    y_output["keypoints_2d_per_view"] = keypoints_2d_per_view
+    y_output["keypoint_visibility_per_view"] = keypoint_visibility_per_view
+    y_output["cam_rot_per_view"] = cam_rot_per_view
+    y_output["cam_trans_per_view"] = cam_trans_per_view
+    y_output["fx_per_view"] = fx_per_view
+    y_output["fy_per_view"] = fy_per_view
+    y_output["cx_per_view"] = cx_per_view
+    y_output["cy_per_view"] = cy_per_view
+    y_output["fov_per_view"] = fov_per_view
+
+    if verbose:
+        print(f"Successfully loaded frame {frame_index:05d} with {len(camera_indices)} cameras")
 
     return x_output, y_output
 

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -5,6 +5,7 @@ import cv2
 import torch
 import os
 import imageio
+import re
 import sys
 from pathlib import Path
 from typing import List, Tuple, Dict, Optional
@@ -1122,12 +1123,6 @@ def load_SMIL_Unreal_multiview_sample(
                   - cam_trans_per_view: List of translation vectors
                   - fx_per_view, fy_per_view, cx_per_view, cy_per_view: Lists of intrinsics
     """
-    from pathlib import Path
-    from typing import List, Tuple, Dict, Optional
-    import re
-
-    import re
-
     x_output = {}
     y_output = {}
 

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -1280,18 +1280,21 @@ def load_SMIL_Unreal_multiview_sample(
             mask_data.append(None)
         mask_paths.append(str(mask_path))
 
-        # Extract per-camera 2D keypoints
+        # Extract per-camera 2D keypoints. The shared `pose_data` above was
+        # read from the first camera's JSON; 2DPos is per-camera, so we re-
+        # read from the current camera's own keypoints dict here.
+        cam_pose = cam_data["iterationData"]["subject Data"][0]["1"]["keypoints"]
         keypoints_2d = []
         keypoint_names = []
-        for key in pose_data.keys():
+        for key in cam_pose.keys():
             keypoint_names.append(key)
             # Intentional axis swap (norm_x <- y/H, norm_y <- x/W) — mirrors the
             # single-view path above. The downstream ID-mask lookup pixel-indexes
             # against these values with the same swap, so don't "fix" one side
             # without updating the other.
             try:
-                norm_x = pose_data[key]["2DPos"]["y"] / image_height
-                norm_y = pose_data[key]["2DPos"]["x"] / image_width
+                norm_x = cam_pose[key]["2DPos"]["y"] / image_height
+                norm_y = cam_pose[key]["2DPos"]["x"] / image_width
             except (KeyError, TypeError):
                 # Fallback if 2D positions not in this camera's data
                 norm_x = 0.5

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -1266,9 +1266,19 @@ def load_SMIL_Unreal_multiview_sample(
                 - Per-camera data:
                   - keypoints_2d_per_view: List of [n_joints, 2] arrays
                   - keypoint_visibility_per_view: List of [n_joints] visibility arrays
+                  - view_valid_per_view: List of bool — False when the
+                    camera has empty `subject Data` (animal absent from
+                    this view's render). Keypoints/visibility for these
+                    slots are zero-sentinels; camera params stay valid.
                   - cam_rot_per_view: List of rotation matrices
                   - cam_trans_per_view: List of translation vectors
                   - fx_per_view, fy_per_view, cx_per_view, cy_per_view: Lists of intrinsics
+
+    Raises:
+        ValueError: when no camera in `camera_indices` has valid
+            `subject Data` for the frame (animal absent from every view).
+            Per-camera resilience is built in — a single bad camera
+            just marks that view invalid via `view_valid_per_view[v]`.
     """
     x_output = {}
     y_output = {}
@@ -1303,10 +1313,45 @@ def load_SMIL_Unreal_multiview_sample(
     if verbose:
         print(f"Loading frame {frame_index:05d} with cameras: {camera_indices}")
 
-    # Load shared data from first camera (pose/shape identical across all cameras)
-    first_camera_json = data_path / f"{dataset_name}_{frame_index:05d}_CAM{camera_indices[0]}.json"
-    with open(first_camera_json, "r") as f:
-        first_camera_data = json.load(f)
+    # Pre-load every camera's JSON. They're small (~10 kB) and we need them
+    # twice — once for the per-camera validity probe right below, then again
+    # in the per-view loop for 2D keypoints + camera params. Avoids
+    # re-opening each file.
+    cam_jsons = {}
+    for cam_id in camera_indices:
+        json_path = data_path / f"{dataset_name}_{frame_index:05d}_CAM{cam_id}.json"
+        with open(json_path, "r") as f:
+            cam_jsons[cam_id] = json.load(f)
+
+    # Per-camera validity: a camera is invalid for supervision when its
+    # `subject Data` is empty (renderer dropped the subject from this view
+    # because the camera couldn't see it). Geometry stays valid — the
+    # camera block (R/T/FOV/Location) is always present — so we can still
+    # use this slot for the canonical-frame transform; we just emit zero
+    # 2D keypoints and zero visibility for it.
+    def _has_subject_data(cam_data):
+        sd = cam_data.get("iterationData", {}).get("subject Data", [])
+        if not isinstance(sd, list) or len(sd) == 0:
+            return False
+        try:
+            _ = sd[0]["1"]["keypoints"]
+            return True
+        except (KeyError, TypeError, IndexError):
+            return False
+
+    view_valid_per_view = [bool(_has_subject_data(cam_jsons[cid])) for cid in camera_indices]
+
+    # Shared pose/shape (identical across cameras per dataset spec) can be
+    # read from any camera that has subject Data. Prefer the canonical one
+    # (camera_indices[0]) when valid so the existing semantics carry over;
+    # otherwise fall back to the first valid camera by sorted ID.
+    shared_ref_idx = next((i for i, ok in enumerate(view_valid_per_view) if ok), None)
+    if shared_ref_idx is None:
+        raise ValueError(
+            f"frame {frame_index}: no camera has valid `subject Data` — "
+            f"the animal is absent from all {len(camera_indices)} views"
+        )
+    first_camera_data = cam_jsons[camera_indices[shared_ref_idx]]
 
     # Extract shared pose and shape data
     pose_data = first_camera_data["iterationData"]["subject Data"][0]["1"]["keypoints"]
@@ -1418,11 +1463,10 @@ def load_SMIL_Unreal_multiview_sample(
     image_height = batch_data_file["Image Resolution"]["y"]
 
     # Load per-camera data
-    for cam_id in camera_indices:
+    for v_idx, cam_id in enumerate(camera_indices):
         json_path = data_path / f"{dataset_name}_{frame_index:05d}_CAM{cam_id}.json"
-
-        with open(json_path, "r") as f:
-            cam_data = json.load(f)
+        cam_data = cam_jsons[cam_id]
+        view_valid = view_valid_per_view[v_idx]
 
         # Load image. cv2.imread + cvtColor is ~2-3x faster than imageio's
         # PIL-backed JPEG decode at 512x512; we keep the existing RGB contract.
@@ -1478,37 +1522,41 @@ def load_SMIL_Unreal_multiview_sample(
                     depth_image = cv2.cvtColor(depth_image, cv2.COLOR_BGR2RGB)
 
         # Extract per-camera 2D keypoints. The shared `pose_data` above was
-        # read from the first camera's JSON; 2DPos is per-camera, so we re-
-        # read from the current camera's own keypoints dict here.
-        cam_pose = cam_data["iterationData"]["subject Data"][0]["1"]["keypoints"]
-        keypoints_2d = []
-        keypoint_names = []
-        for key in cam_pose.keys():
-            keypoint_names.append(key)
-            # Intentional axis swap (norm_x <- y/H, norm_y <- x/W) — mirrors the
-            # single-view path above. The downstream ID-mask lookup pixel-indexes
-            # against these values with the same swap, so don't "fix" one side
-            # without updating the other.
-            try:
-                norm_x = cam_pose[key]["2DPos"]["y"] / image_height
-                norm_y = cam_pose[key]["2DPos"]["x"] / image_width
-            except (KeyError, TypeError):
-                # Fallback if 2D positions not in this camera's data
-                norm_x = 0.5
-                norm_y = 0.5
-            keypoints_2d.append([norm_x, norm_y])
-
-        # Map to SMIL joint order. Track which model J_names actually
-        # have a matching dataset entry this view; model-only joints
-        # have no GT 2D (left at the [0, 0] sentinel) and must NOT be
-        # treated as visible — see the visibility initialisation below.
+        # read from a camera that *does* have subject Data; 2DPos is
+        # per-camera and only meaningful here when the current camera
+        # also has subject Data — when invalid we emit all-zero sentinels
+        # and leave `in_dataset_this_view` as all-False so visibility
+        # short-circuits to zero below.
         mapped_keypoints_2d = np.zeros((len(config.dd["J_names"]), 2), float)
         in_dataset_this_view = np.zeros(len(config.dd["J_names"]), dtype=bool)
-        for o, orig_joint in enumerate(config.dd["J_names"]):
-            for m, mapped_joint in enumerate(keypoint_names):
-                if orig_joint == mapped_joint:
-                    mapped_keypoints_2d[o] = keypoints_2d[m]
-                    in_dataset_this_view[o] = True
+        if view_valid:
+            cam_pose = cam_data["iterationData"]["subject Data"][0]["1"]["keypoints"]
+            keypoints_2d = []
+            keypoint_names = []
+            for key in cam_pose.keys():
+                keypoint_names.append(key)
+                # Intentional axis swap (norm_x <- y/H, norm_y <- x/W) — mirrors the
+                # single-view path above. The downstream ID-mask lookup pixel-indexes
+                # against these values with the same swap, so don't "fix" one side
+                # without updating the other.
+                try:
+                    norm_x = cam_pose[key]["2DPos"]["y"] / image_height
+                    norm_y = cam_pose[key]["2DPos"]["x"] / image_width
+                except (KeyError, TypeError):
+                    # Fallback if 2D positions not in this camera's data
+                    norm_x = 0.5
+                    norm_y = 0.5
+                keypoints_2d.append([norm_x, norm_y])
+
+            # Map to SMIL joint order. Track which model J_names actually
+            # have a matching dataset entry this view; model-only joints
+            # have no GT 2D (left at the [0, 0] sentinel) and must NOT be
+            # treated as visible — see the visibility initialisation below.
+            for o, orig_joint in enumerate(config.dd["J_names"]):
+                for m, mapped_joint in enumerate(keypoint_names):
+                    if orig_joint == mapped_joint:
+                        mapped_keypoints_2d[o] = keypoints_2d[m]
+                        in_dataset_this_view[o] = True
 
         keypoints_2d_per_view.append(mapped_keypoints_2d)
         keypoint_in_dataset_per_view.append(in_dataset_this_view)
@@ -1517,6 +1565,8 @@ def load_SMIL_Unreal_multiview_sample(
         # joints stay invisible regardless of where their [0, 0]
         # sentinel happens to land on the ID/depth pass. The bounds /
         # mask / depth steps below can only ever decrease visibility.
+        # When the view is invalid (no subject data), visibility starts
+        # at all zeros and stays there.
         visibility = in_dataset_this_view.astype(np.float64)
         if mask_data[-1] is not None:
             id_mask = mask_data[-1]
@@ -1738,6 +1788,11 @@ def load_SMIL_Unreal_multiview_sample(
     y_output["keypoints_2d_per_view"] = keypoints_2d_per_view
     y_output["keypoint_visibility_per_view"] = keypoint_visibility_per_view
     y_output["keypoint_in_dataset_per_view"] = keypoint_in_dataset_per_view
+    # Per-view supervision validity (False = animal absent / fully occluded in
+    # this view; keypoints_2d and keypoint_visibility are zero-sentinels for
+    # this slot). Camera params (R/T/K/FOV) remain geometrically valid even
+    # when this is False, so the slot is still usable for cross-view geometry.
+    y_output["view_valid_per_view"] = list(view_valid_per_view)
     y_output["cam_rot_per_view"] = cam_rot_per_view
     y_output["cam_trans_per_view"] = cam_trans_per_view
     y_output["fx_per_view"] = fx_per_view

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -1573,6 +1573,11 @@ def load_SMIL_Unreal_multiview_sample(
     # ------------------------------------------------------------------
     # 3D ground-truth keypoints in raw world frame (PyTorch3D-mirrored,
     # same convention as cam_rot_per_view / cam_trans_per_view / model_loc).
+    # Track which J_names actually have a dataset entry — joints not in
+    # `pose_data` (model-only joints) must NOT participate in the canonical-
+    # frame transform; they end up zeroed-out after all conversions to
+    # match the SLEAP convention of (0,0,0) as the "no GT" sentinel.
+    # Downstream consumers (viz, trainer) recognise (0,0,0) as missing.
     # ------------------------------------------------------------------
     kp3d_by_name = {}
     for k, kp in pose_data.items():
@@ -1584,9 +1589,11 @@ def load_SMIL_Unreal_multiview_sample(
     keypoints_3d_world = np.zeros(
         (len(config.dd["J_names"]), 3), dtype=np.float32
     )
+    keypoint_3d_in_dataset = np.zeros(len(config.dd["J_names"]), dtype=bool)
     for o, j in enumerate(config.dd["J_names"]):
         if j in kp3d_by_name:
             keypoints_3d_world[o] = kp3d_by_name[j]
+            keypoint_3d_in_dataset[o] = True
 
     # ------------------------------------------------------------------
     # Canonical-camera-frame transformation.
@@ -1673,6 +1680,22 @@ def load_SMIL_Unreal_multiview_sample(
         )
         for v in range(len(camera_indices)):
             cam_trans_per_view[v] = cam_trans_per_view[v] * s
+
+    # ------------------------------------------------------------------
+    # Zero out 3D keypoints for joints with no dataset GT.
+    # Reason: when `canonical_frame=True`, a zero-padded row in
+    # `keypoints_3d_world` becomes `0 @ R_0 + t_0 = t_0` after the
+    # canonical-frame transform, i.e. lands at the canonical camera's
+    # position — far from the mesh cluster and a meaningless 3D target.
+    # Apply the (0,0,0) sentinel AFTER all transformations so downstream
+    # consumers (visualisers, trainers) can detect missing joints with the
+    # standard `~np.all(kp3d == 0, axis=1)` check — the SLEAP convention.
+    # `keypoints_3d_world` is also zeroed for the same joints so the inverse
+    # `(x_can - t_0) @ R_0.T` round-trip still maps missing rows to zero.
+    # ------------------------------------------------------------------
+    if (~keypoint_3d_in_dataset).any():
+        keypoints_3d[~keypoint_3d_in_dataset] = 0.0
+        keypoints_3d_world[~keypoint_3d_in_dataset] = 0.0
 
     # Overwrite the earlier raw-frame assignments with (possibly)
     # canonical-frame values. pose_data is left untouched for

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -1424,16 +1424,23 @@ def load_SMIL_Unreal_multiview_sample(
         with open(json_path, "r") as f:
             cam_data = json.load(f)
 
-        # Load image
+        # Load image. cv2.imread + cvtColor is ~2-3x faster than imageio's
+        # PIL-backed JPEG decode at 512x512; we keep the existing RGB contract.
         image_path = json_path.with_suffix(".JPG")
         if load_images and image_path.exists():
-            img = imageio.v2.imread(str(image_path))
+            bgr = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
+            if bgr is None:
+                raise RuntimeError(f"cv2.imread failed on {image_path}")
+            img = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
             image_data.append(img)
         else:
             image_data.append(None)
         image_paths.append(str(image_path))
 
-        # Load ID mask for visibility computation
+        # Load ID mask for visibility computation. Note: kept on imageio
+        # because cv2.imread is empirically ~80% SLOWER for this specific
+        # PNG flavour (likely a palette / metadata path through libpng);
+        # JPG and the depth PNG are migrated to cv2 below.
         mask_path = json_path.with_name(
             f"{dataset_name}_{frame_index:05d}_ID_CAM{cam_id}.png"
         )
@@ -1451,13 +1458,24 @@ def load_SMIL_Unreal_multiview_sample(
         # Load depth pass for the self-occlusion refinement. Optional —
         # if the file is missing we fall back to id-mask-only visibility
         # for this view per the design decision.
+        # `refine_visibility_with_depth` reads `depth_image[..., 0]` and
+        # expects R (the depth encoding lives in the red channel — the
+        # PNG's RGB channels are NOT equal). cv2 returns BGR[A], so we
+        # swap to RGB[A] to keep channel-0 == R.
         depth_path = json_path.with_name(
             f"{dataset_name}_{frame_index:05d}_Depth_CAM{cam_id}.png"
         )
         depth_paths.append(str(depth_path))
         depth_image = None
         if depth_occlusion_check and depth_path.exists():
-            depth_image = imageio.v2.imread(str(depth_path))
+            depth_image = cv2.imread(str(depth_path), cv2.IMREAD_UNCHANGED)
+            if depth_image is None:
+                raise RuntimeError(f"cv2.imread failed on {depth_path}")
+            if depth_image.ndim == 3:
+                if depth_image.shape[2] == 4:
+                    depth_image = cv2.cvtColor(depth_image, cv2.COLOR_BGRA2RGBA)
+                elif depth_image.shape[2] == 3:
+                    depth_image = cv2.cvtColor(depth_image, cv2.COLOR_BGR2RGB)
 
         # Extract per-camera 2D keypoints. The shared `pose_data` above was
         # read from the first camera's JSON; 2DPos is per-camera, so we re-

--- a/smal_fitter/Unreal2Pytorch3D.py
+++ b/smal_fitter/Unreal2Pytorch3D.py
@@ -1285,7 +1285,10 @@ def load_SMIL_Unreal_multiview_sample(
         keypoint_names = []
         for key in pose_data.keys():
             keypoint_names.append(key)
-            # Extract from current camera's JSON (2D positions are per-camera)
+            # Intentional axis swap (norm_x <- y/H, norm_y <- x/W) — mirrors the
+            # single-view path above. The downstream ID-mask lookup pixel-indexes
+            # against these values with the same swap, so don't "fix" one side
+            # without updating the other.
             try:
                 norm_x = pose_data[key]["2DPos"]["y"] / image_height
                 norm_y = pose_data[key]["2DPos"]["x"] / image_width

--- a/smal_fitter/neuralSMIL/configs/examples/multiview_replicant_mice.json
+++ b/smal_fitter/neuralSMIL/configs/examples/multiview_replicant_mice.json
@@ -1,0 +1,192 @@
+{
+  "_doc": "Baseline multi-view replicAnt training config (Mouse, Falkner conv repose). Pairs with the HDF5 produced by smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py. use_ue_scaling is FALSE because the preprocessor bakes the unified 0.1 scale into stored coords (mesh-native and data-frame match without a model-side *10 hack). world_scale stays at 1.0 in the HDF5 metadata.",
+
+  "mode": "multiview",
+
+  "num_views_to_use": null,
+  "min_views_per_sample": 2,
+  "cross_attention_layers": 2,
+  "cross_attention_heads": 8,
+  "cross_attention_dropout": 0.1,
+
+  "smal_model": {
+    "smal_file": "3D_model_prep/SMILy_Mouse_static_joints_Falkner_conv_repose_hind_legs.pkl",
+    "shape_family": null
+  },
+
+  "dataset": {
+    "data_path": "replicant_multiview_mice.h5",
+    "train_ratio": 0.85,
+    "val_ratio": 0.05,
+    "test_ratio": 0.1,
+    "dataset_fraction": 1.0
+  },
+
+  "model": {
+    "backbone_name": "vit_large_patch16_224",
+    "freeze_backbone": false,
+    "backbone_unfreeze_epoch": null,
+    "backbone_lr_multiplier": 0.1,
+    "hidden_dim": 1024,
+    "head_type": "transformer_decoder",
+    "use_unity_prior": false,
+    "use_ue_scaling": false,
+    "rgb_only": true,
+    "transformer_depth": 4,
+    "transformer_heads": 8,
+    "transformer_dim_head": 64,
+    "transformer_mlp_dim": 1024,
+    "transformer_dropout": 0.1,
+    "transformer_ief_iters": 1,
+    "transformer_trans_scale_factor": 1
+  },
+
+  "optimizer": {
+    "learning_rate": 5e-5,
+    "weight_decay": 1e-4,
+    "gradient_clip_norm": 1.0,
+    "optimizer_type": "adamw",
+    "lr_schedule": {
+      "0": 5e-5,
+      "10": 3e-5,
+      "20": 2e-5,
+      "60": 1e-5,
+      "100": 2e-6,
+      "200": 1e-6
+    }
+  },
+
+  "loss_curriculum": {
+    "base_weights": {
+      "global_rot": 0.0,
+      "joint_rot": 0.001,
+      "betas": 0.0005,
+      "trans": 0.001,
+      "fov": 0.001,
+      "cam_rot": 0.01,
+      "cam_trans": 0.01,
+      "log_beta_scales": 0.0005,
+      "betas_trans": 0.0005,
+      "keypoint_2d": 0.1,
+      "keypoint_3d": 0.25,
+      "silhouette": 0.0,
+      "joint_angle_regularization": 0.001,
+      "limb_scale_regularization": 0.01,
+      "limb_trans_regularization": 1,
+      "triangulation_consistency": 0.0,
+      "ief_intermediate": 0.0
+    },
+    "curriculum_stages": {
+      "1": {
+        "joint_angle_regularization": 0.01,
+        "limb_scale_regularization": 0.1,
+        "limb_trans_regularization": 1
+      },
+      "10": {
+        "keypoint_2d": 0.1,
+        "joint_angle_regularization": 1e-5,
+        "limb_scale_regularization": 0.01,
+        "limb_trans_regularization": 1
+      },
+      "20": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-6,
+        "limb_scale_regularization": 0.001,
+        "limb_trans_regularization": 0.5
+      },
+      "50": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-6,
+        "limb_scale_regularization": 1e-5,
+        "limb_trans_regularization": 0.5
+      },
+      "100": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-7,
+        "limb_scale_regularization": 5e-6,
+        "limb_trans_regularization": 0.0001
+      },
+      "150": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-7,
+        "limb_scale_regularization": 1e-6,
+        "limb_trans_regularization": 0.0001,
+        "fov": 1e-7,
+        "cam_rot": 1e-8,
+        "cam_trans": 1e-8
+      },
+      "200": {
+        "keypoint_3d": 2,
+        "joint_angle_regularization": 1e-7,
+        "limb_scale_regularization": 1e-6,
+        "limb_trans_regularization": 0.00001,
+        "fov": 1e-7,
+        "cam_rot": 1e-8,
+        "cam_trans": 1e-8
+      }
+    }
+  },
+
+  "scale_trans_beta": {
+    "mode": "separate"
+  },
+
+  "mesh_scaling": {
+    "allow_mesh_scaling": false,
+    "init_mesh_scale": 1.0,
+    "use_log_scale": true
+  },
+
+  "augmentation": {
+    "enabled": true,
+    "geometric_enabled": false,
+    "color_jitter_brightness": 0.2,
+    "color_jitter_contrast": 0.2,
+    "color_jitter_saturation": 0.15,
+    "gaussian_noise_std": 0.015,
+    "gaussian_blur_prob": 0.3,
+    "gaussian_blur_kernel_range": [3, 7],
+    "random_erasing_prob": 0.2,
+    "random_erasing_scale_range": [0.02, 0.1],
+    "crop_jitter_fraction": 0.0,
+    "scale_jitter_range": [0.9, 1.1]
+  },
+
+  "joint_importance": {
+    "enabled": true,
+    "important_joint_names": ["Nose", "paw_L_tip", "paw_R_tip", "Foot_L_tip", "Foot_R_tip", "Tail_07"],
+    "weight_multiplier": 10.0
+  },
+
+  "ignored_joint_locations": {
+    "enabled": true,
+    "ignored_joint_names": []
+  },
+
+  "output": {
+    "checkpoint_dir": "checkpoints_replicant_multiview_mice",
+    "plots_dir": "plots_replicant_multiview_mice",
+    "visualizations_dir": "visualizations_replicant_multiview_mice",
+    "singleview_visualizations_dir": "singleview_renders_replicant_multiview_mice",
+    "save_checkpoint_every": 10,
+    "generate_visualizations_every": 5,
+    "plot_history_every": 5,
+    "num_visualization_samples": 2
+  },
+
+  "training": {
+    "batch_size": 3,
+    "num_epochs": 300,
+    "seed": 42,
+    "rotation_representation": "6d",
+    "num_workers": 8,
+    "pin_memory": true,
+    "prefetch_factor": 4,
+    "resume_checkpoint": null,
+    "reset_ief_token_embedding": false,
+    "use_gt_camera_init": true,
+    "use_mixed_precision": false,
+    "backbone_chunk_size": 6,
+    "gradient_accumulation_steps": 1
+  }
+}

--- a/smal_fitter/neuralSMIL/smil_datasets.py
+++ b/smal_fitter/neuralSMIL/smil_datasets.py
@@ -1,9 +1,12 @@
-import torch
+import glob
 import os
 import sys
-import numpy as np
+
+import h5py
 import matplotlib
 matplotlib.use('Agg')  # Use non-GUI backend to prevent tkinter issues in multiprocessing
+import numpy as np
+import torch
 from scipy.spatial.transform import Rotation
 
 # Add the parent directories to the path to import modules
@@ -160,22 +163,70 @@ class UnifiedSMILDataset:
     @staticmethod
     def from_path(data_path: str, **kwargs):
         """
-        Create appropriate dataset instance based on file path.
-        
-        Args:
-            data_path: Path to dataset (directory for JSON format, .h5/.hdf5 file for optimized format)
-            **kwargs: Additional arguments passed to dataset constructor
-            
-        Returns:
-            Dataset instance (OptimizedSMILDataset or replicAntSMILDataset)
+        Create the appropriate dataset instance based on `data_path`.
+
+        Dispatch rules:
+
+        - `.h5` / `.hdf5` — open the file and read `/metadata` attrs:
+            * `is_multiview=True` (replicAnt or SLEAP multi-view schema)
+              → `SLEAPMultiViewDataset`
+            * `dataset_type='sleap'` (single-view SLEAP schema)
+              → `SLEAPDataset`
+            * otherwise (legacy single-view replicAnt HDF5)
+              → `OptimizedSMILDataset`
+
+        - directory:
+            * contains `_BatchData_*.json` AND any `*_CAM*.json`
+              → replicAnt multi-view flat-directory layout. The direct-load
+              `MultiViewreplicAntSMILDataset` (Phase 2) is not implemented;
+              raise pointing the caller at the HDF5 preprocessor.
+            * otherwise → `replicAntSMILDataset` (single-view JSON layout).
         """
         if data_path.endswith('.h5') or data_path.endswith('.hdf5'):
-            # Load optimized HDF5 dataset
-            from optimized_dataset import OptimizedSMILDataset
-            return OptimizedSMILDataset(data_path, **kwargs)
-        else:
-            # Load original JSON dataset
-            return replicAntSMILDataset(data_path, **kwargs)
+            return UnifiedSMILDataset._dispatch_hdf5(data_path, **kwargs)
+        return UnifiedSMILDataset._dispatch_directory(data_path, **kwargs)
+
+    @staticmethod
+    def _dispatch_hdf5(data_path: str, **kwargs):
+        try:
+            with h5py.File(data_path, 'r') as f:
+                if 'metadata' in f:
+                    attrs = f['metadata'].attrs
+                    is_multiview = bool(attrs.get('is_multiview', False))
+                    dataset_type = attrs.get('dataset_type', None)
+                    if isinstance(dataset_type, bytes):
+                        dataset_type = dataset_type.decode('utf-8')
+                else:
+                    is_multiview, dataset_type = False, None
+        except OSError as e:
+            raise ValueError(f"Could not open HDF5 file {data_path}: {e}") from e
+
+        if is_multiview:
+            from sleap_data.sleap_multiview_dataset import SLEAPMultiViewDataset
+            return SLEAPMultiViewDataset(data_path, **kwargs)
+
+        if dataset_type == 'sleap':
+            from sleap_data.sleap_dataset import SLEAPDataset
+            return SLEAPDataset(data_path, **kwargs)
+
+        from optimized_dataset import OptimizedSMILDataset
+        return OptimizedSMILDataset(data_path, **kwargs)
+
+    @staticmethod
+    def _dispatch_directory(data_path: str, **kwargs):
+        if os.path.isdir(data_path):
+            batch_files = glob.glob(os.path.join(data_path, "_BatchData_*.json"))
+            if batch_files:
+                cam_files = glob.glob(os.path.join(data_path, "*_CAM*.json"))
+                if cam_files:
+                    raise NotImplementedError(
+                        f"replicAnt multi-view flat-directory layout detected at "
+                        f"{data_path}. The direct-load MultiViewreplicAntSMILDataset "
+                        f"(Phase 2) is not yet implemented. Preprocess to HDF5 via "
+                        f"smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py "
+                        f"and pass the resulting .h5 file instead."
+                    )
+        return replicAntSMILDataset(data_path, **kwargs)
     
     @staticmethod
     def preprocess_dataset(input_dir: str, 

--- a/smal_fitter/neuralSMIL/train_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/train_smil_regressor.py
@@ -41,15 +41,8 @@ from training_config import TrainingConfig
 from configs import SingleViewConfig, load_config, save_config_json, apply_smal_file_override, ConfigurationError
 from memory_optimization import MemoryOptimizer, recommend_training_config, MixedPrecisionTrainer
 
-# Import SLEAP dataset to enable patching of UnifiedSMILDataset
-# Note: This import happens in each worker process due to multiprocessing data loaders
-try:
-    from sleap_data.sleap_dataset import SLEAPDataset, _patch_unified_dataset
-    # Apply the patch to enable SLEAP dataset support (silently to avoid spam from workers)
-    _patch_unified_dataset()
-except ImportError:
-    # SLEAP dataset not available, continue without it
-    pass
+# UnifiedSMILDataset.from_path now dispatches to SLEAPDataset / SLEAPMultiViewDataset
+# directly based on HDF5 /metadata attrs — no monkey-patch required.
 
 
 def set_random_seeds(seed=0):

--- a/smal_fitter/replicAnt_data/__init__.py
+++ b/smal_fitter/replicAnt_data/__init__.py
@@ -4,11 +4,15 @@ Tools for integrating replicAnt (procedural Unreal-Engine generated)
 datasets into the SMILify pipeline. Sibling of `sleap_data/` for the
 SLEAP-sourced multi-camera path.
 
-Main components (current and planned):
+Main components:
 - visualize_multiview_depth_occlusion.py: per-view diagnostic plots for
   the depth-buffer self-occlusion visibility refinement applied by the
   multi-camera replicAnt loader.
-- preprocess_replicant_multiview_dataset.py (planned): converts a flat-
-  directory replicAnt multi-cam dataset into the multiview HDF5 schema
-  consumed by SLEAPMultiViewDataset and train_multiview_regressor.py.
+- preprocess_replicant_multiview_dataset.py: converts a flat-directory
+  replicAnt multi-cam dataset into the multiview HDF5 schema consumed by
+  SLEAPMultiViewDataset and train_multiview_regressor.py. Bakes the
+  multi-view scale unification (translation_factor=0.1) into the stored
+  data and writes camera extrinsics in OpenCV form so the existing
+  SLEAPMultiViewDataset conversion lands on the loader's PyTorch3D
+  values without any class changes.
 """

--- a/smal_fitter/replicAnt_data/__init__.py
+++ b/smal_fitter/replicAnt_data/__init__.py
@@ -1,0 +1,14 @@
+"""replicAnt Data Integration Package
+
+Tools for integrating replicAnt (procedural Unreal-Engine generated)
+datasets into the SMILify pipeline. Sibling of `sleap_data/` for the
+SLEAP-sourced multi-camera path.
+
+Main components (current and planned):
+- visualize_multiview_depth_occlusion.py: per-view diagnostic plots for
+  the depth-buffer self-occlusion visibility refinement applied by the
+  multi-camera replicAnt loader.
+- preprocess_replicant_multiview_dataset.py (planned): converts a flat-
+  directory replicAnt multi-cam dataset into the multiview HDF5 schema
+  consumed by SLEAPMultiViewDataset and train_multiview_regressor.py.
+"""

--- a/smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py
+++ b/smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py
@@ -158,6 +158,23 @@ def _process_frame(task: Dict[str, Any]) -> Dict[str, Any]:
             "reason": "loader returned None image for one or more views",
         }
 
+    # Per-view supervision validity from the loader. False slots have empty
+    # `subject Data` (animal absent from this view's render); we keep the
+    # slot (image + camera geometry still valid) but mark view_mask=False so
+    # the trainer skips supervision for it.
+    view_valid_per_view = list(y.get("view_valid_per_view", [True] * num_views))
+    num_valid_views = int(sum(view_valid_per_view))
+    min_views = int(task["min_views_per_sample"])
+    if num_valid_views < min_views:
+        return {
+            "frame_idx": frame_idx,
+            "ok": False,
+            "reason": (
+                f"only {num_valid_views}/{num_views} views have valid subject data "
+                f"(min_views={min_views})"
+            ),
+        }
+
     H, W = int(images[0].shape[0]), int(images[0].shape[1])
 
     jpeg_blobs: List[bytes] = []
@@ -208,6 +225,7 @@ def _process_frame(task: Dict[str, Any]) -> Dict[str, Any]:
         "camera_ids": camera_ids,
         "camera_names": [f"CAM{c}" for c in camera_ids],
         "jpeg_blobs": jpeg_blobs,
+        "view_valid_per_view": view_valid_per_view,
         "keypoints_2d": keypoints_2d,
         "keypoint_visibility": keypoint_visibility,
         "camera_intrinsics": np.stack(K_list, axis=0),
@@ -247,6 +265,7 @@ class replicAntMultiViewPreprocessor:
         compression_level: int = 6,
         frame_skip: int = 1,
         camera_subset: Optional[List[int]] = None,
+        min_views_per_sample: int = 2,
         depth_occlusion_check: bool = True,
         depth_max_cm: float = 1000.0,
         depth_tolerance_cm: float = 5.0,
@@ -259,6 +278,10 @@ class replicAntMultiViewPreprocessor:
             raise ValueError(f"frame_skip must be >= 1, got {frame_skip}")
         if not (1 <= jpeg_quality <= 100):
             raise ValueError(f"jpeg_quality must be in [1, 100], got {jpeg_quality}")
+        if min_views_per_sample < 1:
+            raise ValueError(
+                f"min_views_per_sample must be >= 1, got {min_views_per_sample}"
+            )
 
         self.target_resolution = int(target_resolution)
         self.backbone_name = backbone_name
@@ -268,6 +291,7 @@ class replicAntMultiViewPreprocessor:
         self.compression_level = int(compression_level)
         self.frame_skip = int(frame_skip)
         self.camera_subset = list(camera_subset) if camera_subset is not None else None
+        self.min_views_per_sample = int(min_views_per_sample)
         self.depth_occlusion_check = bool(depth_occlusion_check)
         self.depth_max_cm = float(depth_max_cm)
         self.depth_tolerance_cm = float(depth_tolerance_cm)
@@ -658,6 +682,7 @@ class replicAntMultiViewPreprocessor:
                 "propagate_scaling": self.propagate_scaling,
                 "translation_factor": self.translation_factor,
                 "jpeg_quality": self.jpeg_quality,
+                "min_views_per_sample": self.min_views_per_sample,
                 "depth_occlusion_check": self.depth_occlusion_check,
                 "depth_max_cm": self.depth_max_cm,
                 "depth_tolerance_cm": self.depth_tolerance_cm,
@@ -700,7 +725,16 @@ class replicAntMultiViewPreprocessor:
 
                     i = num_written
                     nv = int(result["num_views"])
+                    view_valid_per_view = list(
+                        result.get("view_valid_per_view", [True] * nv)
+                    )
                     # Per-view image blobs and view_mask.
+                    # The JPG image and camera geometry (K/R/t) are written for
+                    # every slot regardless of subject-data validity — the image
+                    # itself is real, the camera params still describe the rig.
+                    # `view_mask` and `camera_indices` reflect per-view supervision
+                    # validity: invalid views get view_mask=False + camera_indices=-1
+                    # so SLEAPMultiViewDataset drops the slot at __getitem__ time.
                     view_mask_row = np.zeros((max_views,), dtype=bool)
                     cam_idx_row = np.full((max_views,), -1, dtype=np.int32)
                     for v in range(nv):
@@ -713,8 +747,12 @@ class replicAntMultiViewPreprocessor:
                         handles["image_jpeg_datasets"][slot][i] = np.frombuffer(
                             result["jpeg_blobs"][v], dtype=np.uint8
                         )
-                        view_mask_row[slot] = True
-                        cam_idx_row[slot] = slot
+                        if view_valid_per_view[v]:
+                            view_mask_row[slot] = True
+                            cam_idx_row[slot] = slot
+                        # else: leave view_mask_row[slot]=False and
+                        # cam_idx_row[slot]=-1 (the "this slot is not a real
+                        # supervisable view" convention).
 
                     # Fixed-shape per-view fields. Stored in slot order (matches
                     # canonical_camera_order); padded slots stay at zeros.
@@ -751,7 +789,9 @@ class replicAntMultiViewPreprocessor:
 
                     handles["has_3d_data"][i] = True
                     handles["has_gt_betas"][i] = True
-                    handles["num_views"][i] = nv
+                    # `num_views` stores the count of valid (supervisable) views,
+                    # matching the SLEAP convention and the trainer's expectation.
+                    handles["num_views"][i] = int(sum(view_valid_per_view))
                     handles["frame_idx"][i] = result["frame_idx"]
                     handles["canonical_to_world_R"][i] = result["canonical_to_world_R"]
                     handles["canonical_to_world_t"][i] = result["canonical_to_world_t"]
@@ -790,7 +830,7 @@ class replicAntMultiViewPreprocessor:
             meta.attrs["depth_max_cm"] = float(self.depth_max_cm)
             meta.attrs["depth_tolerance_cm"] = float(self.depth_tolerance_cm)
             meta.attrs["depth_neighborhood"] = int(self.depth_neighborhood)
-            meta.attrs["min_views_per_sample"] = int(max_views)  # always all views present
+            meta.attrs["min_views_per_sample"] = int(self.min_views_per_sample)
             meta.attrs["camera_extrinsics_convention"] = "opencv"
             # Skipped-frame ledger.
             meta.attrs["num_skipped_frames"] = len(skipped)
@@ -854,6 +894,11 @@ def main() -> None:
         help='Comma-separated camera IDs (e.g. "1,2,3"). Default: all cameras at frame 0.',
     )
     parser.add_argument("--max_frames", type=int, default=None, help="Cap number of frames (smoke test)")
+    parser.add_argument("--min_views", type=int, default=2,
+                        help="Minimum valid views per sample. Frames with fewer "
+                             "cameras containing valid subject data are discarded; "
+                             "frames with >= this many keep all camera slots but "
+                             "set view_mask=False on the invalid ones. Default: 2.")
     parser.add_argument("--translation_factor", type=float, default=0.1,
                         help="Loader-side uniform world scale (default 0.1 unifies mesh + data units)")
     parser.add_argument("--depth_occlusion_check", dest="depth_occlusion_check",
@@ -887,6 +932,7 @@ def main() -> None:
         chunk_size=args.chunk_size,
         frame_skip=args.frame_skip,
         camera_subset=_parse_camera_subset(args.camera_subset),
+        min_views_per_sample=args.min_views,
         depth_occlusion_check=args.depth_occlusion_check,
         depth_max_cm=args.depth_max_cm,
         depth_tolerance_cm=args.depth_tolerance_cm,

--- a/smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py
+++ b/smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py
@@ -1,0 +1,917 @@
+#!/usr/bin/env python3
+"""Preprocess a flat-directory replicAnt multi-camera dataset into the multi-view
+HDF5 layout consumed by `SLEAPMultiViewDataset` and `train_multiview_regressor.py`.
+
+Reads the per-frame, per-camera JSON+JPG+ID-mask+optional-depth files produced by
+the replicAnt Unreal Engine pipeline, calls `load_SMIL_Unreal_multiview_sample`
+once per frame (in worker processes), and streams the result to an HDF5 file with
+the same group/dataset names as the SLEAP multi-view path. The trainer reads
+both files interchangeably via `SLEAPMultiViewDataset`.
+
+Conventions baked in by this preprocessor:
+
+- **Scale unification (Phase 1b)**. Calls the loader with `translation_factor=0.1`
+  by default. All world-frame translations (`root_loc`, `cam_trans_per_view`,
+  `keypoints_3d`, `canonical_to_world_t`) come out of the loader already scaled
+  into model-world units. HDF5 metadata advertises `world_scale=1.0`; no further
+  scaling at trainer load.
+- **OpenCV-form extrinsics**. The loader returns extrinsics in PyTorch3D-mirrored
+  row-vector form. We invert that here and store OpenCV-form `(R_cv, t_cv)` so
+  that `SLEAPMultiViewDataset._sleap_to_pytorch3d_camera` re-derives the
+  PyTorch3D form at load time, byte-equivalent to the loader output.
+  See MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md §Scale Unification.
+- **No depth in HDF5**. Depth-buffer self-occlusion runs inside the loader at
+  preprocess time; the resulting visibility is what ends up in
+  `/multiview_keypoints/keypoint_visibility`. The four depth thresholds are
+  recorded in `/metadata` attrs for reproducibility.
+- **Per-frame failure handling**. A frame that fails to load is logged with its
+  reason, skipped, and its source index recorded in
+  `/metadata.skipped_frame_indices`. `num_samples` is the count of successfully
+  preprocessed frames; the HDF5 axis has no gaps.
+
+Usage:
+    python preprocess_replicant_multiview_dataset.py \\
+        --input_dir /mnt/c/replicAnt-dataset-multi-cam-mice \\
+        --output_hdf5 replicant_multiview.h5 \\
+        --smal_file 3D_model_prep/SMILy_Mouse_static_joints_Falkner_conv_repose_hind_legs.pkl \\
+        --max_frames 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import traceback
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import h5py
+import numpy as np
+from tqdm import tqdm
+
+_HERE = Path(__file__).resolve().parent
+_REPO = _HERE.parent.parent
+sys.path.insert(0, str(_REPO))
+sys.path.insert(0, str(_REPO / "smal_fitter"))
+sys.path.insert(0, str(_REPO / "smal_fitter" / "neuralSMIL"))
+
+import config  # noqa: E402
+from neuralSMIL.configs.config_utils import apply_smal_file_override  # noqa: E402
+
+
+# Rz_180 = diag(-1, -1, 1). SLEAPMultiViewDataset._sleap_to_pytorch3d_camera
+# uses this matrix to map OpenCV (R_cv, t_cv) -> PyTorch3D (R_p3d, T_p3d) at
+# dataset-load time:
+#     R_p3d = R_cv.T @ Rz_180
+#     T_p3d = Rz_180 @ t_cv
+# To round-trip the multi-view loader's PyTorch3D-mirrored output through that
+# class without changing its conversion, we apply the inverse here:
+#     R_cv  = Rz_180 @ R_p3d.T
+#     t_cv  = Rz_180 @ T_p3d           (Rz_180 is its own inverse)
+_RZ_180 = np.array(
+    [[-1.0, 0.0, 0.0],
+     [0.0, -1.0, 0.0],
+     [0.0, 0.0, 1.0]],
+    dtype=np.float32,
+)
+
+
+def _pytorch3d_to_opencv_camera(R_p3d: np.ndarray, T_p3d: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    R_cv = (_RZ_180 @ R_p3d.T).astype(np.float32)
+    t_cv = (_RZ_180 @ T_p3d).astype(np.float32)
+    return R_cv, t_cv
+
+
+def _build_K(fx: float, fy: float, cx: float, cy: float) -> np.ndarray:
+    return np.array(
+        [[fx, 0.0, cx],
+         [0.0, fy, cy],
+         [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+
+def _encode_jpeg_rgb(image_rgb: np.ndarray, quality: int) -> bytes:
+    bgr = cv2.cvtColor(image_rgb, cv2.COLOR_RGB2BGR)
+    ok, buf = cv2.imencode(".jpg", bgr, [int(cv2.IMWRITE_JPEG_QUALITY), int(quality)])
+    if not ok:
+        raise RuntimeError("cv2.imencode JPEG failed")
+    return buf.tobytes()
+
+
+# ---------------------------------------------------------------------------
+# Worker-side state and entry point.
+# ---------------------------------------------------------------------------
+
+_WORKER_LOADER = None  # populated by _worker_init
+
+
+def _worker_init(smal_file: Optional[str], shape_family: Optional[int]) -> None:
+    """ProcessPoolExecutor initializer. Runs ONCE per worker process before
+    any task is dispatched. Applies the SMAL pickle override (so
+    `config.dd["J_names"]` matches the dataset) and imports the multi-view
+    loader into a module-level slot."""
+    if smal_file:
+        apply_smal_file_override(smal_file, shape_family=shape_family)
+    global _WORKER_LOADER
+    from Unreal2Pytorch3D import load_SMIL_Unreal_multiview_sample
+    _WORKER_LOADER = load_SMIL_Unreal_multiview_sample
+
+
+def _process_frame(task: Dict[str, Any]) -> Dict[str, Any]:
+    """Worker entry: load one frame, encode JPEGs, build OpenCV-form camera
+    params, return a typed dict the main process can stream to HDF5."""
+    frame_idx = int(task["frame_idx"])
+    try:
+        x, y = _WORKER_LOADER(
+            data_path=task["data_path"],
+            frame_index=frame_idx,
+            camera_indices=task.get("camera_subset"),
+            propagate_scaling=task["propagate_scaling"],
+            translation_factor=task["translation_factor"],
+            load_images=True,
+            canonical_frame=True,
+            depth_occlusion_check=task["depth_occlusion_check"],
+            depth_max_cm=task["depth_max_cm"],
+            depth_tolerance_cm=task["depth_tolerance_cm"],
+            depth_neighborhood=task["depth_neighborhood"],
+        )
+    except Exception as exc:
+        return {
+            "frame_idx": frame_idx,
+            "ok": False,
+            "reason": f"loader: {type(exc).__name__}: {exc}",
+        }
+
+    num_views = int(x["num_views"])
+    images = x["image_data"]
+    if any(img is None for img in images):
+        return {
+            "frame_idx": frame_idx,
+            "ok": False,
+            "reason": "loader returned None image for one or more views",
+        }
+
+    H, W = int(images[0].shape[0]), int(images[0].shape[1])
+
+    jpeg_blobs: List[bytes] = []
+    K_list: List[np.ndarray] = []
+    R_cv_list: List[np.ndarray] = []
+    t_cv_list: List[np.ndarray] = []
+    image_sizes: List[np.ndarray] = []
+
+    try:
+        for v in range(num_views):
+            jpeg_blobs.append(_encode_jpeg_rgb(images[v], task["jpeg_quality"]))
+
+            fx = float(y["fx_per_view"][v])
+            fy = float(y["fy_per_view"][v])
+            cx = float(y["cx_per_view"][v])
+            cy = float(y["cy_per_view"][v])
+            K_list.append(_build_K(fx, fy, cx, cy))
+
+            R_p3d_t = y["cam_rot_per_view"][v]
+            T_p3d_t = y["cam_trans_per_view"][v]
+            R_p3d = R_p3d_t.detach().cpu().numpy().astype(np.float32) if hasattr(R_p3d_t, "detach") else np.asarray(R_p3d_t, dtype=np.float32)
+            T_p3d = T_p3d_t.detach().cpu().numpy().astype(np.float32) if hasattr(T_p3d_t, "detach") else np.asarray(T_p3d_t, dtype=np.float32)
+
+            R_cv, t_cv = _pytorch3d_to_opencv_camera(R_p3d, T_p3d)
+            R_cv_list.append(R_cv)
+            t_cv_list.append(t_cv)
+
+            image_sizes.append(np.array([W, H], dtype=np.int32))
+    except Exception as exc:
+        return {
+            "frame_idx": frame_idx,
+            "ok": False,
+            "reason": f"camera/jpeg pack: {type(exc).__name__}: {exc}",
+        }
+
+    keypoints_2d = np.stack(y["keypoints_2d_per_view"], axis=0).astype(np.float32)
+    keypoint_visibility = np.stack(y["keypoint_visibility_per_view"], axis=0).astype(np.float32)
+    keypoints_3d = np.asarray(y["keypoints_3d"], dtype=np.float32)
+
+    camera_ids = list(x["camera_ids"])
+
+    return {
+        "frame_idx": frame_idx,
+        "ok": True,
+        "num_views": num_views,
+        "image_h": H,
+        "image_w": W,
+        "camera_ids": camera_ids,
+        "camera_names": [f"CAM{c}" for c in camera_ids],
+        "jpeg_blobs": jpeg_blobs,
+        "keypoints_2d": keypoints_2d,
+        "keypoint_visibility": keypoint_visibility,
+        "camera_intrinsics": np.stack(K_list, axis=0),
+        "camera_extrinsics_R": np.stack(R_cv_list, axis=0),
+        "camera_extrinsics_t": np.stack(t_cv_list, axis=0),
+        "image_sizes": np.stack(image_sizes, axis=0),
+        "keypoints_3d": keypoints_3d,
+        "joint_angles": np.asarray(y["joint_angles"], dtype=np.float32),
+        "root_rot": np.asarray(y["root_rot"], dtype=np.float32),
+        "root_loc": np.asarray(y["root_loc"], dtype=np.float32),
+        "shape_betas": np.asarray(y["shape_betas"], dtype=np.float32),
+        "canonical_to_world_R": np.asarray(y["canonical_to_world"][0], dtype=np.float32),
+        "canonical_to_world_t": np.asarray(y["canonical_to_world"][1], dtype=np.float32),
+        "canonical_cam_id": int(y["canonical_cam_id"]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Preprocessor.
+# ---------------------------------------------------------------------------
+
+
+class replicAntMultiViewPreprocessor:
+    """Streams one HDF5 multi-view dataset from a flat-directory replicAnt
+    multi-camera dataset. Output schema is identical to the layout produced by
+    `preprocess_sleap_multiview_dataset.py` (modulo replicAnt-specific extras
+    under /auxiliary/), so `SLEAPMultiViewDataset` reads either file unchanged.
+    """
+
+    def __init__(
+        self,
+        target_resolution: int = 512,
+        backbone_name: str = "vit_large_patch16_224",
+        jpeg_quality: int = 95,
+        chunk_size: int = 8,
+        compression: str = "gzip",
+        compression_level: int = 6,
+        frame_skip: int = 1,
+        camera_subset: Optional[List[int]] = None,
+        depth_occlusion_check: bool = True,
+        depth_max_cm: float = 1000.0,
+        depth_tolerance_cm: float = 5.0,
+        depth_neighborhood: int = 1,
+        propagate_scaling: bool = True,
+        translation_factor: float = 0.1,
+        debug: bool = False,
+    ):
+        if frame_skip < 1:
+            raise ValueError(f"frame_skip must be >= 1, got {frame_skip}")
+        if not (1 <= jpeg_quality <= 100):
+            raise ValueError(f"jpeg_quality must be in [1, 100], got {jpeg_quality}")
+
+        self.target_resolution = int(target_resolution)
+        self.backbone_name = backbone_name
+        self.jpeg_quality = int(jpeg_quality)
+        self.chunk_size = int(chunk_size)
+        self.compression = compression
+        self.compression_level = int(compression_level)
+        self.frame_skip = int(frame_skip)
+        self.camera_subset = list(camera_subset) if camera_subset is not None else None
+        self.depth_occlusion_check = bool(depth_occlusion_check)
+        self.depth_max_cm = float(depth_max_cm)
+        self.depth_tolerance_cm = float(depth_tolerance_cm)
+        self.depth_neighborhood = int(depth_neighborhood)
+        self.propagate_scaling = bool(propagate_scaling)
+        self.translation_factor = float(translation_factor)
+        self.debug = bool(debug)
+
+    # ---------- dataset discovery ------------------------------------------
+
+    def _detect_dataset_structure(self, data_path: Path) -> Tuple[str, List[int], List[int]]:
+        """Returns (dataset_name, canonical_camera_subset, frame_indices)."""
+        batch_files = list(data_path.glob("_BatchData_*.json"))
+        if not batch_files:
+            raise FileNotFoundError(f"No _BatchData_*.json found in {data_path}")
+        batch_file = batch_files[0]
+        dataset_name = batch_file.stem.replace("_BatchData_", "")
+
+        # Discover cameras present at frame 0
+        cam_files_00000 = list(data_path.glob(f"{dataset_name}_00000_CAM*.json"))
+        all_cam_ids = sorted(
+            {int(re.search(r"CAM(\d+)", f.name).group(1)) for f in cam_files_00000}
+        )
+        if not all_cam_ids:
+            raise FileNotFoundError(
+                f"No {dataset_name}_00000_CAM*.json files under {data_path}"
+            )
+
+        if self.camera_subset is not None:
+            missing = set(self.camera_subset) - set(all_cam_ids)
+            if missing:
+                raise ValueError(
+                    f"camera_subset {sorted(self.camera_subset)} requested but cameras "
+                    f"{sorted(missing)} not present at frame 00000 (have {all_cam_ids})"
+                )
+            camera_subset = sorted(self.camera_subset)
+        else:
+            camera_subset = all_cam_ids
+
+        # Discover frames present (use the FIRST canonical cam as the index).
+        canonical_cam = camera_subset[0]
+        cam_files = list(
+            data_path.glob(f"{dataset_name}_*_CAM{canonical_cam}.json")
+        )
+        frame_indices: List[int] = []
+        pattern = re.compile(
+            rf"{re.escape(dataset_name)}_(\d+)_CAM{canonical_cam}\.json$"
+        )
+        for cf in cam_files:
+            m = pattern.search(cf.name)
+            if m:
+                frame_indices.append(int(m.group(1)))
+        if not frame_indices:
+            raise FileNotFoundError(
+                f"No CAM{canonical_cam} frame JSON files matched under {data_path}"
+            )
+        frame_indices.sort()
+
+        return dataset_name, camera_subset, frame_indices
+
+    # ---------- HDF5 setup --------------------------------------------------
+
+    def _create_hdf5_layout(
+        self,
+        f: h5py.File,
+        num_alloc: int,
+        max_views: int,
+        n_joints: int,
+        n_pose: int,
+        n_betas: int,
+    ) -> Dict[str, Any]:
+        """Pre-allocate all fixed-shape datasets at `num_alloc` rows. Returns a
+        dict of handles for streaming writes."""
+        images_g = f.create_group("multiview_images")
+        kp_g = f.create_group("multiview_keypoints")
+        par_g = f.create_group("parameters")
+        aux_g = f.create_group("auxiliary")
+        meta_g = f.create_group("metadata")
+
+        ck_n = max(1, min(self.chunk_size, num_alloc))
+        comp = dict(compression=self.compression, compression_opts=self.compression_level)
+
+        # Variable-length JPEG bytes, one dataset per view slot.
+        vlen_u8 = h5py.vlen_dtype(np.uint8)
+        image_jpeg_datasets = []
+        for v in range(max_views):
+            ds = images_g.create_dataset(
+                f"image_jpeg_view_{v}",
+                shape=(num_alloc,),
+                maxshape=(None,),
+                dtype=vlen_u8,
+            )
+            image_jpeg_datasets.append(ds)
+
+        view_mask = images_g.create_dataset(
+            "view_mask",
+            shape=(num_alloc, max_views),
+            maxshape=(None, max_views),
+            dtype=bool,
+            chunks=(ck_n, max_views),
+            **comp,
+        )
+
+        keypoints_2d = kp_g.create_dataset(
+            "keypoints_2d",
+            shape=(num_alloc, max_views, n_joints, 2),
+            maxshape=(None, max_views, n_joints, 2),
+            dtype=np.float32,
+            chunks=(ck_n, max_views, n_joints, 2),
+            **comp,
+        )
+        keypoint_visibility = kp_g.create_dataset(
+            "keypoint_visibility",
+            shape=(num_alloc, max_views, n_joints),
+            maxshape=(None, max_views, n_joints),
+            dtype=np.float32,
+            chunks=(ck_n, max_views, n_joints),
+            **comp,
+        )
+        camera_indices = kp_g.create_dataset(
+            "camera_indices",
+            shape=(num_alloc, max_views),
+            maxshape=(None, max_views),
+            dtype=np.int32,
+            chunks=(ck_n, max_views),
+            **comp,
+        )
+        camera_intrinsics = kp_g.create_dataset(
+            "camera_intrinsics",
+            shape=(num_alloc, max_views, 3, 3),
+            maxshape=(None, max_views, 3, 3),
+            dtype=np.float32,
+            chunks=(ck_n, max_views, 3, 3),
+            **comp,
+        )
+        camera_extrinsics_R = kp_g.create_dataset(
+            "camera_extrinsics_R",
+            shape=(num_alloc, max_views, 3, 3),
+            maxshape=(None, max_views, 3, 3),
+            dtype=np.float32,
+            chunks=(ck_n, max_views, 3, 3),
+            **comp,
+        )
+        camera_extrinsics_t = kp_g.create_dataset(
+            "camera_extrinsics_t",
+            shape=(num_alloc, max_views, 3),
+            maxshape=(None, max_views, 3),
+            dtype=np.float32,
+            chunks=(ck_n, max_views, 3),
+            **comp,
+        )
+        image_sizes = kp_g.create_dataset(
+            "image_sizes",
+            shape=(num_alloc, max_views, 2),
+            maxshape=(None, max_views, 2),
+            dtype=np.int32,
+            chunks=(ck_n, max_views, 2),
+            **comp,
+        )
+        keypoints_3d = kp_g.create_dataset(
+            "keypoints_3d",
+            shape=(num_alloc, n_joints, 3),
+            maxshape=(None, n_joints, 3),
+            dtype=np.float32,
+            chunks=(ck_n, n_joints, 3),
+            **comp,
+        )
+
+        global_rot = par_g.create_dataset(
+            "global_rot",
+            shape=(num_alloc, 3),
+            maxshape=(None, 3),
+            dtype=np.float32,
+            chunks=(ck_n, 3),
+            **comp,
+        )
+        joint_rot = par_g.create_dataset(
+            "joint_rot",
+            shape=(num_alloc, n_pose + 1, 3),
+            maxshape=(None, n_pose + 1, 3),
+            dtype=np.float32,
+            chunks=(ck_n, n_pose + 1, 3),
+            **comp,
+        )
+        betas = par_g.create_dataset(
+            "betas",
+            shape=(num_alloc, n_betas),
+            maxshape=(None, n_betas),
+            dtype=np.float32,
+            chunks=(ck_n, n_betas),
+            **comp,
+        )
+        trans = par_g.create_dataset(
+            "trans",
+            shape=(num_alloc, 3),
+            maxshape=(None, 3),
+            dtype=np.float32,
+            chunks=(ck_n, 3),
+            **comp,
+        )
+
+        has_3d_data = aux_g.create_dataset(
+            "has_3d_data",
+            shape=(num_alloc,),
+            maxshape=(None,),
+            dtype=bool,
+            chunks=(ck_n,),
+            **comp,
+        )
+        has_gt_betas = aux_g.create_dataset(
+            "has_ground_truth_betas",
+            shape=(num_alloc,),
+            maxshape=(None,),
+            dtype=bool,
+            chunks=(ck_n,),
+            **comp,
+        )
+        num_views_ds = aux_g.create_dataset(
+            "num_views",
+            shape=(num_alloc,),
+            maxshape=(None,),
+            dtype=np.int32,
+            chunks=(ck_n,),
+            **comp,
+        )
+        frame_idx_ds = aux_g.create_dataset(
+            "frame_idx",
+            shape=(num_alloc,),
+            maxshape=(None,),
+            dtype=np.int32,
+            chunks=(ck_n,),
+            **comp,
+        )
+        canonical_to_world_R_ds = aux_g.create_dataset(
+            "canonical_to_world_R",
+            shape=(num_alloc, 3, 3),
+            maxshape=(None, 3, 3),
+            dtype=np.float32,
+            chunks=(ck_n, 3, 3),
+            **comp,
+        )
+        canonical_to_world_t_ds = aux_g.create_dataset(
+            "canonical_to_world_t",
+            shape=(num_alloc, 3),
+            maxshape=(None, 3),
+            dtype=np.float32,
+            chunks=(ck_n, 3),
+            **comp,
+        )
+        canonical_cam_id_ds = aux_g.create_dataset(
+            "canonical_cam_id",
+            shape=(num_alloc,),
+            maxshape=(None,),
+            dtype=np.int32,
+            chunks=(ck_n,),
+            **comp,
+        )
+        vlen_str = h5py.string_dtype(encoding="utf-8")
+        session_name_ds = aux_g.create_dataset(
+            "session_name",
+            shape=(num_alloc,),
+            maxshape=(None,),
+            dtype=vlen_str,
+        )
+        camera_names_ds = aux_g.create_dataset(
+            "camera_names",
+            shape=(num_alloc,),
+            maxshape=(None,),
+            dtype=vlen_str,
+        )
+
+        return {
+            "metadata_group": meta_g,
+            "image_jpeg_datasets": image_jpeg_datasets,
+            "view_mask": view_mask,
+            "keypoints_2d": keypoints_2d,
+            "keypoint_visibility": keypoint_visibility,
+            "camera_indices": camera_indices,
+            "camera_intrinsics": camera_intrinsics,
+            "camera_extrinsics_R": camera_extrinsics_R,
+            "camera_extrinsics_t": camera_extrinsics_t,
+            "image_sizes": image_sizes,
+            "keypoints_3d": keypoints_3d,
+            "global_rot": global_rot,
+            "joint_rot": joint_rot,
+            "betas": betas,
+            "trans": trans,
+            "has_3d_data": has_3d_data,
+            "has_gt_betas": has_gt_betas,
+            "num_views": num_views_ds,
+            "frame_idx": frame_idx_ds,
+            "canonical_to_world_R": canonical_to_world_R_ds,
+            "canonical_to_world_t": canonical_to_world_t_ds,
+            "canonical_cam_id": canonical_cam_id_ds,
+            "session_name": session_name_ds,
+            "camera_names": camera_names_ds,
+        }
+
+    def _resize_datasets(self, handles: Dict[str, Any], num_written: int, max_views: int) -> None:
+        for ds in handles["image_jpeg_datasets"]:
+            ds.resize((num_written,))
+        # All non-image datasets have the sample axis as axis 0; resize keeps
+        # the remaining axes intact.
+        for key in (
+            "view_mask",
+            "keypoints_2d",
+            "keypoint_visibility",
+            "camera_indices",
+            "camera_intrinsics",
+            "camera_extrinsics_R",
+            "camera_extrinsics_t",
+            "image_sizes",
+            "keypoints_3d",
+            "global_rot",
+            "joint_rot",
+            "betas",
+            "trans",
+            "has_3d_data",
+            "has_gt_betas",
+            "num_views",
+            "frame_idx",
+            "canonical_to_world_R",
+            "canonical_to_world_t",
+            "canonical_cam_id",
+            "session_name",
+            "camera_names",
+        ):
+            ds = handles[key]
+            new_shape = (num_written,) + ds.shape[1:]
+            ds.resize(new_shape)
+
+    # ---------- main entry --------------------------------------------------
+
+    def preprocess(
+        self,
+        input_dir: str,
+        output_hdf5: str,
+        num_workers: int = 8,
+        max_frames: Optional[int] = None,
+        smal_file: Optional[str] = None,
+        shape_family: Optional[int] = None,
+        verbose: bool = True,
+    ) -> Dict[str, Any]:
+        data_path = Path(input_dir)
+        if not data_path.is_dir():
+            raise NotADirectoryError(f"input_dir does not exist: {data_path}")
+
+        dataset_name, camera_subset, all_frame_indices = self._detect_dataset_structure(data_path)
+        canonical_camera_order = [f"CAM{c}" for c in camera_subset]
+        max_views = len(camera_subset)
+        canonical_camera_names_str = ",".join(canonical_camera_order)
+
+        # Apply frame_skip then max_frames.
+        frame_indices = all_frame_indices[:: self.frame_skip]
+        if max_frames is not None:
+            frame_indices = frame_indices[:max_frames]
+        num_alloc = len(frame_indices)
+        if num_alloc == 0:
+            raise ValueError("No frames left after frame_skip/max_frames filtering")
+
+        # n_joints / n_pose / n_betas — derive from config AFTER the SMAL pickle
+        # override (so the main-process state matches what workers will compute).
+        if smal_file:
+            apply_smal_file_override(smal_file, shape_family=shape_family)
+        n_joints = int(len(config.dd["J_names"]))
+        n_pose = int(config.N_POSE)
+        n_betas = int(config.N_BETAS)
+
+        if verbose:
+            print(f"Dataset: {dataset_name}")
+            print(f"  flat-dir path:           {data_path}")
+            print(f"  cameras (subset):        {camera_subset}")
+            print(f"  canonical_camera_order:  {canonical_camera_order}")
+            print(f"  total frames:            {len(all_frame_indices)}")
+            print(f"  frames after skip/max:   {num_alloc} (frame_skip={self.frame_skip}, max_frames={max_frames})")
+            print(f"  n_joints={n_joints}, n_pose={n_pose}, n_betas={n_betas}")
+            print(f"  translation_factor:      {self.translation_factor}")
+            print(f"  depth_occlusion_check:   {self.depth_occlusion_check}")
+            print(f"  jpeg_quality:            {self.jpeg_quality}")
+            print(f"  num_workers:             {num_workers}")
+            print()
+
+        worker_tasks = [
+            {
+                "frame_idx": fi,
+                "data_path": str(data_path),
+                "camera_subset": list(camera_subset),
+                "propagate_scaling": self.propagate_scaling,
+                "translation_factor": self.translation_factor,
+                "jpeg_quality": self.jpeg_quality,
+                "depth_occlusion_check": self.depth_occlusion_check,
+                "depth_max_cm": self.depth_max_cm,
+                "depth_tolerance_cm": self.depth_tolerance_cm,
+                "depth_neighborhood": self.depth_neighborhood,
+            }
+            for fi in frame_indices
+        ]
+
+        start_time = time.time()
+        num_written = 0
+        skipped: List[Tuple[int, str]] = []
+
+        with h5py.File(output_hdf5, "w") as f:
+            handles = self._create_hdf5_layout(
+                f, num_alloc, max_views, n_joints, n_pose, n_betas
+            )
+            cam_idx_map = {cam_id: idx for idx, cam_id in enumerate(camera_subset)}
+
+            executor_kwargs = dict(
+                max_workers=num_workers,
+                initializer=_worker_init,
+                initargs=(smal_file, shape_family),
+            )
+            with ProcessPoolExecutor(**executor_kwargs) as pool:
+                results_iter = pool.map(_process_frame, worker_tasks, chunksize=1)
+                progress = tqdm(
+                    results_iter,
+                    total=len(worker_tasks),
+                    desc="Preprocess",
+                    disable=not verbose,
+                )
+                for result in progress:
+                    if not result.get("ok"):
+                        skipped.append((int(result["frame_idx"]), str(result.get("reason", "unknown"))))
+                        if self.debug and verbose:
+                            tqdm.write(
+                                f"  SKIP frame {result['frame_idx']}: {result.get('reason')}"
+                            )
+                        continue
+
+                    i = num_written
+                    nv = int(result["num_views"])
+                    # Per-view image blobs and view_mask.
+                    view_mask_row = np.zeros((max_views,), dtype=bool)
+                    cam_idx_row = np.full((max_views,), -1, dtype=np.int32)
+                    for v in range(nv):
+                        # Slot index: the v-th camera in this frame should land in
+                        # the canonical slot for its camera id. With a fixed
+                        # camera_subset and canonical_frame=True, the loader
+                        # returns views in the same order — assert it.
+                        cam_id = result["camera_ids"][v]
+                        slot = cam_idx_map.get(int(cam_id), v)
+                        handles["image_jpeg_datasets"][slot][i] = np.frombuffer(
+                            result["jpeg_blobs"][v], dtype=np.uint8
+                        )
+                        view_mask_row[slot] = True
+                        cam_idx_row[slot] = slot
+
+                    # Fixed-shape per-view fields. Stored in slot order (matches
+                    # canonical_camera_order); padded slots stay at zeros.
+                    kp2d_row = np.zeros((max_views, n_joints, 2), dtype=np.float32)
+                    vis_row = np.zeros((max_views, n_joints), dtype=np.float32)
+                    K_row = np.zeros((max_views, 3, 3), dtype=np.float32)
+                    R_row = np.zeros((max_views, 3, 3), dtype=np.float32)
+                    t_row = np.zeros((max_views, 3), dtype=np.float32)
+                    sz_row = np.zeros((max_views, 2), dtype=np.int32)
+                    for v in range(nv):
+                        cam_id = result["camera_ids"][v]
+                        slot = cam_idx_map.get(int(cam_id), v)
+                        kp2d_row[slot] = result["keypoints_2d"][v]
+                        vis_row[slot] = result["keypoint_visibility"][v]
+                        K_row[slot] = result["camera_intrinsics"][v]
+                        R_row[slot] = result["camera_extrinsics_R"][v]
+                        t_row[slot] = result["camera_extrinsics_t"][v]
+                        sz_row[slot] = result["image_sizes"][v]
+
+                    handles["view_mask"][i] = view_mask_row
+                    handles["camera_indices"][i] = cam_idx_row
+                    handles["keypoints_2d"][i] = kp2d_row
+                    handles["keypoint_visibility"][i] = vis_row
+                    handles["camera_intrinsics"][i] = K_row
+                    handles["camera_extrinsics_R"][i] = R_row
+                    handles["camera_extrinsics_t"][i] = t_row
+                    handles["image_sizes"][i] = sz_row
+
+                    handles["keypoints_3d"][i] = result["keypoints_3d"]
+                    handles["global_rot"][i] = result["root_rot"]
+                    handles["joint_rot"][i] = result["joint_angles"]
+                    handles["betas"][i] = result["shape_betas"]
+                    handles["trans"][i] = result["root_loc"]
+
+                    handles["has_3d_data"][i] = True
+                    handles["has_gt_betas"][i] = True
+                    handles["num_views"][i] = nv
+                    handles["frame_idx"][i] = result["frame_idx"]
+                    handles["canonical_to_world_R"][i] = result["canonical_to_world_R"]
+                    handles["canonical_to_world_t"][i] = result["canonical_to_world_t"]
+                    handles["canonical_cam_id"][i] = result["canonical_cam_id"]
+                    handles["session_name"][i] = dataset_name
+                    handles["camera_names"][i] = canonical_camera_names_str
+
+                    num_written += 1
+
+            # Resize down to actual successful count.
+            if num_written < num_alloc:
+                self._resize_datasets(handles, num_written, max_views)
+
+            # Metadata attrs.
+            meta = handles["metadata_group"]
+            meta.attrs["num_samples"] = int(num_written)
+            meta.attrs["max_views"] = int(max_views)
+            meta.attrs["n_joints"] = n_joints
+            meta.attrs["n_pose"] = n_pose
+            meta.attrs["n_betas"] = n_betas
+            meta.attrs["target_resolution"] = int(self.target_resolution)
+            meta.attrs["backbone_name"] = self.backbone_name
+            meta.attrs["jpeg_quality"] = int(self.jpeg_quality)
+            meta.attrs["dataset_type"] = "replicant_multiview"
+            meta.attrs["is_multiview"] = True
+            meta.attrs["has_camera_parameters"] = True
+            meta.attrs["has_3d_keypoints"] = True
+            meta.attrs["load_3d_data"] = True
+            meta.attrs["world_scale"] = 1.0
+            meta.attrs["canonical_camera_order"] = json.dumps(canonical_camera_order)
+            meta.attrs["dataset_name"] = dataset_name
+            meta.attrs["frame_skip"] = int(self.frame_skip)
+            meta.attrs["translation_factor"] = float(self.translation_factor)
+            meta.attrs["propagate_scaling"] = bool(self.propagate_scaling)
+            meta.attrs["depth_occlusion_check"] = bool(self.depth_occlusion_check)
+            meta.attrs["depth_max_cm"] = float(self.depth_max_cm)
+            meta.attrs["depth_tolerance_cm"] = float(self.depth_tolerance_cm)
+            meta.attrs["depth_neighborhood"] = int(self.depth_neighborhood)
+            meta.attrs["min_views_per_sample"] = int(max_views)  # always all views present
+            meta.attrs["camera_extrinsics_convention"] = "opencv"
+            # Skipped-frame ledger.
+            meta.attrs["num_skipped_frames"] = len(skipped)
+            if skipped:
+                meta.attrs["skipped_frame_indices"] = np.array(
+                    [s[0] for s in skipped], dtype=np.int32
+                )
+                meta.attrs["skipped_frame_reasons"] = json.dumps(
+                    {int(idx): reason for idx, reason in skipped}
+                )
+
+        elapsed = time.time() - start_time
+        if verbose:
+            print()
+            print(f"Wrote {num_written} samples to {output_hdf5} in {elapsed:.1f}s")
+            if skipped:
+                print(f"Skipped {len(skipped)} frames:")
+                for idx, reason in skipped[:10]:
+                    print(f"  frame {idx}: {reason}")
+                if len(skipped) > 10:
+                    print(f"  … and {len(skipped) - 10} more")
+
+        return {
+            "num_written": num_written,
+            "num_skipped": len(skipped),
+            "skipped": skipped,
+            "elapsed_seconds": elapsed,
+            "output_hdf5": str(output_hdf5),
+        }
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def _parse_camera_subset(s: Optional[str]) -> Optional[List[int]]:
+    if s is None:
+        return None
+    parts = [p.strip() for p in s.split(",") if p.strip()]
+    return [int(p) for p in parts]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Preprocess a flat-directory replicAnt multi-camera dataset into HDF5.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--input_dir", required=True, help="Flat-directory replicAnt dataset")
+    parser.add_argument("--output_hdf5", required=True, help="Output HDF5 path")
+    parser.add_argument("--smal_file", default=None, help="SMAL/SMIL .pkl matching the dataset skeleton")
+    parser.add_argument("--shape_family", type=int, default=None)
+    parser.add_argument("--num_workers", type=int, default=8)
+    parser.add_argument("--jpeg_quality", type=int, default=95)
+    parser.add_argument("--chunk_size", type=int, default=8)
+    parser.add_argument("--frame_skip", type=int, default=1)
+    parser.add_argument(
+        "--camera_subset",
+        type=str,
+        default=None,
+        help='Comma-separated camera IDs (e.g. "1,2,3"). Default: all cameras at frame 0.',
+    )
+    parser.add_argument("--max_frames", type=int, default=None, help="Cap number of frames (smoke test)")
+    parser.add_argument("--translation_factor", type=float, default=0.1,
+                        help="Loader-side uniform world scale (default 0.1 unifies mesh + data units)")
+    parser.add_argument("--depth_occlusion_check", dest="depth_occlusion_check",
+                        action="store_true", default=True)
+    parser.add_argument("--no_depth_occlusion_check", dest="depth_occlusion_check",
+                        action="store_false")
+    parser.add_argument("--depth_max_cm", type=float, default=1000.0)
+    parser.add_argument("--depth_tolerance_cm", type=float, default=5.0)
+    parser.add_argument("--depth_neighborhood", type=int, default=1)
+    parser.add_argument("--target_resolution", type=int, default=512,
+                        help="Stored image resolution (default: 512, native). Dataset class resizes at load.")
+    parser.add_argument("--backbone_name", type=str, default="vit_large_patch16_224")
+    parser.add_argument("--debug", action="store_true")
+
+    args = parser.parse_args()
+
+    if args.smal_file:
+        smal_path = Path(args.smal_file)
+        if not smal_path.is_file():
+            print(f"Error: --smal_file does not exist: {smal_path}", file=sys.stderr)
+            sys.exit(1)
+
+    output_dir = os.path.dirname(args.output_hdf5)
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
+
+    preprocessor = replicAntMultiViewPreprocessor(
+        target_resolution=args.target_resolution,
+        backbone_name=args.backbone_name,
+        jpeg_quality=args.jpeg_quality,
+        chunk_size=args.chunk_size,
+        frame_skip=args.frame_skip,
+        camera_subset=_parse_camera_subset(args.camera_subset),
+        depth_occlusion_check=args.depth_occlusion_check,
+        depth_max_cm=args.depth_max_cm,
+        depth_tolerance_cm=args.depth_tolerance_cm,
+        depth_neighborhood=args.depth_neighborhood,
+        translation_factor=args.translation_factor,
+        debug=args.debug,
+    )
+
+    try:
+        stats = preprocessor.preprocess(
+            input_dir=args.input_dir,
+            output_hdf5=args.output_hdf5,
+            num_workers=args.num_workers,
+            max_frames=args.max_frames,
+            smal_file=args.smal_file,
+            shape_family=args.shape_family,
+            verbose=True,
+        )
+    except Exception as exc:
+        print(f"\nError during preprocessing: {exc}", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
+
+    print(f"\nDone. {stats['num_written']} samples written; {stats['num_skipped']} skipped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/smal_fitter/replicAnt_data/test_replicant_preprocessing.py
+++ b/smal_fitter/replicAnt_data/test_replicant_preprocessing.py
@@ -115,8 +115,17 @@ def _check_sample(
         trans_h5 = f["parameters/trans"][sample_idx].astype(np.float32)
         rot_h5 = f["parameters/global_rot"][sample_idx].astype(np.float32)
         betas_h5 = f["parameters/betas"][sample_idx].astype(np.float32)
+    # Canonical inverse round-trip only applies to joints with real GT.
+    # Joints absent from the dataset land at the SLEAP-style (0,0,0) sentinel
+    # in BOTH keypoints_3d and keypoints_3d_world — exclude them from the
+    # geometric check (the canonical inverse of (0,0,0) is not (0,0,0)).
+    loader_world = np.asarray(y_mv["keypoints_3d_world"], dtype=np.float32)
+    has_gt_3d = ~(np.all(kp3d_ds == 0, axis=1) & np.all(loader_world == 0, axis=1))
     recovered_world = (kp3d_ds - c2w_t) @ c2w_R.T
-    max_world = float(np.max(np.abs(recovered_world - np.asarray(y_mv["keypoints_3d_world"], dtype=np.float32))))
+    if has_gt_3d.any():
+        max_world = float(np.max(np.abs(recovered_world[has_gt_3d] - loader_world[has_gt_3d])))
+    else:
+        max_world = 0.0
 
     max_trans = float(np.max(np.abs(np.asarray(y_mv["root_loc"], dtype=np.float32) - trans_h5)))
     max_rot = float(np.max(np.abs(np.asarray(y_mv["root_rot"], dtype=np.float32) - rot_h5)))

--- a/smal_fitter/replicAnt_data/test_replicant_preprocessing.py
+++ b/smal_fitter/replicAnt_data/test_replicant_preprocessing.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Round-trip verification for the multi-view replicAnt preprocessor.
+
+For each requested sample in a preprocessed HDF5, compares the values the
+production reader (`SLEAPMultiViewDataset`) exposes against a fresh call to
+`load_SMIL_Unreal_multiview_sample` for the same source frame. This pins down
+the conversion contract that the preprocessor relies on (OpenCV-form extrinsics
+stored, PyTorch3D-form recovered at dataset-load via
+`_sleap_to_pytorch3d_camera`).
+
+Tested invariants (per sample, against tol=1e-5 unless noted):
+
+- `y_data['cam_rot_per_view']`, `cam_trans_per_view`, `cam_fov_per_view`
+  reconstructed by the dataset class match the loader's per-view PyTorch3D
+  cameras.
+- `keypoints_2d`, `keypoint_visibility` per slot match the loader.
+- `keypoints_3d` in canonical frame matches the loader.
+- Applying the stored `canonical_to_world` inverse recovers the loader's
+  `keypoints_3d_world` (raw PyTorch3D-mirrored world frame).
+- `parameters/trans`, `global_rot`, `betas` match the loader's
+  `root_loc`, `root_rot`, `shape_betas`.
+
+Run manually (no live CI — needs the source dataset on disk):
+
+    python smal_fitter/replicAnt_data/test_replicant_preprocessing.py \\
+        --hdf5 SMOKE_replicant_500.h5 \\
+        --dataset_dir /mnt/c/replicAnt-dataset-multi-cam-mice \\
+        --smal_file 3D_model_prep/SMILy_Mouse_static_joints_Falkner_conv_repose_hind_legs.pkl \\
+        --sample_indices 0 100 250 499
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+import h5py
+import numpy as np
+
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO))
+sys.path.insert(0, str(_REPO / "smal_fitter"))
+sys.path.insert(0, str(_REPO / "smal_fitter" / "neuralSMIL"))
+
+
+def _check_sample(
+    hdf5_path: str,
+    dataset_dir: str,
+    sample_idx: int,
+    tol: float = 1e-5,
+    fov_tol_deg: float = 1e-3,
+) -> bool:
+    from Unreal2Pytorch3D import load_SMIL_Unreal_multiview_sample
+    from sleap_data.sleap_multiview_dataset import SLEAPMultiViewDataset
+
+    ds = SLEAPMultiViewDataset(hdf5_path, augment=False)
+    if sample_idx >= len(ds):
+        print(f"  sample_idx {sample_idx} >= dataset size {len(ds)}; skip.")
+        return False
+
+    x_data, y_data = ds[sample_idx]
+    frame_idx = int(x_data["frame_idx"])
+    print(f"  sample {sample_idx} = source frame {frame_idx}")
+
+    x_mv, y_mv = load_SMIL_Unreal_multiview_sample(
+        data_path=dataset_dir,
+        frame_index=frame_idx,
+        camera_indices=None,
+        load_images=False,
+        canonical_frame=True,
+    )
+
+    n_views = int(x_data["num_active_views"])
+    if n_views != int(x_mv["num_views"]):
+        print(f"  FAIL: view-count mismatch (HDF5={n_views} vs loader={x_mv['num_views']})")
+        return False
+
+    max_R = 0.0
+    max_T = 0.0
+    max_fov = 0.0
+    for v in range(n_views):
+        R_loader = y_mv["cam_rot_per_view"][v].detach().cpu().numpy().astype(np.float32)
+        T_loader = y_mv["cam_trans_per_view"][v].detach().cpu().numpy().astype(np.float32)
+        R_ds = y_data["cam_rot_per_view"][v]
+        T_ds = y_data["cam_trans_per_view"][v]
+        max_R = max(max_R, float(np.max(np.abs(R_loader - R_ds))))
+        max_T = max(max_T, float(np.max(np.abs(T_loader - T_ds))))
+        max_fov = max(
+            max_fov,
+            abs(float(y_mv["fov_per_view"][v]) - float(y_data["cam_fov_per_view"][v, 0])),
+        )
+
+    max_kp = max_vis = 0.0
+    for v in range(n_views):
+        max_kp = max(
+            max_kp,
+            float(np.max(np.abs(y_mv["keypoints_2d_per_view"][v].astype(np.float32) - y_data["keypoints_2d"][v].astype(np.float32)))),
+        )
+        max_vis = max(
+            max_vis,
+            float(np.max(np.abs(y_mv["keypoint_visibility_per_view"][v].astype(np.float32) - y_data["keypoint_visibility"][v].astype(np.float32)))),
+        )
+
+    kp3d_loader = np.asarray(y_mv["keypoints_3d"], dtype=np.float32)
+    kp3d_ds = y_data["keypoints_3d"].astype(np.float32)
+    max_kp3d = float(np.max(np.abs(kp3d_loader - kp3d_ds)))
+
+    with h5py.File(hdf5_path, "r") as f:
+        c2w_R = f["auxiliary/canonical_to_world_R"][sample_idx].astype(np.float32)
+        c2w_t = f["auxiliary/canonical_to_world_t"][sample_idx].astype(np.float32)
+        trans_h5 = f["parameters/trans"][sample_idx].astype(np.float32)
+        rot_h5 = f["parameters/global_rot"][sample_idx].astype(np.float32)
+        betas_h5 = f["parameters/betas"][sample_idx].astype(np.float32)
+    recovered_world = (kp3d_ds - c2w_t) @ c2w_R.T
+    max_world = float(np.max(np.abs(recovered_world - np.asarray(y_mv["keypoints_3d_world"], dtype=np.float32))))
+
+    max_trans = float(np.max(np.abs(np.asarray(y_mv["root_loc"], dtype=np.float32) - trans_h5)))
+    max_rot = float(np.max(np.abs(np.asarray(y_mv["root_rot"], dtype=np.float32) - rot_h5)))
+    max_betas = float(np.max(np.abs(np.asarray(y_mv["shape_betas"], dtype=np.float32) - betas_h5)))
+
+    checks = {
+        "R_per_view":          (max_R, tol),
+        "T_per_view":          (max_T, tol),
+        "fov_per_view":        (max_fov, fov_tol_deg),
+        "keypoints_2d":        (max_kp, tol),
+        "keypoint_vis":        (max_vis, tol),
+        "keypoints_3d":        (max_kp3d, tol),
+        "canonical_inverse":   (max_world, tol),
+        "parameters/trans":    (max_trans, tol),
+        "parameters/rot":      (max_rot, tol),
+        "parameters/betas":    (max_betas, tol),
+    }
+    all_ok = True
+    for name, (val, this_tol) in checks.items():
+        ok = val < this_tol
+        all_ok = all_ok and ok
+        print(f"    {'PASS' if ok else 'FAIL'} {name:<22s}  max Δ = {val:.3e}  (tol {this_tol:.0e})")
+    return all_ok
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Round-trip check for replicAnt multi-view HDF5.")
+    p.add_argument("--hdf5", required=True, help="Path to the preprocessor's HDF5 output")
+    p.add_argument("--dataset_dir", required=True, help="Source flat-directory replicAnt dataset")
+    p.add_argument("--smal_file", required=True, help="SMAL/SMIL .pkl used at preprocess time")
+    p.add_argument("--shape_family", type=int, default=None)
+    p.add_argument("--sample_indices", type=int, nargs="+", default=[0],
+                   help="HDF5 sample indices to verify (default: just 0)")
+    p.add_argument("--tol", type=float, default=1e-5)
+    args = p.parse_args()
+
+    if not os.path.isfile(args.hdf5):
+        print(f"HDF5 not found: {args.hdf5}", file=sys.stderr)
+        sys.exit(2)
+    if not os.path.isdir(args.dataset_dir):
+        print(f"Dataset directory not found: {args.dataset_dir}", file=sys.stderr)
+        sys.exit(2)
+    if not os.path.isfile(args.smal_file):
+        print(f"SMAL pickle not found: {args.smal_file}", file=sys.stderr)
+        sys.exit(2)
+
+    # Apply override BEFORE any module touches config.dd.
+    from configs.config_utils import apply_smal_file_override  # noqa: E402
+    apply_smal_file_override(args.smal_file, shape_family=args.shape_family)
+
+    print(f"HDF5:         {args.hdf5}")
+    print(f"Dataset dir:  {args.dataset_dir}")
+    print(f"SMAL file:    {args.smal_file}")
+    print(f"Tol:          {args.tol}")
+    print()
+
+    all_ok = True
+    for idx in args.sample_indices:
+        print(f"-- sample_idx {idx} --")
+        all_ok &= _check_sample(args.hdf5, args.dataset_dir, idx, tol=args.tol)
+        print()
+
+    print("Overall:", "PASS" if all_ok else "FAIL")
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/smal_fitter/replicAnt_data/test_replicant_preprocessing.py
+++ b/smal_fitter/replicAnt_data/test_replicant_preprocessing.py
@@ -74,35 +74,51 @@ def _check_sample(
         canonical_frame=True,
     )
 
+    # The dataset drops view_mask=False slots, so its view count equals the
+    # number of valid loader slots. The loader still emits ALL camera slots
+    # (with `view_valid_per_view[i]=False` for the bad ones); pair the
+    # dataset's views with the loader's *valid* slots in canonical order.
     n_views = int(x_data["num_active_views"])
-    if n_views != int(x_mv["num_views"]):
-        print(f"  FAIL: view-count mismatch (HDF5={n_views} vs loader={x_mv['num_views']})")
+    view_valid = list(y_mv.get("view_valid_per_view", [True] * int(x_mv["num_views"])))
+    valid_loader_idx = [i for i, ok in enumerate(view_valid) if ok]
+    n_valid_loader = len(valid_loader_idx)
+    if n_views != n_valid_loader:
+        print(
+            f"  FAIL: view-count mismatch — HDF5 active={n_views}, "
+            f"loader valid={n_valid_loader}/{x_mv['num_views']} "
+            f"(view_valid={view_valid})"
+        )
         return False
+    if n_views < int(x_mv["num_views"]):
+        print(
+            f"  NOTE: {int(x_mv['num_views']) - n_views} view(s) masked out "
+            f"(view_valid={view_valid})"
+        )
 
     max_R = 0.0
     max_T = 0.0
     max_fov = 0.0
-    for v in range(n_views):
-        R_loader = y_mv["cam_rot_per_view"][v].detach().cpu().numpy().astype(np.float32)
-        T_loader = y_mv["cam_trans_per_view"][v].detach().cpu().numpy().astype(np.float32)
-        R_ds = y_data["cam_rot_per_view"][v]
-        T_ds = y_data["cam_trans_per_view"][v]
+    for v_ds, v_loader in enumerate(valid_loader_idx):
+        R_loader = y_mv["cam_rot_per_view"][v_loader].detach().cpu().numpy().astype(np.float32)
+        T_loader = y_mv["cam_trans_per_view"][v_loader].detach().cpu().numpy().astype(np.float32)
+        R_ds = y_data["cam_rot_per_view"][v_ds]
+        T_ds = y_data["cam_trans_per_view"][v_ds]
         max_R = max(max_R, float(np.max(np.abs(R_loader - R_ds))))
         max_T = max(max_T, float(np.max(np.abs(T_loader - T_ds))))
         max_fov = max(
             max_fov,
-            abs(float(y_mv["fov_per_view"][v]) - float(y_data["cam_fov_per_view"][v, 0])),
+            abs(float(y_mv["fov_per_view"][v_loader]) - float(y_data["cam_fov_per_view"][v_ds, 0])),
         )
 
     max_kp = max_vis = 0.0
-    for v in range(n_views):
+    for v_ds, v_loader in enumerate(valid_loader_idx):
         max_kp = max(
             max_kp,
-            float(np.max(np.abs(y_mv["keypoints_2d_per_view"][v].astype(np.float32) - y_data["keypoints_2d"][v].astype(np.float32)))),
+            float(np.max(np.abs(y_mv["keypoints_2d_per_view"][v_loader].astype(np.float32) - y_data["keypoints_2d"][v_ds].astype(np.float32)))),
         )
         max_vis = max(
             max_vis,
-            float(np.max(np.abs(y_mv["keypoint_visibility_per_view"][v].astype(np.float32) - y_data["keypoint_visibility"][v].astype(np.float32)))),
+            float(np.max(np.abs(y_mv["keypoint_visibility_per_view"][v_loader].astype(np.float32) - y_data["keypoint_visibility"][v_ds].astype(np.float32)))),
         )
 
     kp3d_loader = np.asarray(y_mv["keypoints_3d"], dtype=np.float32)

--- a/smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py
+++ b/smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py
@@ -156,7 +156,10 @@ def _view_geometry(x_payload, y_payload, view_idx):
     # uses (col, row) as (x, y), so col = norm_y*W, row = norm_x*H.
     px_col = kp2d[:, 1] * W
     px_row = kp2d[:, 0] * H
-    in_frame = (px_col >= 0) & (px_col < W) & (px_row >= 0) & (px_row < H)
+    # AND in-dataset so model-only joints (left at the [0, 0] sentinel by
+    # the loader) don't get drawn at the image corner.
+    in_dataset = y_payload["keypoint_in_dataset_per_view"][view_idx]
+    in_frame = in_dataset & (px_col >= 0) & (px_col < W) & (px_row >= 0) & (px_row < H)
 
     depth_path = Path(x_payload["depth_paths"][view_idx])
     if depth_path.exists():

--- a/smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py
+++ b/smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Diagnostic plots for the per-view depth-occlusion visibility refinement.
+
+Loads one frame of a multi-camera replicAnt dataset twice (id-mask only vs
+id-mask + depth-buffer self-occlusion) and writes per-view PNGs comparing
+which keypoints survive each stage. Use this to tune `depth_tolerance_cm` /
+`depth_max_cm` or to sanity-check that the surface depth lines up with the
+projected keypoints.
+
+For each camera the script produces a 1x4 panel:
+  1. Original RGB + ALL in-frame keypoints (cyan).
+  2. After ID-mask culling: green = kept, red X = culled.
+  3. After ID + depth culling: green = kept, red X = culled by ID,
+     orange X = culled by depth (passed ID but blocked by surface).
+  4. Same as 3 with the depth pass (R-channel grayscale) blended at 50%.
+
+Usage (from repo root):
+    python smal_fitter/replicAnt_data/visualize_multiview_depth_occlusion.py \\
+        <data_path> \\
+        --smal_file 3D_model_prep/SMILy_Mouse_static_joints_Falkner_conv_repose_hind_legs.pkl \\
+        --frame 100 \\
+        --out_dir multiview_depth_occlusion_viz
+
+Note: the SMAL/SMIL file must match the dataset's skeleton, otherwise the
+J_names mapping in the loader produces all-zero keypoints and every panel
+will be empty. The default `config.SMAL_FILE` is the ant model — pass
+`--smal_file` pointing at the mouse pkl for the multi-cam mice dataset.
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Standard sys.path pattern used by sibling scripts in this directory so
+# `import config` and `from neuralSMIL...` resolve when the script is run
+# directly (rather than as a module).
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import imageio.v2 as iio
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+import config
+from neuralSMIL.configs.config_utils import apply_smal_file_override
+from Unreal2Pytorch3D import load_SMIL_Unreal_multiview_sample
+
+
+def _plot_panel(
+    ax,
+    image,
+    depth_gray,
+    px_col,
+    px_row,
+    in_frame,
+    vis_id,
+    vis_dep,
+    joint_names,
+    panel,
+    show_legend,
+    label_depth_culled,
+):
+    """One of the four panels for a single view.
+
+    panel = 0 -> raw image + all in-frame keypoints (cyan)
+    panel = 1 -> raw image + id-mask kept/culled
+    panel = 2 -> raw image + id+depth kept/culled (id-culled red, depth-culled orange)
+    panel = 3 -> depth-overlay image + id+depth kept/culled
+    """
+    if panel == 3:
+        depth_rgb = np.stack([depth_gray] * 3, axis=-1)
+        blended = (image.astype(np.float32) / 255.0) * 0.5 + depth_rgb * 0.5
+        ax.imshow(np.clip(blended, 0.0, 1.0))
+    else:
+        ax.imshow(image)
+    ax.set_xticks([])
+    ax.set_yticks([])
+
+    if panel == 0:
+        ax.scatter(
+            px_col[in_frame],
+            px_row[in_frame],
+            s=60,
+            c="cyan",
+            edgecolors="black",
+            linewidths=0.7,
+        )
+        for j in np.where(in_frame)[0]:
+            ax.annotate(
+                joint_names[j],
+                (px_col[j], px_row[j]),
+                fontsize=6,
+                color="white",
+                xytext=(3, -3),
+                textcoords="offset points",
+            )
+        return
+
+    kept = (vis_dep == 1.0) if panel >= 2 else (vis_id == 1.0)
+    culled_id = (vis_id == 0.0) & in_frame
+    culled_depth_only = (vis_id == 1.0) & (vis_dep == 0.0)
+
+    ax.scatter(
+        px_col[kept],
+        px_row[kept],
+        s=80,
+        c="lime",
+        edgecolors="black",
+        linewidths=0.7,
+        label="kept",
+    )
+    ax.scatter(
+        px_col[culled_id],
+        px_row[culled_id],
+        s=70,
+        c="red",
+        marker="x",
+        linewidths=2.0,
+        label="culled (ID)",
+    )
+    if panel >= 2:
+        ax.scatter(
+            px_col[culled_depth_only],
+            px_row[culled_depth_only],
+            s=90,
+            c="orange",
+            marker="x",
+            linewidths=2.2,
+            label="culled (depth)",
+        )
+        if label_depth_culled:
+            for j in np.where(culled_depth_only)[0]:
+                ax.annotate(
+                    joint_names[j],
+                    (px_col[j], px_row[j]),
+                    fontsize=6,
+                    color="orange",
+                    xytext=(4, -4),
+                    textcoords="offset points",
+                )
+    if show_legend:
+        ax.legend(loc="upper right", fontsize=8, framealpha=0.85)
+
+
+def _view_geometry(x_payload, y_payload, view_idx):
+    """Pull image, depth grayscale, and pixel-space keypoints for one view."""
+    image = x_payload["image_data"][view_idx]
+    H, W = image.shape[:2]
+    kp2d = y_payload["keypoints_2d_per_view"][view_idx]
+
+    # The loader stores 2D keypoints in an axis-swapped normalised form
+    # (norm_x = 2DPos.y / H, norm_y = 2DPos.x / W). matplotlib's imshow
+    # uses (col, row) as (x, y), so col = norm_y*W, row = norm_x*H.
+    px_col = kp2d[:, 1] * W
+    px_row = kp2d[:, 0] * H
+    in_frame = (px_col >= 0) & (px_col < W) & (px_row >= 0) & (px_row < H)
+
+    depth_path = Path(x_payload["depth_paths"][view_idx])
+    if depth_path.exists():
+        depth_gray = iio.imread(str(depth_path))[..., 0].astype(np.float32) / 255.0
+    else:
+        depth_gray = np.zeros((H, W), dtype=np.float32)
+
+    return image, depth_gray, px_col, px_row, in_frame
+
+
+def visualize_frame(
+    data_path: str,
+    frame_index: int,
+    out_dir: Path,
+    depth_max_cm: float,
+    depth_tolerance_cm: float,
+    depth_neighborhood: int,
+    write_composite: bool,
+):
+    """Generate the per-view (and optional composite) PNGs for one frame."""
+    x_id, y_id = load_SMIL_Unreal_multiview_sample(
+        data_path,
+        frame_index,
+        depth_occlusion_check=False,
+        load_images=True,
+    )
+    x_d, y_d = load_SMIL_Unreal_multiview_sample(
+        data_path,
+        frame_index,
+        depth_occlusion_check=True,
+        depth_max_cm=depth_max_cm,
+        depth_tolerance_cm=depth_tolerance_cm,
+        depth_neighborhood=depth_neighborhood,
+        load_images=True,
+    )
+
+    V = x_d["num_views"]
+    joint_names = y_d["joint_names"]
+    J = len(joint_names)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    panel_titles = ("all kp", "after ID", "after ID+depth", "ID+depth, depth overlay")
+    totals = {"id": 0, "depth": 0, "depth_only_culled": 0}
+
+    # Per-view full-resolution PNGs.
+    print(f"frame {frame_index}: writing {V} per-view PNGs to {out_dir}/")
+    for v in range(V):
+        cam_id = x_d["camera_ids"][v]
+        image, depth_gray, px_col, px_row, in_frame = _view_geometry(x_d, y_d, v)
+        vis_id = y_id["keypoint_visibility_per_view"][v]
+        vis_dep = y_d["keypoint_visibility_per_view"][v]
+
+        fig, axes = plt.subplots(1, 4, figsize=(20, 5.2))
+        for col, base_title in enumerate(panel_titles):
+            ax = axes[col]
+            counts = {
+                0: f"({int(in_frame.sum())}/{J} in frame)",
+                1: f"({int(vis_id.sum())} kept)",
+                2: f"({int(vis_dep.sum())} kept)",
+                3: "",
+            }[col]
+            ax.set_title(f"{base_title} {counts}".strip(), fontsize=11)
+            _plot_panel(
+                ax,
+                image,
+                depth_gray,
+                px_col,
+                px_row,
+                in_frame,
+                vis_id,
+                vis_dep,
+                joint_names,
+                panel=col,
+                show_legend=(col > 0),
+                label_depth_culled=(col >= 2),
+            )
+        fig.suptitle(
+            f"frame {frame_index} cam{cam_id}  "
+            f"id={int(vis_id.sum())} -> id+depth={int(vis_dep.sum())}",
+            fontsize=12,
+        )
+        plt.tight_layout(rect=[0, 0, 1, 0.96])
+        pv_out = out_dir / f"frame_{frame_index:05d}_cam{cam_id:02d}.png"
+        plt.savefig(pv_out, dpi=110, bbox_inches="tight")
+        plt.close(fig)
+
+        totals["id"] += int(vis_id.sum())
+        totals["depth"] += int(vis_dep.sum())
+        totals["depth_only_culled"] += int(((vis_id == 1.0) & (vis_dep == 0.0)).sum())
+
+    # Optional composite (12 rows x 4 cols on one page).
+    if write_composite:
+        fig, axes = plt.subplots(V, 4, figsize=(16, 4 * V), squeeze=False)
+        for v in range(V):
+            cam_id = x_d["camera_ids"][v]
+            image, depth_gray, px_col, px_row, in_frame = _view_geometry(x_d, y_d, v)
+            vis_id = y_id["keypoint_visibility_per_view"][v]
+            vis_dep = y_d["keypoint_visibility_per_view"][v]
+            for col in range(4):
+                ax = axes[v, col]
+                ax.set_title(f"cam{cam_id}: {panel_titles[col]}", fontsize=8)
+                _plot_panel(
+                    ax,
+                    image,
+                    depth_gray,
+                    px_col,
+                    px_row,
+                    in_frame,
+                    vis_id,
+                    vis_dep,
+                    joint_names,
+                    panel=col,
+                    show_legend=(v == 0 and col > 0),
+                    label_depth_culled=False,  # too cluttered at this zoom
+                )
+        fig.suptitle(
+            f"Frame {frame_index} - id-mask vs id+depth "
+            f"(totals across {V} views: id={totals['id']}  "
+            f"id+depth={totals['depth']}  "
+            f"newly culled by depth={totals['depth_only_culled']})",
+            fontsize=11,
+        )
+        plt.tight_layout(rect=[0, 0, 1, 0.995])
+        comp_out = out_dir / f"frame_{frame_index:05d}_composite.png"
+        plt.savefig(comp_out, dpi=110, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  composite -> {comp_out.name}")
+
+    # Summary table.
+    print()
+    print(f"  {'cam':>4} {'id_vis':>7} {'depth_vis':>10} {'culled_by_depth':>16}")
+    for v in range(V):
+        vid = int(y_id["keypoint_visibility_per_view"][v].sum())
+        vd = int(y_d["keypoint_visibility_per_view"][v].sum())
+        print(f"  {x_d['camera_ids'][v]:>4} {vid:>7} {vd:>10} {vid - vd:>16}")
+    print(
+        f"  totals: id={totals['id']}  id+depth={totals['depth']}  "
+        f"culled_by_depth={totals['depth_only_culled']}"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Per-view depth-occlusion visibility diagnostic for the multi-cam "
+            "replicAnt loader (load_SMIL_Unreal_multiview_sample)."
+        ),
+    )
+    parser.add_argument(
+        "data_path",
+        type=str,
+        help="Path to the flat-directory multi-camera replicAnt dataset.",
+    )
+    parser.add_argument(
+        "--frame",
+        type=int,
+        default=100,
+        help="Frame index to visualize (default: 100).",
+    )
+    parser.add_argument(
+        "--smal_file",
+        type=str,
+        default=None,
+        help=(
+            "Path to the SMAL/SMIL .pkl file matching the dataset's skeleton. "
+            "If omitted, the global config.SMAL_FILE is used. For the multi-cam "
+            "mice dataset pass "
+            "3D_model_prep/SMILy_Mouse_static_joints_Falkner_conv_repose_hind_legs.pkl."
+        ),
+    )
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        default="multiview_depth_occlusion_viz",
+        help="Output directory for the PNGs (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--depth_max_cm",
+        type=float,
+        default=1000.0,
+        help="Encoded range of the depth pass in cm (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--depth_tolerance_cm",
+        type=float,
+        default=5.0,
+        help=(
+            "Margin added to surface depth before declaring a joint occluded. "
+            "Default 5.0 cm covers one depth-LSB (~3.92 cm @ 1000 cm range) "
+            "plus ~1 cm interior offset."
+        ),
+    )
+    parser.add_argument(
+        "--depth_neighborhood",
+        type=int,
+        default=1,
+        help="Half-window in pixels for surface min-depth sample (default: 1 = 3x3).",
+    )
+    parser.add_argument(
+        "--no_composite",
+        action="store_true",
+        help="Skip the 12-row composite PNG (faster, less disk).",
+    )
+    args = parser.parse_args()
+
+    if args.smal_file is not None:
+        apply_smal_file_override(args.smal_file)
+    print(
+        f"SMAL file: {config.SMAL_FILE}  "
+        f"({len(config.dd['J_names'])} joints)"
+    )
+
+    visualize_frame(
+        data_path=args.data_path,
+        frame_index=args.frame,
+        out_dir=Path(args.out_dir),
+        depth_max_cm=args.depth_max_cm,
+        depth_tolerance_cm=args.depth_tolerance_cm,
+        depth_neighborhood=args.depth_neighborhood,
+        write_composite=not args.no_composite,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/smal_fitter/sleap_data/sleap_dataset.py
+++ b/smal_fitter/sleap_data/sleap_dataset.py
@@ -354,70 +354,11 @@ class SLEAPDataset(torch.utils.data.Dataset):
         print("="*50)
 
 
-# Add SLEAP dataset support to UnifiedSMILDataset
-def _patch_unified_dataset(verbose: bool = False):
-    """
-    Patch the UnifiedSMILDataset to support SLEAP datasets.
-    This function should be called after importing this module.
-    """
-    if verbose:
-        print("Patching UnifiedSMILDataset to support SLEAP datasets...")
-    try:
-        import smal_fitter.neuralSMIL.smil_datasets as smil_datasets
-    except ImportError:
-        # Fallback for when running from different directory
-        import sys
-        sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'neuralSMIL'))
-        import smil_datasets
-
-    # Check if already patched
-    if hasattr(smil_datasets.UnifiedSMILDataset.from_path, '_sleap_patched'):
-        if verbose:
-            print("UnifiedSMILDataset already patched, skipping...")
-        return
-    
-    # Store original from_path method
-    original_from_path = smil_datasets.UnifiedSMILDataset.from_path
-    
-    @staticmethod
-    def from_path_with_sleap(data_path: str, **kwargs):
-        """
-        Create appropriate dataset instance based on file path.
-        
-        Args:
-            data_path: Path to dataset (directory for JSON format, .h5/.hdf5 file for optimized format)
-            **kwargs: Additional arguments passed to dataset constructor
-            
-        Returns:
-            Dataset instance (OptimizedSMILDataset, replicAntSMILDataset, or SLEAPDataset)
-        """
-        if data_path.endswith('.h5') or data_path.endswith('.hdf5'):
-            # Check if it's a SLEAP dataset by examining metadata
-            try:
-                with h5py.File(data_path, 'r') as f:
-                    if 'metadata' in f and 'dataset_type' in f['metadata'].attrs:
-                        dataset_type = f['metadata'].attrs['dataset_type']
-                        if dataset_type == 'sleap':
-                            return SLEAPDataset(data_path, **kwargs)
-            except Exception as e:
-                pass  # Fall back to original logic
-            
-            # Load optimized HDF5 dataset (original logic)
-            from optimized_dataset import OptimizedSMILDataset
-            return OptimizedSMILDataset(data_path, **kwargs)
-        else:
-            # Load original JSON dataset
-            return smil_datasets.replicAntSMILDataset(data_path, **kwargs)
-    
-    # Replace the method
-    from_path_with_sleap._sleap_patched = True
-    smil_datasets.UnifiedSMILDataset.from_path = from_path_with_sleap
-    if verbose:
-        print("UnifiedSMILDataset.from_path method patched successfully")
-
-
-# Note: Patching is done manually in train_smil_regressor.py
-# _patch_unified_dataset()
+# Note: dispatch from a user-facing path to SLEAPDataset / SLEAPMultiViewDataset /
+# OptimizedSMILDataset / replicAntSMILDataset lives in
+# `smal_fitter/neuralSMIL/smil_datasets.UnifiedSMILDataset.from_path` and is driven
+# by `/metadata` attrs in the HDF5 file. SLEAPDataset is selected when
+# `dataset_type='sleap'` AND `is_multiview` is not set/False.
 
 
 if __name__ == "__main__":

--- a/tests/validate_multiview_replicant_loader.py
+++ b/tests/validate_multiview_replicant_loader.py
@@ -223,13 +223,24 @@ def _reparameterize_view(R_model_p3d, t_model_p3d, R_v, T_v):
     return R_new, T_new
 
 
-def render_per_view(dataset_path, frame_index, output_dir):
+def render_per_view(dataset_path, frame_index, output_dir,
+                    canonical_frame=True, label="canonical"):
     """Mirror Render_SMAL_Model_from_Unreal_data for each view, write a grid PNG.
 
     Strategy: load multi-view data, derive the shared model-world transform,
     then for every view build a single-view-style (x_v, y_v) with the
     per-view reparameterisation applied and run the SMALFitter visualisation.
     Collect each view's collage from disk and stitch into one composite.
+
+    canonical_frame controls the loader call. When True, R_model_p3d derived
+    from raw pose_data quaternion is right-multiplied by R_0 to compose
+    body->world with world->canonical — the renderer formula
+    R_new = Rz @ R_model_p3d @ R_v, T_new = t_model @ R_v + T_v is then
+    pixel-identical under the canonical transformation (see derivation
+    in Unreal2Pytorch3D.py:load_SMIL_Unreal_multiview_sample).
+
+    Returns the list of (cam_id, collage_path) so callers (e.g. the
+    --compare_frames stitcher) can assemble combined plots.
     """
     _lazy_render_imports()
     torch = _TORCH
@@ -240,18 +251,22 @@ def render_per_view(dataset_path, frame_index, output_dir):
         frame_index=frame_index,
         camera_indices=None,
         load_images=True,
+        canonical_frame=canonical_frame,
         verbose=False,
     )
     pose_data = y_mv["pose_data"]
     root_key = config.ROOT_JOINT if config.ROOT_JOINT in pose_data else next(iter(pose_data))
 
     R_model_p3d = _build_model_world_rotation(pose_data, root_key)
+    if canonical_frame:
+        R_0_np, _ = y_mv["canonical_to_world"]
+        R_model_p3d = (R_model_p3d @ R_0_np).astype(np.float32)
     t_model_p3d = np.asarray(y_mv["root_loc"], dtype=np.float32)
 
-    print(f"\n--- Per-view rendering ---")
-    print(f"  root_key={root_key!r}  t_model={t_model_p3d}")
+    print(f"\n--- Per-view rendering ({label}) ---")
+    print(f"  root_key={root_key!r}  t_model={t_model_p3d}  canonical_cam={y_mv.get('canonical_cam_id')}")
 
-    render_root = (Path(output_dir) / f"frame_{frame_index:05d}_renders").resolve()
+    render_root = (Path(output_dir) / f"frame_{frame_index:05d}_renders_{label}").resolve()
     render_root.mkdir(parents=True, exist_ok=True)
 
     # Render_SMAL_Model_from_Unreal_data writes via ImageExporter("LOCAL_TEST", …)
@@ -308,7 +323,7 @@ def render_per_view(dataset_path, frame_index, output_dir):
 
     if not rendered_paths:
         print("  No renders produced.")
-        return
+        return []
 
     # Assemble the grid.
     n = len(rendered_paths)
@@ -322,12 +337,153 @@ def render_per_view(dataset_path, frame_index, output_dir):
         ax.axis("off")
     for j in range(len(rendered_paths), n_rows * n_cols):
         axes.flatten()[j].axis("off")
-    fig.suptitle(f"Frame {frame_index} — per-view SMAL renders via single-view path", fontsize=12)
+    fig.suptitle(
+        f"Frame {frame_index} — per-view SMAL renders ({label} frame)",
+        fontsize=12,
+    )
     fig.tight_layout()
-    grid_path = Path(output_dir) / f"frame_{frame_index:05d}_render_grid.png"
+    grid_path = Path(output_dir) / f"frame_{frame_index:05d}_render_grid_{label}.png"
     fig.savefig(grid_path, dpi=100, bbox_inches="tight")
+    plt.close(fig)
     print(f"\n  Grid saved → {grid_path}")
     print(f"  Individual collages under: {render_root}/LOCAL_TEST/")
+    return rendered_paths
+
+
+def compare_frames_test(dataset_path, frame_index, output_dir, per_camera, cam_ids):
+    """Run raw + canonical loader paths side-by-side and validate equivalence.
+
+    Three checks:
+      1. Numeric round-trip: |kp3d_world - (kp3d_can - t_0) @ R_0.T| ~ 0.
+      2. Reprojection per camera in both frames; both should hit ~0 px GT error.
+      3. Visual mesh render in both frames; pixel-identical implies the
+         camera/extrinsics/model-rotation composition is correct.
+    """
+    # 1. Numeric round-trip on the canonical-frame loader output.
+    _, y_can = load_SMIL_Unreal_multiview_sample(
+        data_path=str(dataset_path),
+        frame_index=frame_index,
+        camera_indices=None,
+        load_images=False,
+        canonical_frame=True,
+        verbose=False,
+    )
+    _, y_raw = load_SMIL_Unreal_multiview_sample(
+        data_path=str(dataset_path),
+        frame_index=frame_index,
+        camera_indices=None,
+        load_images=False,
+        canonical_frame=False,
+        verbose=False,
+    )
+    R_0, t_0 = y_can["canonical_to_world"]
+    kp_world_from_can = (y_can["keypoints_3d"] - t_0) @ R_0.T
+    rt_diff = np.max(np.abs(kp_world_from_can - y_can["keypoints_3d_world"]))
+    print("\n--- Canonical frame: round-trip check ---")
+    print(f"  canonical_cam_id: {y_can['canonical_cam_id']}")
+    print(f"  max |kp3d_world - (kp3d_can - t_0) @ R_0.T| = {rt_diff:.3e}")
+    if rt_diff > 1e-3:
+        print(f"  WARN: round-trip residual above 1e-3 — math suspect.")
+    # Also check raw == canonical-world-recovery on the camera extrinsics
+    R_v0_raw = y_raw["cam_rot_per_view"][0].numpy()
+    R_v0_can = y_can["cam_rot_per_view"][0].numpy()
+    print(f"  cam[0] R should be identity in canonical frame: "
+          f"max |R_v0_can - I| = {np.max(np.abs(R_v0_can - np.eye(3))):.3e}")
+    t_v0_can = y_can["cam_trans_per_view"][0].numpy()
+    print(f"  cam[0] t should be zero in canonical frame:     "
+          f"max |t_v0_can| = {np.max(np.abs(t_v0_can)):.3e}")
+
+    # 2. Reprojection check in both frames, using the loader's stored
+    #    cam_rot_per_view / cam_trans_per_view (row-vector,
+    #    PyTorch3D-mirrored) and the loader's keypoints_3d / _world.
+    def _project_via_loader(kp3d, R_v, t_v, fx, fy, cx, cy):
+        # All inputs are in PyTorch3D-mirrored frame (x-axis negated vs raw
+        # Unreal). The raw-frame projection convention u = fx*x/z + cx then
+        # flips to u = -fx*x/z + cx after the mirror; v keeps its sign.
+        x_cam = kp3d @ R_v + t_v
+        depth = x_cam[:, 2]
+        safe = np.where(np.abs(depth) < 1e-8, 1e-8, depth)
+        u = -fx * x_cam[:, 0] / safe + cx
+        v = -fy * x_cam[:, 1] / safe + cy
+        return u, v, depth
+
+    print("\n--- Loader-frame reprojection: raw vs canonical ---")
+    print(f"{'CAM':>5}  {'raw_mean':>10}  {'raw_max':>10}  "
+          f"{'can_mean':>10}  {'can_max':>10}")
+    for v, cid in enumerate(cam_ids):
+        gt = per_camera[cid]["kp2d_pixels"]
+        # Build a 2D-GT array indexed the same way as keypoints_3d (model J_names order).
+        gt_mapped = np.zeros((len(config.dd["J_names"]), 2))
+        for o, jn in enumerate(config.dd["J_names"]):
+            if jn in per_camera[cid]["names"]:
+                src_idx = per_camera[cid]["names"].index(jn)
+                gt_mapped[o] = gt[src_idx]
+        valid = ~np.all(gt_mapped == 0, axis=1)
+        fx, fy = y_raw["fx_per_view"][v], y_raw["fy_per_view"][v]
+        cx, cy = y_raw["cx_per_view"][v], y_raw["cy_per_view"][v]
+
+        u_r, v_r, d_r = _project_via_loader(
+            y_raw["keypoints_3d_world"],
+            y_raw["cam_rot_per_view"][v].numpy(),
+            y_raw["cam_trans_per_view"][v].numpy(),
+            fx, fy, cx, cy,
+        )
+        u_c, v_c, d_c = _project_via_loader(
+            y_can["keypoints_3d"],
+            y_can["cam_rot_per_view"][v].numpy(),
+            y_can["cam_trans_per_view"][v].numpy(),
+            fx, fy, cx, cy,
+        )
+
+        def _err(u, v, d):
+            mask = valid & (d > 0)
+            if not mask.any():
+                return float("nan"), float("nan")
+            e = np.sqrt((u[mask] - gt_mapped[mask, 0]) ** 2 +
+                        (v[mask] - gt_mapped[mask, 1]) ** 2)
+            return float(e.mean()), float(e.max())
+
+        raw_mean, raw_max = _err(u_r, v_r, d_r)
+        can_mean, can_max = _err(u_c, v_c, d_c)
+        print(f"{cid:>5}  {raw_mean:>10.3f}  {raw_max:>10.3f}  "
+              f"{can_mean:>10.3f}  {can_max:>10.3f}")
+
+    # 3. Visual mesh renders, raw and canonical, side by side.
+    raw_paths = render_per_view(
+        dataset_path, frame_index, output_dir,
+        canonical_frame=False, label="raw",
+    )
+    can_paths = render_per_view(
+        dataset_path, frame_index, output_dir,
+        canonical_frame=True, label="canonical",
+    )
+
+    if not raw_paths or not can_paths:
+        print("  Skipping side-by-side stitch — one render set empty.")
+        return
+
+    raw_by_cam = dict(raw_paths)
+    can_by_cam = dict(can_paths)
+    common = [c for c, _ in raw_paths if c in can_by_cam]
+    n_rows = len(common)
+    fig, axes = plt.subplots(n_rows, 2, figsize=(12, 4 * n_rows), squeeze=False)
+    for r, cid in enumerate(common):
+        axes[r, 0].imshow(imageio.imread(raw_by_cam[cid]))
+        axes[r, 0].set_title(f"CAM{cid}  RAW (world frame)")
+        axes[r, 0].axis("off")
+        axes[r, 1].imshow(imageio.imread(can_by_cam[cid]))
+        axes[r, 1].set_title(f"CAM{cid}  CANONICAL frame")
+        axes[r, 1].axis("off")
+    fig.suptitle(
+        f"Frame {frame_index} — raw vs canonical SMAL render "
+        "(should be pixel-identical)",
+        fontsize=12,
+    )
+    fig.tight_layout()
+    side_by_side = Path(output_dir) / f"frame_{frame_index:05d}_compare_frames.png"
+    fig.savefig(side_by_side, dpi=100, bbox_inches="tight")
+    plt.close(fig)
+    print(f"\n  Side-by-side grid saved → {side_by_side}")
 
 
 def report_loader_smoke(dataset_path, frame_index):
@@ -368,6 +524,10 @@ def main():
     parser.add_argument("--render", action="store_true",
                         help="Also render the posed SMAL mesh through each view's camera. "
                              "Requires --smal_file and GPU; mirrors the single-view render path.")
+    parser.add_argument("--compare_frames", action="store_true",
+                        help="Run the canonical-camera-frame validation: numeric "
+                             "round-trip, side-by-side reprojection check, and raw-vs-"
+                             "canonical mesh renders. Requires --smal_file and GPU.")
     args = parser.parse_args()
 
     dataset_path = Path(args.dataset_path)
@@ -477,8 +637,12 @@ def main():
 
         if args.render:
             render_per_view(dataset_path, args.frame_index, output_dir)
-    elif args.render:
-        print("\n⚠ --render requires --smal_file; skipping render stage.")
+        if args.compare_frames:
+            compare_frames_test(
+                dataset_path, args.frame_index, output_dir, per_camera, cam_ids,
+            )
+    elif args.render or args.compare_frames:
+        print("\n⚠ --render / --compare_frames requires --smal_file; skipping.")
 
 
 if __name__ == "__main__":

--- a/tests/validate_multiview_replicant_loader.py
+++ b/tests/validate_multiview_replicant_loader.py
@@ -1,0 +1,241 @@
+"""Visual validation for multi-view replicAnt camera geometry.
+
+For each view of one frame:
+  1. Read raw 3D world keypoints from that camera's JSON.
+  2. Read raw 2D keypoints from the same JSON.
+  3. Read raw camera extrinsics (R, t) via parse_projection_components,
+     and intrinsics (fx, fy, cx, cy) via parse_camera_intrinsics.
+  4. Project the 3D keypoints through (R, t, K) and overlay the result
+     on the camera image alongside the raw 2D ground truth.
+
+If raw 2D (green) and projected 3D (red) coincide pixel-for-pixel, the
+single-camera projection geometry is correct. This is the prerequisite
+for any per-view multi-view storage convention.
+
+This script intentionally **bypasses** `load_SMIL_Unreal_multiview_sample`
+for now — the current draft hard-codes `config.ROOT_JOINT` (= 'b_t') which
+doesn't exist in this dataset's joint set ('Mskel', 'Lumbar-Vertebrae', …).
+Fixing that is part of the Phase 1 cleanup; once it's done, we'll extend
+this script to also overlay the loader's output for end-to-end validation.
+
+Usage:
+    python tests/validate_multiview_replicant_loader.py \\
+        --dataset_path /mnt/c/replicAnt-dataset-multi-cam-mice \\
+        --frame_index 0 \\
+        --output_dir TEST_plots/multiview_loader
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import imageio.v2 as imageio
+import matplotlib
+
+matplotlib.use("Agg")  # No display in WSL.
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "smal_fitter"))
+
+from Unreal2Pytorch3D import (  # noqa: E402
+    parse_camera_intrinsics,
+    parse_projection_components,
+)
+
+
+def project_row_vector(X_world, R, t, fx, fy, cx, cy):
+    """Project N world-space points through (R, t, K).
+
+    Tries a small grid of (R | R.T) × (depth axis: x | y | z) × (sign: +/-)
+    conventions and picks the one minimising pixel error against ground-truth
+    midway through the script's loop. For exploration we return all variants;
+    the caller scores them externally.
+    """
+    X_world = np.asarray(X_world, dtype=np.float64)
+    R = np.asarray(R, dtype=np.float64)
+    t = np.asarray(t, dtype=np.float64).reshape(3)
+
+    variants = {}
+    for r_name, R_use in (("R", R), ("Rt", R.T)):
+        X_cam_base = X_world @ R_use + t
+        for axis_name, axis_idx in (("x", 0), ("y", 1), ("z", 2)):
+            for dsign in (1.0, -1.0):
+                depth = dsign * X_cam_base[:, axis_idx]
+                other = [i for i in (0, 1, 2) if i != axis_idx]
+                for usign in (1.0, -1.0):
+                    for vsign in (1.0, -1.0):
+                        u_world = usign * X_cam_base[:, other[0]]
+                        v_world = vsign * X_cam_base[:, other[1]]
+                        safe = np.where(np.abs(depth) < 1e-8, 1e-8, depth)
+                        u = fx * u_world / safe + cx
+                        v = fy * v_world / safe + cy
+                        key = (
+                            f"{r_name}_d={dsign:+.0f}{axis_name}"
+                            f"_u={usign:+.0f}{'xyz'[other[0]]}"
+                            f"_v={vsign:+.0f}{'xyz'[other[1]]}"
+                        )
+                        variants[key] = (u, v, depth)
+    return variants
+
+
+def list_camera_ids(dataset_path: Path, dataset_name: str, frame_index: int):
+    pattern = re.compile(rf"^{re.escape(dataset_name)}_{frame_index:05d}_CAM(\d+)\.json$")
+    ids = []
+    for entry in dataset_path.iterdir():
+        m = pattern.match(entry.name)
+        if m:
+            ids.append(int(m.group(1)))
+    return sorted(ids)
+
+
+def load_per_camera(dataset_path: Path, dataset_name: str, frame_index: int, cam_id: int, batch_data_file):
+    json_path = dataset_path / f"{dataset_name}_{frame_index:05d}_CAM{cam_id}.json"
+    with open(json_path) as f:
+        cam_data = json.load(f)
+    pose_data = cam_data["iterationData"]["subject Data"][0]["1"]["keypoints"]
+    names = list(pose_data.keys())
+
+    kp3d = np.zeros((len(names), 3), dtype=np.float64)
+    kp2d = np.zeros((len(names), 2), dtype=np.float64)
+    for i, name in enumerate(names):
+        p3 = pose_data[name].get("3DPos")
+        p2 = pose_data[name].get("2DPos")
+        if p3 is not None:
+            kp3d[i] = [p3["x"], p3["y"], p3["z"]]
+        if p2 is not None:
+            kp2d[i] = [p2["x"], p2["y"]]
+
+    R, t = parse_projection_components(cam_data)
+    cx, cy, fx, fy = parse_camera_intrinsics(
+        batch_data_file=batch_data_file, iteration_data_file=cam_data
+    )
+
+    image_path = json_path.with_suffix(".JPG")
+    img = imageio.imread(image_path) if image_path.exists() else None
+
+    return {
+        "names": names,
+        "kp3d_world": kp3d,
+        "kp2d_pixels": kp2d,
+        "R": R,
+        "t": t,
+        "fx": fx,
+        "fy": fy,
+        "cx": cx,
+        "cy": cy,
+        "image": img,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_path", required=True)
+    parser.add_argument("--frame_index", type=int, default=0)
+    parser.add_argument("--output_dir", default="TEST_plots/multiview_loader")
+    parser.add_argument("--camera_indices", type=int, nargs="*", default=None)
+    args = parser.parse_args()
+
+    dataset_path = Path(args.dataset_path)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    batch_files = list(dataset_path.glob("_BatchData_*.json"))
+    if not batch_files:
+        sys.exit(f"No _BatchData_*.json in {dataset_path}")
+    with open(batch_files[0]) as f:
+        batch_data_file = json.load(f)
+    dataset_name = batch_files[0].stem.replace("_BatchData_", "")
+
+    cam_ids = args.camera_indices or list_camera_ids(dataset_path, dataset_name, args.frame_index)
+    if not cam_ids:
+        sys.exit(f"No camera JSONs found for frame {args.frame_index}")
+    print(f"Frame {args.frame_index}: {len(cam_ids)} cameras: {cam_ids}")
+
+    per_camera = {cid: load_per_camera(dataset_path, dataset_name, args.frame_index, cid, batch_data_file) for cid in cam_ids}
+
+    n_views = len(cam_ids)
+    n_cols = min(4, n_views)
+    n_rows = (n_views + n_cols - 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5 * n_cols, 5 * n_rows), squeeze=False)
+    axes_flat = axes.flatten()
+
+    summary = []
+    for view_idx, cid in enumerate(cam_ids):
+        ax = axes_flat[view_idx]
+        pc = per_camera[cid]
+        img = pc["image"]
+        if img is None:
+            ax.set_title(f"CAM{cid} — no image")
+            ax.axis("off")
+            continue
+        H, W = img.shape[:2]
+        ax.imshow(img)
+
+        # GT 2D from this camera's JSON, plotted as raw pixels (2DPos.x, 2DPos.y).
+        gt = pc["kp2d_pixels"]
+        valid_gt = ~np.all(gt == 0, axis=1)
+        ax.scatter(gt[valid_gt, 0], gt[valid_gt, 1],
+                   facecolors="none", edgecolors="lime", s=80, linewidths=1.5,
+                   label="GT 2D (JSON 2DPos)")
+
+        # Try every (R | R.T) × signed-depth-axis convention; pick the lowest-error one.
+        variants = project_row_vector(
+            pc["kp3d_world"], pc["R"], pc["t"], pc["fx"], pc["fy"], pc["cx"], pc["cy"]
+        )
+        best_conv, best_err, best_uv = None, float("inf"), None
+        for name, (u, v, depth) in variants.items():
+            in_front = depth > 0
+            common = valid_gt & in_front
+            if common.sum() < 4:
+                continue
+            err = np.sqrt((u[common] - gt[common, 0])**2 + (v[common] - gt[common, 1])**2).mean()
+            if err < best_err:
+                best_err = err
+                best_conv = name
+                best_uv = (u, v, depth)
+        if best_uv is None:
+            best_conv = "no-valid-conv"
+            best_uv = (np.zeros(len(gt)), np.zeros(len(gt)), np.ones(len(gt)))
+        u, v, depth = best_uv
+        in_front = depth > 0
+        ax.scatter(u[in_front], v[in_front],
+                   marker="+", color="red", s=80, linewidths=1.5,
+                   label=f"Projected 3D ({best_conv})")
+
+        common = valid_gt & in_front
+        if common.any():
+            err = np.sqrt((u[common] - gt[common, 0])**2 + (v[common] - gt[common, 1])**2)
+            mean_err = float(err.mean())
+            max_err = float(err.max())
+        else:
+            mean_err = max_err = float("nan")
+        summary.append((cid, best_conv, mean_err, max_err, int(in_front.sum()), int(valid_gt.sum())))
+
+        ax.set_title(f"CAM{cid}  {best_conv}  mean={mean_err:.1f}px  max={max_err:.1f}px")
+        ax.set_xlim(0, W)
+        ax.set_ylim(H, 0)
+        ax.set_aspect("equal")
+        ax.legend(fontsize=7, loc="upper right")
+
+    for j in range(n_views, len(axes_flat)):
+        axes_flat[j].axis("off")
+
+    fig.suptitle(f"Frame {args.frame_index} — projection (red +) vs raw GT 2D (green circle)", fontsize=12)
+    fig.tight_layout()
+    out_path = output_dir / f"frame_{args.frame_index:05d}_reprojection_check.png"
+    fig.savefig(out_path, dpi=120, bbox_inches="tight")
+    print(f"Saved → {out_path}")
+
+    print(f"\n{'CAM':>5}  {'conv':>30}  {'mean_px':>8}  {'max_px':>8}  {'in_front':>8}  {'gt_pts':>6}")
+    for cid, conv, mean_err, max_err, in_front, gt_pts in summary:
+        print(f"{cid:>5}  {conv:>30}  {mean_err:>8.2f}  {max_err:>8.2f}  {in_front:>8}  {gt_pts:>6}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/validate_multiview_replicant_loader.py
+++ b/tests/validate_multiview_replicant_loader.py
@@ -491,9 +491,13 @@ def compare_frames_test(dataset_path, frame_index, output_dir, per_camera, cam_i
 
 def _compute_posed_smal_joints(x_mv, y_mv, device):
     """Run SMAL forward with the loader's pose params and return (N_joints, 3)
-    in canonical world frame. Mirrors the path in
-    Render_SMAL_Model_from_Unreal_data with apply_UE_transform=True but
-    skips the rendering step.
+    in canonical world frame.
+
+    NOTE: this consumes the multi-view loader's scale-unified output
+    (translation_factor=0.1 applied at load), so the model placement is the
+    plain `(joints - root) + trans` branch — NO `*10` mesh expansion. That
+    differs from Render_SMAL_Model_from_Unreal_data with apply_UE_transform=True,
+    which is still used for the legacy single-view path.
     """
     torch = _TORCH
     SMALFitter = _SMALFitter
@@ -562,9 +566,11 @@ def _compute_posed_smal_joints(x_mv, y_mv, device):
             betas_trans=batch_params.get("betas_trans", None),
             propagate_scaling=getattr(model, "propagate_scaling", None),
         )
-        # Match generate_visualization's apply_UE_transform=True path.
+        # Scale-unified multi-view convention: data was already scaled by
+        # translation_factor=0.1 at load time so mesh-native and trans-frame
+        # units match. Recenter on the root and add trans directly — no *10.
         root_joint = joints[:, 0:1, :]
-        joints = (joints - root_joint) * 10 + batch_params["trans"].unsqueeze(1)
+        joints = (joints - root_joint) + batch_params["trans"].unsqueeze(1)
 
     return joints.squeeze(0).cpu().numpy().astype(np.float32)
 

--- a/tests/validate_multiview_replicant_loader.py
+++ b/tests/validate_multiview_replicant_loader.py
@@ -1,28 +1,31 @@
-"""Visual validation for multi-view replicAnt camera geometry.
+"""Visual validation for multi-view replicAnt camera geometry + model fit.
 
-For each view of one frame:
-  1. Read raw 3D world keypoints from that camera's JSON.
-  2. Read raw 2D keypoints from the same JSON.
-  3. Read raw camera extrinsics (R, t) via parse_projection_components,
-     and intrinsics (fx, fy, cx, cy) via parse_camera_intrinsics.
-  4. Project the 3D keypoints through (R, t, K) and overlay the result
-     on the camera image alongside the raw 2D ground truth.
+Two checks per frame:
 
-If raw 2D (green) and projected 3D (red) coincide pixel-for-pixel, the
-single-camera projection geometry is correct. This is the prerequisite
-for any per-view multi-view storage convention.
+1. **Camera geometry (always run)**: for each view, read raw 3D world
+   keypoints, raw 2D keypoints, and raw extrinsics+intrinsics from that
+   camera's JSON. Project the 3D through (R, t, K) and overlay against
+   the raw 2D. Green (GT 2D) and red (projected 3D) should coincide
+   pixel-for-pixel.
 
-This script intentionally **bypasses** `load_SMIL_Unreal_multiview_sample`
-for now — the current draft hard-codes `config.ROOT_JOINT` (= 'b_t') which
-doesn't exist in this dataset's joint set ('Mskel', 'Lumbar-Vertebrae', …).
-Fixing that is part of the Phase 1 cleanup; once it's done, we'll extend
-this script to also overlay the loader's output for end-to-end validation.
+2. **Model-fit compatibility (only when --smal_file is passed)**: load
+   the specified SMAL pickle via apply_smal_file_override and report
+   how the model's ``J_names`` compare to the dataset's joint names —
+   overlap count, dataset-only joints, model-only joints. Also runs
+   ``load_SMIL_Unreal_multiview_sample`` end-to-end and reports root /
+   shape / joint angle extraction.
 
 Usage:
+    # geometry only
+    python tests/validate_multiview_replicant_loader.py \\
+        --dataset_path /mnt/c/replicAnt-dataset-multi-cam-mice \\
+        --frame_index 0
+
+    # geometry + model-fit compatibility
     python tests/validate_multiview_replicant_loader.py \\
         --dataset_path /mnt/c/replicAnt-dataset-multi-cam-mice \\
         --frame_index 0 \\
-        --output_dir TEST_plots/multiview_loader
+        --smal_file 3D_model_prep/SMILy_Mouse_static_joints_Falkner_conv_repose_hind_legs_fix_eyes.pkl
 """
 
 import argparse
@@ -42,11 +45,50 @@ import numpy as np  # noqa: E402
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, PROJECT_ROOT)
 sys.path.insert(0, os.path.join(PROJECT_ROOT, "smal_fitter"))
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "smal_fitter", "neuralSMIL"))
 
+
+# Parse --smal_file first so we can apply the override *before* importing
+# Unreal2Pytorch3D (which pulls in `config.dd`).
+def _early_parse():
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--smal_file", default=None)
+    p.add_argument("--shape_family", type=int, default=None)
+    known, _ = p.parse_known_args()
+    return known
+
+
+_early = _early_parse()
+if _early.smal_file:
+    from configs.config_utils import apply_smal_file_override  # noqa: E402
+    apply_smal_file_override(_early.smal_file, shape_family=_early.shape_family)
+
+import config  # noqa: E402
 from Unreal2Pytorch3D import (  # noqa: E402
+    load_SMIL_Unreal_multiview_sample,
     parse_camera_intrinsics,
     parse_projection_components,
 )
+
+# Rendering deps (heavy — only used when --render is passed).
+_TORCH = None
+_SMALFitter = None
+_ImageExporter = None
+_R_scipy = None
+
+
+def _lazy_render_imports():
+    global _TORCH, _SMALFitter, _ImageExporter, _R_scipy
+    if _TORCH is not None:
+        return
+    import torch as _t  # noqa: F401
+    from smal_fitter import SMALFitter as _SF  # noqa: F401
+    from optimize_to_joints import ImageExporter as _IE  # noqa: F401
+    from scipy.spatial.transform import Rotation as _R  # noqa: F401
+    _TORCH = _t
+    _SMALFitter = _SF
+    _ImageExporter = _IE
+    _R_scipy = _R
 
 
 def project_row_vector(X_world, R, t, fx, fy, cx, cy):
@@ -133,12 +175,199 @@ def load_per_camera(dataset_path: Path, dataset_name: str, frame_index: int, cam
     }
 
 
+def report_joint_name_overlap(dataset_names, model_names):
+    ds = list(dict.fromkeys(dataset_names))  # preserve order, drop duplicates
+    md = list(dict.fromkeys(model_names))
+    ds_set, md_set = set(ds), set(md)
+    overlap = [n for n in ds if n in md_set]
+    ds_only = [n for n in ds if n not in md_set]
+    md_only = [n for n in md if n not in ds_set]
+    print("\n--- Joint name overlap (dataset vs. loaded SMAL model J_names) ---")
+    print(f"  Dataset joints: {len(ds)}")
+    print(f"  Model J_names:  {len(md)}")
+    print(f"  Overlap:        {len(overlap)}/{max(len(ds), len(md))}  "
+          f"(perfect-match needs both numbers to equal overlap)")
+    if ds_only:
+        print(f"  Dataset-only ({len(ds_only)}): {ds_only}")
+    if md_only:
+        print(f"  Model-only   ({len(md_only)}): {md_only}")
+    if not ds_only and not md_only:
+        print("  ✓ Joint sets are identical.")
+
+
+MIRROR_MAT = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float32)
+
+
+def _build_model_world_rotation(pose_data, root_key):
+    """Compute R_model_p3d from the root joint's globalRotation, matching the
+    single-view path at Unreal2Pytorch3D.py:998-1008.
+    """
+    grot = pose_data[root_key]["globalRotation"]
+    rot_model_ue = _R_scipy.from_quat(
+        [-grot["x"], -grot["y"], -grot["z"], grot["w"]], scalar_first=False
+    )
+    R_model_ue = rot_model_ue.as_matrix().astype(np.float32)
+    return MIRROR_MAT @ R_model_ue @ MIRROR_MAT.T
+
+
+def _reparameterize_view(R_model_p3d, t_model_p3d, R_v, T_v):
+    """Per-view single-view-style reparameterisation:
+        R_cam_new = Rz(180°) @ R_model @ R_v
+        T_cam_new = t_model @ R_v + T_v
+    Mirrors Unreal2Pytorch3D.py:1015-1026 (note: Rz applied to R only, not to T —
+    matches the single-view convention).
+    """
+    Rz = np.array([[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+    R_new = (Rz @ R_model_p3d @ R_v).astype(np.float32)
+    T_new = (t_model_p3d @ R_v + T_v).astype(np.float32)
+    return R_new, T_new
+
+
+def render_per_view(dataset_path, frame_index, output_dir):
+    """Mirror Render_SMAL_Model_from_Unreal_data for each view, write a grid PNG.
+
+    Strategy: load multi-view data, derive the shared model-world transform,
+    then for every view build a single-view-style (x_v, y_v) with the
+    per-view reparameterisation applied and run the SMALFitter visualisation.
+    Collect each view's collage from disk and stitch into one composite.
+    """
+    _lazy_render_imports()
+    torch = _TORCH
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    x_mv, y_mv = load_SMIL_Unreal_multiview_sample(
+        data_path=str(dataset_path),
+        frame_index=frame_index,
+        camera_indices=None,
+        load_images=True,
+        verbose=False,
+    )
+    pose_data = y_mv["pose_data"]
+    root_key = config.ROOT_JOINT if config.ROOT_JOINT in pose_data else next(iter(pose_data))
+
+    R_model_p3d = _build_model_world_rotation(pose_data, root_key)
+    t_model_p3d = np.asarray(y_mv["root_loc"], dtype=np.float32)
+
+    print(f"\n--- Per-view rendering ---")
+    print(f"  root_key={root_key!r}  t_model={t_model_p3d}")
+
+    render_root = (Path(output_dir) / f"frame_{frame_index:05d}_renders").resolve()
+    render_root.mkdir(parents=True, exist_ok=True)
+
+    # Render_SMAL_Model_from_Unreal_data writes via ImageExporter("LOCAL_TEST", …)
+    # to the *current* working directory. To redirect the output without
+    # touching the Unreal2Pytorch3D module, we cd into render_root for the
+    # duration of the renders. Critical: absolutise any relative paths in
+    # config that the renderer will try to open (e.g. SMAL_FILE) before chdir.
+    if not os.path.isabs(config.SMAL_FILE):
+        config.SMAL_FILE = str((Path(prev_cwd_root := os.getcwd()) / config.SMAL_FILE).resolve())
+    prev_cwd = os.getcwd()
+    os.chdir(render_root)
+    rendered_paths = []
+    try:
+        for v, cam_id in enumerate(x_mv["camera_ids"]):
+            R_v = np.asarray(y_mv["cam_rot_per_view"][v], dtype=np.float32)
+            T_v = np.asarray(y_mv["cam_trans_per_view"][v], dtype=np.float32)
+            R_new, T_new = _reparameterize_view(R_model_p3d, t_model_p3d, R_v, T_v)
+
+            x_v = {
+                "input_image": x_mv["image_paths"][v],
+                "input_image_data": x_mv["image_data"][v],
+                "input_image_mask": x_mv["input_image_mask"][v],
+            }
+            y_v = dict(y_mv)  # shallow copy of shared fields
+            y_v["cam_rot"] = torch.tensor(R_new, dtype=torch.float32)
+            y_v["cam_trans"] = torch.tensor(T_new, dtype=torch.float32)
+            y_v["root_loc"] = np.zeros(3, dtype=np.float32)
+            y_v["root_rot"] = np.zeros(3, dtype=np.float32)
+            y_v["cam_fov"] = [float(y_mv["fov_per_view"][v])]
+            y_v["fx"] = float(y_mv["fx_per_view"][v])
+            y_v["fy"] = float(y_mv["fy_per_view"][v])
+            y_v["cx"] = float(y_mv["cx_per_view"][v])
+            y_v["cy"] = float(y_mv["cy_per_view"][v])
+            y_v["keypoints_2d"] = y_mv["keypoints_2d_per_view"][v]
+            y_v["keypoint_visibility"] = y_mv["keypoint_visibility_per_view"][v]
+
+            print(f"  CAM{cam_id}: rendering ...", flush=True)
+            from Unreal2Pytorch3D import Render_SMAL_Model_from_Unreal_data
+            try:
+                Render_SMAL_Model_from_Unreal_data(x_v, y_v, device, verbose=False)
+            except Exception as e:
+                print(f"  CAM{cam_id}: render FAILED — {e}")
+                continue
+
+            # ImageExporter writes LOCAL_TEST/<basename>/st0_ep0.png in current cwd.
+            basename = os.path.splitext(os.path.basename(x_mv["image_paths"][v]))[0]
+            collage_path = Path("LOCAL_TEST") / basename / "st0_ep0.png"
+            if collage_path.exists():
+                rendered_paths.append((cam_id, collage_path.resolve()))
+            else:
+                print(f"  CAM{cam_id}: expected collage at {collage_path} not found")
+    finally:
+        os.chdir(prev_cwd)
+
+    if not rendered_paths:
+        print("  No renders produced.")
+        return
+
+    # Assemble the grid.
+    n = len(rendered_paths)
+    n_cols = min(4, n)
+    n_rows = (n + n_cols - 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(6 * n_cols, 4 * n_rows), squeeze=False)
+    for ax, (cam_id, path) in zip(axes.flatten(), rendered_paths):
+        img = imageio.imread(path)
+        ax.imshow(img)
+        ax.set_title(f"CAM{cam_id}")
+        ax.axis("off")
+    for j in range(len(rendered_paths), n_rows * n_cols):
+        axes.flatten()[j].axis("off")
+    fig.suptitle(f"Frame {frame_index} — per-view SMAL renders via single-view path", fontsize=12)
+    fig.tight_layout()
+    grid_path = Path(output_dir) / f"frame_{frame_index:05d}_render_grid.png"
+    fig.savefig(grid_path, dpi=100, bbox_inches="tight")
+    print(f"\n  Grid saved → {grid_path}")
+    print(f"  Individual collages under: {render_root}/LOCAL_TEST/")
+
+
+def report_loader_smoke(dataset_path, frame_index):
+    print("\n--- Loader smoke test: load_SMIL_Unreal_multiview_sample ---")
+    x, y = load_SMIL_Unreal_multiview_sample(
+        data_path=str(dataset_path),
+        frame_index=frame_index,
+        camera_indices=None,
+        load_images=False,
+        verbose=False,
+    )
+    print(f"  num_views:        {x['num_views']}")
+    print(f"  camera_ids:       {x['camera_ids']}")
+    print(f"  shape_betas[:5]:  {y['shape_betas'][:5]}")
+    print(f"  joint_angles:     shape={y['joint_angles'].shape}")
+    print(f"  root_loc:         {y['root_loc']}")
+    print(f"  root_rot:         {y['root_rot']}")
+    if y.get("scale_weights") is not None:
+        print(f"  scale_weights:    present, shape={np.asarray(y['scale_weights']).shape}")
+    else:
+        print("  scale_weights:    None")
+    # Verify joint_angles aren't all zero (would indicate mapping failure).
+    nonzero = int(np.any(np.abs(y["joint_angles"]) > 1e-6, axis=1).sum())
+    print(f"  joint_angles non-zero rows: {nonzero}/{y['joint_angles'].shape[0]}")
+    if nonzero == 0:
+        print("  ⚠ All joint_angles are zero — likely a model/dataset joint-name mismatch.")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--dataset_path", required=True)
     parser.add_argument("--frame_index", type=int, default=0)
     parser.add_argument("--output_dir", default="TEST_plots/multiview_loader")
     parser.add_argument("--camera_indices", type=int, nargs="*", default=None)
+    parser.add_argument("--smal_file", default=None,
+                        help="If given, run model-fit compatibility checks against this SMAL pickle.")
+    parser.add_argument("--shape_family", type=int, default=None)
+    parser.add_argument("--render", action="store_true",
+                        help="Also render the posed SMAL mesh through each view's camera. "
+                             "Requires --smal_file and GPU; mirrors the single-view render path.")
     args = parser.parse_args()
 
     dataset_path = Path(args.dataset_path)
@@ -235,6 +464,21 @@ def main():
     print(f"\n{'CAM':>5}  {'conv':>30}  {'mean_px':>8}  {'max_px':>8}  {'in_front':>8}  {'gt_pts':>6}")
     for cid, conv, mean_err, max_err, in_front, gt_pts in summary:
         print(f"{cid:>5}  {conv:>30}  {mean_err:>8.2f}  {max_err:>8.2f}  {in_front:>8}  {gt_pts:>6}")
+
+    # Optional model-fit compatibility report (requires --smal_file).
+    if args.smal_file:
+        first_cam = cam_ids[0]
+        dataset_joint_names = per_camera[first_cam]["names"]
+        model_joint_names = list(config.dd["J_names"])
+        print(f"\nActive SMAL model: {config.SMAL_FILE}")
+        print(f"Active ROOT_JOINT: {config.ROOT_JOINT!r}")
+        report_joint_name_overlap(dataset_joint_names, model_joint_names)
+        report_loader_smoke(dataset_path, args.frame_index)
+
+        if args.render:
+            render_per_view(dataset_path, args.frame_index, output_dir)
+    elif args.render:
+        print("\n⚠ --render requires --smal_file; skipping render stage.")
 
 
 if __name__ == "__main__":

--- a/tests/validate_multiview_replicant_loader.py
+++ b/tests/validate_multiview_replicant_loader.py
@@ -68,6 +68,9 @@ from Unreal2Pytorch3D import (  # noqa: E402
     load_SMIL_Unreal_multiview_sample,
     parse_camera_intrinsics,
     parse_projection_components,
+    return_placeholder_data,
+    sample_pca_transforms_from_dirs,
+    set_axes_equal,
 )
 
 # Rendering deps (heavy — only used when --render is passed).
@@ -486,6 +489,227 @@ def compare_frames_test(dataset_path, frame_index, output_dir, per_camera, cam_i
     print(f"\n  Side-by-side grid saved → {side_by_side}")
 
 
+def _compute_posed_smal_joints(x_mv, y_mv, device):
+    """Run SMAL forward with the loader's pose params and return (N_joints, 3)
+    in canonical world frame. Mirrors the path in
+    Render_SMAL_Model_from_Unreal_data with apply_UE_transform=True but
+    skips the rendering step.
+    """
+    torch = _TORCH
+    SMALFitter = _SMALFitter
+
+    data_json, _ = return_placeholder_data(
+        input_image=x_mv["image_paths"][0],
+        num_joints=len(y_mv["joint_angles"]),
+        keypoints_2d=y_mv["keypoints_2d_per_view"][0],
+        keypoint_visibility=y_mv["keypoint_visibility_per_view"][0],
+        silhouette=x_mv["input_image_mask"][0],
+    )
+
+    model = SMALFitter(device, data_json, config.WINDOW_SIZE, config.SHAPE_FAMILY, False)
+    model.betas = torch.nn.Parameter(torch.Tensor(y_mv["shape_betas"]).to(device))
+
+    if ("scaledirs" in config.dd and "transdirs" in config.dd
+            and y_mv.get("scale_weights") is not None
+            and y_mv.get("trans_weights") is not None):
+        trans_out, scale_out = sample_pca_transforms_from_dirs(
+            config.dd, y_mv["scale_weights"], y_mv["trans_weights"]
+        )
+        model.log_beta_scales = torch.nn.Parameter(
+            torch.from_numpy(np.log(scale_out))[None, ...].float().to(device)
+        )
+        model.betas_trans = torch.nn.Parameter(
+            torch.from_numpy(trans_out * y_mv["translation_factor"])[None, ...].float().to(device)
+        )
+        model.propagate_scaling = y_mv["propagate_scaling"]
+
+    model.joint_rotations = torch.nn.Parameter(
+        torch.Tensor(y_mv["joint_angles"][1:])
+        .reshape((1, y_mv["joint_angles"][1:].shape[0], 3))
+        .to(device)
+    )
+    model.global_rotation = torch.nn.Parameter(
+        torch.from_numpy(y_mv["root_rot"]).float().to(device).unsqueeze(0)
+    )
+    model.trans = torch.nn.Parameter(
+        torch.Tensor(np.array([y_mv["root_loc"]])).to(device)
+    )
+
+    batch_params = {
+        "global_rotation": model.global_rotation * model.global_mask,
+        "joint_rotations": model.joint_rotations * model.rotation_mask,
+        "betas": model.betas.expand(1, model.n_betas),
+        "trans": model.trans,
+    }
+    if config.ignore_hardcoded_body:
+        batch_params["log_betascale"] = model.log_beta_scales.expand(
+            1, model.joint_rotations.shape[1] + 1, 3
+        ).to(device)
+        if hasattr(model, "betas_trans"):
+            batch_params["betas_trans"] = model.betas_trans.expand(
+                1, model.joint_rotations.shape[1] + 1, 3
+            ).to(device)
+    else:
+        batch_params["log_betascale"] = model.log_beta_scales.expand(1, 6)
+
+    with torch.no_grad():
+        _, joints, _, _ = model.smal_model(
+            batch_params["betas"],
+            torch.cat([
+                batch_params["global_rotation"].unsqueeze(1),
+                batch_params["joint_rotations"]], dim=1),
+            betas_logscale=batch_params.get("log_betascale", None),
+            betas_trans=batch_params.get("betas_trans", None),
+            propagate_scaling=getattr(model, "propagate_scaling", None),
+        )
+        # Match generate_visualization's apply_UE_transform=True path.
+        root_joint = joints[:, 0:1, :]
+        joints = (joints - root_joint) * 10 + batch_params["trans"].unsqueeze(1)
+
+    return joints.squeeze(0).cpu().numpy().astype(np.float32)
+
+
+def _project_canonical(kp3d, R_v, t_v, fx, fy, cx, cy):
+    """Project canonical-frame 3D points through a canonical-frame camera
+    in the PyTorch3D-mirrored convention (see _project_via_loader)."""
+    x_cam = kp3d @ R_v + t_v
+    depth = x_cam[:, 2]
+    safe = np.where(np.abs(depth) < 1e-8, 1e-8, depth)
+    u = -fx * x_cam[:, 0] / safe + cx
+    v = -fy * x_cam[:, 1] / safe + cy
+    return u, v, depth
+
+
+def visualize_named_keypoints(dataset_path, frame_index, output_dir, cam_ids):
+    """High-res per-camera 2D overlay + 3D side-by-side plot with joint
+    names labelled. Compares loader GT (green) against SMAL forward
+    posed joints (red) so we can spot per-joint indexing issues.
+    """
+    _lazy_render_imports()
+    torch = _TORCH
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    x_mv, y_mv = load_SMIL_Unreal_multiview_sample(
+        data_path=str(dataset_path),
+        frame_index=frame_index,
+        camera_indices=cam_ids,
+        load_images=True,
+        canonical_frame=True,
+        verbose=False,
+    )
+
+    j_names = list(y_mv["joint_names"])
+    n_joints = len(j_names)
+    gt_3d_can = np.asarray(y_mv["keypoints_3d"], dtype=np.float32)  # (N, 3)
+    posed_3d_can = _compute_posed_smal_joints(x_mv, y_mv, device)  # (N, 3)
+    if posed_3d_can.shape[0] != n_joints:
+        print(f"  WARN: SMAL produced {posed_3d_can.shape[0]} joints, expected {n_joints}")
+        n_joints = min(posed_3d_can.shape[0], n_joints)
+
+    # --- Per-camera 2D overlay grid (high-res, joint names labelled) ---
+    print(f"\n--- Named 2D overlay (frame {frame_index}) ---")
+    n_views = len(cam_ids)
+    n_cols = min(4, n_views)
+    n_rows = (n_views + n_cols - 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(8 * n_cols, 6 * n_rows),
+                             squeeze=False)
+    axes_flat = axes.flatten()
+    gt_present = ~np.all(gt_3d_can == 0, axis=1)  # joints the dataset actually has
+
+    for v, cid in enumerate(cam_ids):
+        ax = axes_flat[v]
+        img = x_mv["image_data"][v]
+        if img is None:
+            ax.set_title(f"CAM{cid} - no image")
+            ax.axis("off")
+            continue
+        H, W = img.shape[:2]
+        ax.imshow(img)
+
+        R_v = y_mv["cam_rot_per_view"][v].numpy()
+        t_v = y_mv["cam_trans_per_view"][v].numpy()
+        fx, fy = y_mv["fx_per_view"][v], y_mv["fy_per_view"][v]
+        cx, cy = y_mv["cx_per_view"][v], y_mv["cy_per_view"][v]
+
+        gt_u, gt_v_, gt_d = _project_canonical(gt_3d_can, R_v, t_v, fx, fy, cx, cy)
+        ps_u, ps_v_, ps_d = _project_canonical(posed_3d_can[:n_joints],
+                                               R_v, t_v, fx, fy, cx, cy)
+
+        for i in range(n_joints):
+            name = j_names[i]
+            if gt_present[i] and gt_d[i] > 0:
+                ax.plot(gt_u[i], gt_v_[i], marker="o", color="lime",
+                        markersize=6, markerfacecolor="none", markeredgewidth=1.4)
+                ax.annotate(name, (gt_u[i], gt_v_[i]), color="lime",
+                            xytext=(4, -4), textcoords="offset points",
+                            fontsize=5, alpha=0.9)
+            if ps_d[i] > 0:
+                ax.plot(ps_u[i], ps_v_[i], marker="+", color="red",
+                        markersize=8, markeredgewidth=1.4)
+                ax.annotate(name, (ps_u[i], ps_v_[i]), color="red",
+                            xytext=(4, 8), textcoords="offset points",
+                            fontsize=5, alpha=0.9)
+
+        ax.set_title(f"CAM{cid}  GT (lime o) vs posed model (red +)", fontsize=10)
+        ax.set_xlim(0, W)
+        ax.set_ylim(H, 0)
+        ax.set_aspect("equal")
+        ax.axis("off")
+
+    for j in range(n_views, len(axes_flat)):
+        axes_flat[j].axis("off")
+
+    fig.suptitle(
+        f"Frame {frame_index} - per-view named GT vs posed-model joints "
+        "(canonical frame). Same joint name on both colours should land on "
+        "the same anatomy.",
+        fontsize=12,
+    )
+    fig.tight_layout()
+    overlay_path = Path(output_dir) / f"frame_{frame_index:05d}_named_overlay.png"
+    fig.savefig(overlay_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  2D overlay grid (high-res) -> {overlay_path}")
+
+    # --- 3D side-by-side ---
+    print(f"\n--- Named 3D plot (canonical frame, frame {frame_index}) ---")
+    fig = plt.figure(figsize=(16, 10))
+    ax = fig.add_subplot(111, projection="3d")
+
+    gt_pts = gt_3d_can[gt_present]
+    ax.scatter(gt_pts[:, 0], gt_pts[:, 1], gt_pts[:, 2],
+               c="green", s=50, label="GT (loader)", depthshade=False)
+    ax.scatter(posed_3d_can[:n_joints, 0], posed_3d_can[:n_joints, 1],
+               posed_3d_can[:n_joints, 2],
+               c="red", s=50, marker="+", label="Posed model (SMAL fwd)",
+               depthshade=False)
+
+    for i in range(n_joints):
+        name = j_names[i]
+        if gt_present[i]:
+            ax.text(gt_3d_can[i, 0], gt_3d_can[i, 1], gt_3d_can[i, 2],
+                    f"  {name}", color="green", fontsize=6, alpha=0.85)
+        ax.text(posed_3d_can[i, 0], posed_3d_can[i, 1], posed_3d_can[i, 2],
+                f"  {name}", color="red", fontsize=6, alpha=0.85)
+
+    # Equal axes for honest visual distance.
+    all_pts = np.concatenate([gt_pts, posed_3d_can[:n_joints]], axis=0)
+    ax.set_xlim(all_pts[:, 0].min(), all_pts[:, 0].max())
+    ax.set_ylim(all_pts[:, 1].min(), all_pts[:, 1].max())
+    ax.set_zlim(all_pts[:, 2].min(), all_pts[:, 2].max())
+    set_axes_equal(ax)
+    ax.set_xlabel("X (canonical)")
+    ax.set_ylabel("Y (canonical)")
+    ax.set_zlabel("Z (canonical)")
+    ax.set_title(f"Frame {frame_index} - 3D GT (green) vs posed model (red), "
+                 "joint names labelled.")
+    ax.legend()
+    out_3d = Path(output_dir) / f"frame_{frame_index:05d}_named_3d.png"
+    fig.savefig(out_3d, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  3D named plot -> {out_3d}")
+
+
 def report_loader_smoke(dataset_path, frame_index):
     print("\n--- Loader smoke test: load_SMIL_Unreal_multiview_sample ---")
     x, y = load_SMIL_Unreal_multiview_sample(
@@ -528,6 +752,11 @@ def main():
                         help="Run the canonical-camera-frame validation: numeric "
                              "round-trip, side-by-side reprojection check, and raw-vs-"
                              "canonical mesh renders. Requires --smal_file and GPU.")
+    parser.add_argument("--named_overlay", action="store_true",
+                        help="High-res per-camera overlay + 3D side-by-side plot "
+                             "with joint name labels. Compares loader GT against "
+                             "SMAL forward posed joints in canonical frame. "
+                             "Requires --smal_file and GPU.")
     args = parser.parse_args()
 
     dataset_path = Path(args.dataset_path)
@@ -641,8 +870,12 @@ def main():
             compare_frames_test(
                 dataset_path, args.frame_index, output_dir, per_camera, cam_ids,
             )
-    elif args.render or args.compare_frames:
-        print("\n⚠ --render / --compare_frames requires --smal_file; skipping.")
+        if args.named_overlay:
+            visualize_named_keypoints(
+                dataset_path, args.frame_index, output_dir, cam_ids,
+            )
+    elif args.render or args.compare_frames or args.named_overlay:
+        print("\n⚠ --render / --compare_frames / --named_overlay requires --smal_file; skipping.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds end-to-end support for the multi-camera replicAnt synthetic dataset on the multi-view training path. Plumbs from raw flat-directory JSONs → multi-view loader → HDF5 preprocessor → trainer (via `SLEAPMultiViewDataset`, unchanged) with byte-equivalent round-trips at every stage.

The design is captured in [MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md](MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md).

### Phase 1 — multi-view loader

`load_SMIL_Unreal_multiview_sample` in [smal_fitter/Unreal2Pytorch3D.py](smal_fitter/Unreal2Pytorch3D.py) reads all cameras for a frame from a flat-directory replicAnt layout. Per-frame output:

- **Canonical-camera-frame storage**: lowest-index camera with valid geometry becomes the canonical anchor (`R = I`, `t = 0`). Stores forward transform `canonical_to_world = (R_0, t_0)` for the inverse round-trip.
- **Depth-buffer self-occlusion** refinement at load time; visibility = `in_dataset AND in_bounds AND id_mask_pass AND depth_pass`. No `/multiview_depth/` group needed in the HDF5; depth knobs are recorded in `/metadata` attrs for reproducibility.
- **In-dataset bitmap** so model-only joints stay invisible regardless of where the `[0, 0]` sentinel lands on the ID/depth pass.
- **Scale unification (`translation_factor=0.1`)**: applies a uniform `×0.1` to `root_loc`, `cam_trans_per_view`, `keypoints_3d`, `keypoints_3d_world`, `canonical_to_world_t` so mesh-native and data-frame units coincide. Multi-view configs run with `use_ue_scaling=false` (no `×10` model-side hack). Empirical probe verified `data×0.01` fails reprojection by 700–1600 px; `data×0.1` matches to numerical noise.
- **(0,0,0) sentinel for missing 3D GT**: joints in `config.dd["J_names"]` without a dataset entry are re-zeroed **after** canonical-frame + scale transforms so downstream consumers can detect them via the standard `~np.all(kp3d == 0, axis=1)` check.
- **Per-camera resilience**: when one or more cameras have empty `subject Data` (animal absent from that view's render), the loader emits `view_valid_per_view[v] = False` for those slots and falls back to the first valid camera for shared pose/shape extraction. Raises only when no camera in the frame has subject data.
- **cv2/imageio loader hybrid**: JPG + depth go through `cv2.imread` (~15% / ~60% faster); ID mask stays on `imageio` because cv2 is ~80% slower on that specific PNG flavour. Projected 38% per-frame decode-time reduction; byte-equivalent vs imageio across all 12 cameras of frame 0.

Empirical: 0.00 px reprojection error on 12 cameras of frame 0; 7.6e-06 max abs round-trip on 3D keypoints; canonical-cam extrinsics R = I and t = 0 to numerical precision.

### Phase 3 — HDF5 preprocessor

[smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py](smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py):

- Writes the schema [SLEAPMultiViewDataset](smal_fitter/sleap_data/sleap_multiview_dataset.py) already reads — no trainer changes required.
- `ProcessPoolExecutor` with `_worker_init` that runs `apply_smal_file_override` once per worker.
- Camera extrinsics stored in OpenCV form; SLEAP reader re-derives PyTorch3D values at dataset-load with byte equivalence.
- CLI knobs include `--min_views`, `--target_resolution`, `--translation_factor`, depth pass-through, and the standard chunking / compression / worker controls.
- **Per-camera resilience**: when `>= --min_views` cameras have valid `subject Data`, the frame is kept with `view_mask[i, v] = False` + `camera_indices[i, v] = -1` on the invalid slots; otherwise the frame goes to the `skipped_frame_indices` ledger.

[smal_fitter/replicAnt_data/test_replicant_preprocessing.py](smal_fitter/replicAnt_data/test_replicant_preprocessing.py) is a manual-run round-trip check that pairs the dataset's active views with the loader's valid slots in canonical order and verifies byte equivalence on R, T, K, 2D keypoints, visibility, 3D keypoints, parameters, and the `canonical_to_world` inverse.

### Phase 4 — dispatch refactor

[smal_fitter/neuralSMIL/smil_datasets.py](smal_fitter/neuralSMIL/smil_datasets.py)'s `UnifiedSMILDataset.from_path()` now does a real dispatch driven by HDF5 `/metadata` attrs:

- `is_multiview=True` → `SLEAPMultiViewDataset` (replicAnt or SLEAP multi-view)
- `dataset_type='sleap'` → `SLEAPDataset` (single-view)
- otherwise → `OptimizedSMILDataset` (legacy single-view replicAnt HDF5)
- Directory with `_BatchData_*.json` AND any `*_CAM*.json` → raises `NotImplementedError` pointing at the preprocessor (Phase 2 direct-load class is intentionally deferred).

Replaces the runtime monkey-patch in [smal_fitter/sleap_data/sleap_dataset.py](smal_fitter/sleap_data/sleap_dataset.py) (`_patch_unified_dataset`), which had no multi-view branch and silently routed multi-view HDF5s to `OptimizedSMILDataset`.

### Phase 6 — example training config

[smal_fitter/neuralSMIL/configs/examples/multiview_replicant_mice.json](smal_fitter/neuralSMIL/configs/examples/multiview_replicant_mice.json) — production baseline with `use_ue_scaling: false`, scale-unified data path, ViT-large backbone, transformer-decoder head, full curriculum schedule.

## Test plan

- [x] **Loader geometry**: 0.00 px reprojection error on 12 cameras of frame 0; 7.6e-06 max abs round-trip on 3D keypoints; canonical-cam extrinsics R = I and t = 0 to numerical precision.
- [x] **HDF5 round-trip**: byte-equivalent loader ↔ HDF5 ↔ `SLEAPMultiViewDataset` on samples 0 / 184 / 435 / 441 / 499 (including frame 435 where the canonical camera CAM1 itself had empty subject data). Max delta = 0 on R, T, 2D keypoints, visibility, 3D keypoints, parameters; `canonical_to_world` inverse recovers raw world to 1.4e-6.
- [x] **cv2 swap**: byte-equivalent vs imageio on all 12 cameras of frame 0 for JPG, ID mask (with downstream binarisation), and depth channel 0; full preprocessor round-trip PASS post-swap.
- [x] **Per-camera resilience**: 500 / 500 samples written on the smoke (was 497 / 500). The 3 previously-skipped frames (184, 435, 441) are now retained with `view_mask=False` on the bad slot.
- [x] **Dispatch**: 5 cases verified on real HDF5s — replicAnt multi-view, SLEAP multi-view, SLEAP single-view, legacy single-view replicAnt, and the flat-dir `NotImplementedError` path.
- [x] **Multi-view training, small subset** (ViT-large frozen, 1 epoch): real-mouse 6-cam HDF5 — 2m55s, best val 0.0167, `Plotted joints: 34, Suppressed: 6`; replicAnt 500-frame smoke (8 train, 12 cams) — 7m20s, best val 14.47, `Plotted joints: 31, Suppressed: 9`. Both produce clean per-view image + GT-cam GT-3D reproj visualisations.
- [x] **Multi-view training, full-coverage SMOKE** (1 epoch on all 500 replicAnt samples, ViT-large frozen, 425 train + 75 val): 8m19s, best val 1.58, no exceptions including the 3 partially-masked frames.
- [x] **Earlier 5-epoch convergence test** (post-sentinel-fix): train loss **2.27 → 0.49** monotonic ↓; `keypoint_3d` train 8.35 → 1.83 (5.4× drop vs the pre-fix ghost-joint run); per-view reprojection converges; `trans` head supervises without divergence.

## What's deferred (independent next steps)

- **Phase 2** — `MultiViewreplicAntSMILDataset` direct-load PyTorch class. Low priority; production training reads the HDF5 via the existing `SLEAPMultiViewDataset`.
- **Phase 5** — single-view sampler over a multi-view HDF5. Deferred per design.
- **Follow-up** — single-view scale unification: apply the same `0.1` rescale in `load_SMIL_Unreal_sample` and flip single-view configs to `use_ue_scaling=False`. Separate PR.
- **Follow-up** — package-import refactor + ruff. Separate mechanical PR.

## Out of band

The full 10k-frame preprocess at 512 px is running locally (~2 h ETA) and lands at `replicant_multiview_mice.h5` — the path the production config expects. Production training run is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
