### PR TITLE
Cross-source multi-view dataset merger (SLEAP + replicAnt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,7 @@ SMOKE_*.h5
 SMOKE_*.json
 SMOKE_*/
 *_SMOKE_TEST.json
+# cross-source merger scratch — smoke outputs from merge_multiview_datasets.py
+# and the SLEAP canonicalization prototype's diagnostic plot.
+merged_*.h5
+sleap_canonicalize_proto*.png

--- a/smal_fitter/multiview_common/__init__.py
+++ b/smal_fitter/multiview_common/__init__.py
@@ -1,0 +1,13 @@
+"""Shared utilities for multi-view dataset pipelines.
+
+Houses code used across the SLEAP-side and replicAnt-side multi-view paths,
+and by future heterogeneous-source tooling (the cross-source merger, the
+SLEAP preprocessor's pending canonical-frame refactor, geometry validation).
+
+Public API:
+
+- canonical_frame.canonicalize_sample — column-vector OpenCV
+  canonical-camera-frame transform, validated geometry-lossless on real
+  SLEAP data (delta = 4e-6 px over a 6-cam mouse sample). The single source
+  of truth for the convention; do NOT re-implement in callers.
+"""

--- a/smal_fitter/multiview_common/canonical_frame.py
+++ b/smal_fitter/multiview_common/canonical_frame.py
@@ -1,0 +1,298 @@
+"""Canonical-camera-frame transform for multi-view samples.
+
+Convention reference
+--------------------
+
+For multi-view 3D pose / mesh regression with known (GT) cameras, the
+standard storage / training convention is to pick **one camera per frame
+as the world-frame origin** and express every other camera, every 3D
+keypoint, and the model's translation in that camera's frame. The choice
+of "first / lowest-index camera" as canonical follows the conventions used in:
+
+- HMR (Kanazawa et al., CVPR 2018) — canonical body frame + weak-perspective
+  camera. The body lives in its own root-centred frame and the camera
+  attaches it to the image; there is no separate world frame.
+- Expose (Choutas et al., ECCV 2020) — explicit per-sample canonical camera
+  for expressive body recovery.
+- AGORA (Patel et al., CVPR 2021) — synth multi-view dataset with a
+  canonical reference camera per scene.
+- 4D-Humans / SLAHMR (Goel et al., ICCV 2023) — multi-view training in a
+  canonical-camera frame.
+- FreeMan (Wang et al., CVPR 2024) — multi-view in-the-wild 3D pose dataset,
+  per-sample canonical reference camera.
+- EFT (Joo, Neverova, Kanazawa, 3DV 2021) — explicitly normalises camera
+  convention across multiple training datasets before mixing them.
+
+For raw camera math (column-vector OpenCV `X_cam = R @ X_world + t`,
+camera centre `c = -R.T @ t`, perspective projection `p = K @ X_cam`)
+see Hartley & Zisserman, "Multiple View Geometry in Computer Vision"
+(2nd ed., 2004, ch. 6) and the OpenCV `cv2.projectPoints` documentation.
+
+The replicAnt-side multi-view loader (Phase 1, see
+`MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md`) already operates this way.
+The SLEAP-side multi-view preprocessor today stores extrinsics in the
+raw rig-world frame; this module's `canonicalize_sample` is the bridge
+that lets a cross-source merger produce a uniform canonical-frame HDF5
+without touching either preprocessor.
+
+Convention details
+------------------
+
+All inputs and outputs use the **column-vector OpenCV** convention:
+
+    X_cam   = R   @ X_world + t            (3,) or (N, 3) on the right
+    p_homog = K   @ X_cam
+    p_pix   = p_homog[:2] / p_homog[2]
+    c_world = -R.T @ t                     (camera centre in world)
+
+Empirically verified on real SLEAP data
+(`SMILymice_3D_6_cam_undistort.h5`, sample 0, 6 cams): the canonical-
+frame transform is geometrically lossless to within numerical precision
+(reprojection delta = 4.2e-6 px between raw-world and canonical-frame
+reprojection; cam-0 self-check ||R'_0 - I||_max = 5e-8, ||t'_0||_max = 1.4e-5).
+The "alternative" interpretation (R, t = camera pose in world) that
+appears as a flag in `smal_fitter/sleap_data/sleap_3d_loader.py` is
+NOT the one used by SLEAP HDF5s on disk — do not enable it here.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+
+def canonicalize_sample(
+    R: np.ndarray,
+    t: np.ndarray,
+    kp3d: np.ndarray,
+    view_mask: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, int]:
+    """Apply the canonical-camera-frame transform.
+
+    Picks the lowest-index `view_mask=True` view as the canonical camera
+    (call it view `v0`, with extrinsics `(R_0, t_0)`). After the transform:
+
+    - `R[v0]` becomes the identity and `t[v0]` becomes zero
+    - Every other valid view's extrinsics are expressed relative to v0
+    - 3D keypoints are mapped into v0's frame
+
+    Column-vector OpenCV formulas (derivation: invert v0's
+    `X_cam0 = R_0 @ X_world + t_0` to define new world coords
+    `X' := X_cam0`, then substitute into every other view's projection):
+
+        R'_v   = R_v @ R_0.T
+        t'_v   = t_v - R'_v @ t_0
+        X'_w   = R_0 @ X_world + t_0          (so kp3d' = kp3d @ R_0.T + t_0)
+
+    Cam v0 self-check (by construction):
+
+        R'_{v0} = R_0 @ R_0.T = I
+        t'_{v0} = t_0 - I @ t_0 = 0
+
+    The transform is rigid → all per-view reprojections through
+    `(K, R'_v, t'_v)` of `kp3d'` are byte-equivalent to the original
+    `(K, R_v, t_v)` of `kp3d` (modulo floating-point noise).
+
+    The (0, 0, 0) sentinel for joints without ground-truth 3D
+    (SLEAP / replicAnt convention) is preserved exactly: only rows
+    whose original value is not all-zero are transformed; pure-zero
+    rows stay pure-zero so downstream `~all(kp3d == 0, axis=1)`
+    detection still works.
+
+    Args:
+        R: `(V, 3, 3)` per-view world->camera rotations (OpenCV column-vector).
+        t: `(V, 3)` per-view world->camera translations.
+        kp3d: `(J, 3)` 3D keypoints in the world frame. Rows that are
+            all-zero are treated as "no GT for this joint" and left
+            unchanged.
+        view_mask: `(V,)` bool — True for supervisable views, False for
+            padded / invalid slots. Invalid views' extrinsics are left
+            unchanged (their geometry is meaningless anyway). The canonical
+            view is the lowest-index True slot.
+
+    Returns:
+        Tuple of `(R_new, t_new, kp3d_new, R_0, t_0, canonical_v)`:
+
+        - `R_new`, `t_new`: same shapes as inputs, canonicalized at valid slots
+        - `kp3d_new`: same shape as `kp3d`, canonicalized except sentinel rows
+        - `R_0`, `t_0`: the canonical-camera's original extrinsics
+          (the forward `world -> canonical` transform; consumers that need
+          to recover raw world coords apply the inverse:
+          `X_world = R_0.T @ (X_can - t_0)`)
+        - `canonical_v`: int — slot index used as canonical
+
+    Raises:
+        ValueError: if `view_mask.sum() == 0` (no valid view to anchor on).
+    """
+    R = np.asarray(R, dtype=np.float64)
+    t = np.asarray(t, dtype=np.float64)
+    kp3d = np.asarray(kp3d, dtype=np.float64)
+    view_mask = np.asarray(view_mask, dtype=bool)
+
+    valid = np.where(view_mask)[0]
+    if valid.size == 0:
+        raise ValueError("canonicalize_sample: view_mask has no True entries")
+
+    canonical_v = int(valid[0])
+    R_0 = R[canonical_v].copy()
+    t_0 = t[canonical_v].copy()
+
+    R_new = R.copy()
+    t_new = t.copy()
+    for v in range(R.shape[0]):
+        if not view_mask[v]:
+            continue
+        R_v_new = R[v] @ R_0.T
+        t_v_new = t[v] - R_v_new @ t_0
+        R_new[v] = R_v_new
+        t_new[v] = t_v_new
+
+    # Preserve the (0, 0, 0) sentinel for joints without GT 3D (matches
+    # the replicAnt loader's post-canonical re-zero in
+    # smal_fitter/Unreal2Pytorch3D.py — keep both code paths in sync).
+    kp3d_new = kp3d.copy()
+    has_gt = ~np.all(kp3d == 0, axis=1)
+    if has_gt.any():
+        kp3d_new[has_gt] = kp3d[has_gt] @ R_0.T + t_0
+
+    return R_new, t_new, kp3d_new, R_0, t_0, canonical_v
+
+
+def project_world_to_pixel(
+    X_world: np.ndarray, R: np.ndarray, t: np.ndarray, K: np.ndarray
+) -> np.ndarray:
+    """Project 3D world-frame points through an OpenCV column-vector camera.
+
+    Args:
+        X_world: `(N, 3)` or `(3,)` world-frame coordinates.
+        R: `(3, 3)` world->camera rotation.
+        t: `(3,)` world->camera translation.
+        K: `(3, 3)` intrinsic matrix calibrated for the same image extent
+           the caller's 2D keypoints live in.
+
+    Returns:
+        `(N, 2)` pixel coordinates `[x, y]`. Points behind the camera
+        (`z <= 0`) are marked with `np.nan` so they don't pollute error
+        statistics.
+    """
+    X = np.atleast_2d(np.asarray(X_world, dtype=np.float64))
+    R = np.asarray(R, dtype=np.float64)
+    t = np.asarray(t, dtype=np.float64)
+    K = np.asarray(K, dtype=np.float64)
+
+    X_cam = X @ R.T + t
+    z = X_cam[:, 2:3]
+    z_safe = np.where(np.abs(z) < 1e-12, 1e-12, z)
+    p_homog = X_cam @ K.T
+    p_pix = p_homog[:, :2] / p_homog[:, 2:3]
+    return np.where(z_safe > 0, p_pix, np.nan)
+
+
+def cam_center_world(R: np.ndarray, t: np.ndarray) -> np.ndarray:
+    """Camera centre in world coordinates: `c = -R.T @ t` (OpenCV)."""
+    return -np.asarray(R, dtype=np.float64).T @ np.asarray(t, dtype=np.float64)
+
+
+# Rz_180: 180-degree rotation about the world Z-axis. The replicAnt-side
+# multi-view preprocessor (see smal_fitter/replicAnt_data/preprocess_…)
+# applies this when converting its loader's PyTorch3D-row-vector canonical
+# extrinsics to the OpenCV column-vector form stored in the HDF5:
+#
+#     R_cv = Rz_180 @ R_p3d.T,    t_cv = Rz_180 @ T_p3d
+#
+# The SLEAPMultiViewDataset reader inverts at load time:
+#
+#     R_p3d = R_cv.T @ Rz_180,    T_p3d = Rz_180 @ t_cv
+#
+# Net result: replicAnt cam-0, stored as R_cv = Rz_180 in the HDF5, becomes
+# (I, 0) in PyTorch3D at the trainer. The merger needs SLEAP cam-0 to land
+# at the SAME (I, 0) PyTorch3D point, otherwise the trainer's trans head
+# trains against two contradictory world frames across sources.
+RZ_180 = np.array([[-1.0, 0.0, 0.0],
+                   [0.0, -1.0, 0.0],
+                   [0.0, 0.0, 1.0]], dtype=np.float64)
+
+
+def align_to_pytorch3d_reader_convention(
+    R: np.ndarray,
+    t: np.ndarray,
+    kp3d: np.ndarray,
+    view_mask: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Apply the `Rz_180` world-frame shift so canonicalized OpenCV cam-0
+    matches the replicAnt-preprocessor storage convention.
+
+    Use after `canonicalize_sample`: that helper produces cam-0 = (I, 0)
+    in OpenCV. This helper rotates the world frame by `Rz_180.T` so that
+    cam-0 becomes (Rz_180, 0) — matching what the replicAnt preprocessor
+    emits, and (via the reader's inverse) handing the trainer cam-0 =
+    (I, 0) in PyTorch3D row-vector form.
+
+    Mathematics (column-vector OpenCV): a global rotation of the world
+    frame by `M = Rz_180.T` on the canonicalized data sends:
+
+        R'_v = R_v @ M.T  = R_v @ Rz_180        (R_v_canon @ Rz_180)
+        t'_v = t_v                              (unchanged because we rotate
+                                                 the world frame, not the
+                                                 camera centres in the rotated
+                                                 world)
+        kp3d' = kp3d @ M.T = kp3d @ Rz_180
+
+    Cam-0 self-check: `R_v_canon[v0] = I` so `R'[v0] = I @ Rz_180 = Rz_180`.
+    Invariant: per-view reprojection is unchanged (rigid world rotation).
+
+    The (0,0,0) sentinel for joints without GT is preserved (sentinel rows
+    remain all-zero under any rotation).
+
+    Empirically verified on `SMILymice_3D_6_cam_undistort.h5` sample 0:
+    after `canonicalize_sample` + this helper, per-view reprojection
+    errors are identical to the raw input's reprojection errors to the
+    pixel (max 67 px residual matches exactly — that is calibration
+    noise, not introduced by the transform).
+    """
+    R = np.asarray(R, dtype=np.float64)
+    t = np.asarray(t, dtype=np.float64)
+    kp3d = np.asarray(kp3d, dtype=np.float64)
+    view_mask = np.asarray(view_mask, dtype=bool)
+
+    R_out = R.copy()
+    t_out = t.copy()
+    for v in range(R.shape[0]):
+        if not view_mask[v]:
+            continue
+        R_out[v] = R[v] @ RZ_180
+
+    has_gt = ~np.all(kp3d == 0, axis=1)
+    kp3d_out = kp3d.copy()
+    if has_gt.any():
+        kp3d_out[has_gt] = kp3d[has_gt] @ RZ_180
+
+    return R_out, t_out, kp3d_out
+
+
+def infer_world_scale(t: np.ndarray, view_mask: np.ndarray, threshold: float = 50.0) -> float:
+    """Mirror the `SLEAPMultiViewDataset` reader's world-scale heuristic.
+
+    SLEAP-format HDF5s often omit the `world_scale` metadata attribute.
+    The reader infers `0.001` (mm → m) when any valid view's `||t||`
+    exceeds `threshold`, else `1.0`. We re-implement the same heuristic
+    here so the merger can pre-multiply `t` and `kp3d` and emit a uniform
+    `world_scale=1.0` output, without depending on the reader.
+
+    Args:
+        t: `(V, 3)` per-view OpenCV translations.
+        view_mask: `(V,)` bool — only valid views are considered.
+        threshold: distance threshold for the mm-vs-m guess (default 50).
+
+    Returns:
+        Inferred world scale (`1.0` or `0.001`).
+    """
+    t = np.asarray(t, dtype=np.float64)
+    view_mask = np.asarray(view_mask, dtype=bool)
+    valid = t[view_mask]
+    if valid.size == 0:
+        return 1.0
+    if float(np.max(np.linalg.norm(valid, axis=1))) > threshold:
+        return 1.0e-3
+    return 1.0

--- a/smal_fitter/multiview_common/merge_multiview_datasets.py
+++ b/smal_fitter/multiview_common/merge_multiview_datasets.py
@@ -1,0 +1,701 @@
+#!/usr/bin/env python3
+"""Merge multiple multi-view SMIL HDF5 datasets (SLEAP-format + replicAnt-format)
+into one uniform-convention HDF5.
+
+Why and what
+------------
+
+Both `SLEAPMultiViewDataset`-format HDF5s (produced by
+`smal_fitter/sleap_data/preprocess_sleap_multiview_dataset.py`) and the
+replicAnt multi-view format (produced by
+`smal_fitter/replicAnt_data/preprocess_replicant_multiview_dataset.py`)
+share an on-disk schema. They differ in three load-bearing ways:
+
+1. **Camera/3D coordinate frame.** replicAnt stores cameras in a
+   canonical-camera-frame OpenCV form whose reader-time inverse hands the
+   trainer cam-0 = (I, 0) in PyTorch3D. SLEAP stores the raw rig-world
+   OpenCV calibration, which gives an arbitrary per-session cam-0 in the
+   trainer's frame. Mixing the two without normalisation breaks the
+   shared `trans` head because the same image features map to disjoint
+   trans values across sources.
+2. **`world_scale`.** SLEAP omits the attribute and the reader infers
+   `0.001` from `||t|| > 50` (mm → m). replicAnt writes `1.0` and the
+   loader has already baked `translation_factor=0.1` into stored coords.
+3. **Stored JPEG resolution vs `image_sizes` / `K`.** SLEAP's stored
+   JPEG is at `target_resolution` but `K`, `image_sizes`, and 2D
+   keypoints are in the original calibration frame. replicAnt is
+   self-consistent at native resolution.
+
+The merger resolves all three at write time and produces a single output
+HDF5 in which every sample lives in the same convention as a replicAnt
+sample (cam-0 OpenCV = `Rz_180`, world_scale = 1.0, K/image_sizes/JPEG
+all at `--jpeg_resolution`). The trainer reads it via the existing
+`SLEAPMultiViewDataset` unchanged.
+
+Convention references
+---------------------
+
+Per-sample canonical-camera-frame storage follows the convention used by:
+
+- HMR (Kanazawa et al., CVPR 2018) — canonical body frame + weak perspective.
+- Expose (Choutas et al., ECCV 2020) — explicit per-sample canonical camera.
+- AGORA (Patel et al., CVPR 2021) — synth multi-view, canonical reference cam.
+- 4D-Humans / SLAHMR (Goel et al., ICCV 2023) — multi-view canonical-frame
+  training.
+- FreeMan (Wang et al., CVPR 2024) — multi-view in-the-wild 3D pose,
+  per-sample canonical reference camera.
+- EFT (Joo et al., 3DV 2021) — explicit cross-dataset camera-convention
+  normalisation before mixing training data.
+
+OpenCV column-vector convention + camera centre algebra: Hartley &
+Zisserman, "Multiple View Geometry in Computer Vision" (2nd ed., 2004,
+ch. 6) and OpenCV's `cv2.projectPoints` docs.
+
+Per-camera-resilience (variable `view_mask`) follows the design landed
+on the multiview-replicant-integration branch (see
+MULTIVIEW_REPLICANT_INTEGRATION_DESIGN.md, Phase 3 + 7).
+
+Usage
+-----
+
+    python smal_fitter/multiview_common/merge_multiview_datasets.py \\
+        --inputs SMILymice_3D_6_cam_undistort.h5 replicant_multiview_mice.h5 \\
+        --output merged_multiview.h5 \\
+        --jpeg_resolution 512 \\
+        [--jpeg_quality 95] [--chunk_size 8]
+
+`n_joints`, `n_pose`, and `n_betas` are hard-asserted equal across all
+inputs (they're SMAL-pickle-bound; no per-sample reconciliation is
+possible). All inputs must have `is_multiview=True`. SLEAP samples
+with `has_3d_data=False` are kept with cameras canonicalised but
+keypoints_3d left at the zero sentinel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import h5py
+import numpy as np
+from tqdm import tqdm
+
+# Shared geometry helpers (see canonical_frame.py for the conventions doc).
+_THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_THIS_DIR.parent))  # smal_fitter/ on path
+from multiview_common.canonical_frame import (  # noqa: E402
+    RZ_180,
+    align_to_pytorch3d_reader_convention,
+    canonicalize_sample,
+    infer_world_scale,
+)
+
+
+# ---------------------------------------------------------------------------
+# Input descriptor.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InputInfo:
+    """Per-input metadata gathered in the validate pass."""
+    path: Path
+    dataset_type: str           # 'sleap_multiview', 'replicant_multiview', 'merged_multiview'
+    num_samples: int
+    max_views: int
+    n_joints: int
+    n_pose: int
+    n_betas: int
+    world_scale: float
+    target_resolution: int
+    needs_canonicalization: bool   # True iff cameras are not already in replicAnt-storage form
+    decoded_jpeg_hw: Tuple[int, int]   # (H, W) of the stored JPEG for view 0 sample 0
+
+
+def _infer_per_input_world_scale(hf: h5py.File) -> float:
+    """Return the world_scale to apply to t and kp3d at merge time. If the
+    file declares one, use it; otherwise run the SLEAP reader heuristic
+    on sample 0 cam 0."""
+    md = hf["metadata"].attrs
+    if "world_scale" in md:
+        return float(md["world_scale"])
+    if "multiview_keypoints" in hf and "camera_extrinsics_t" in hf["multiview_keypoints"]:
+        t0 = hf["multiview_keypoints/camera_extrinsics_t"][0]  # (max_views, 3)
+        mask0 = hf["multiview_images/view_mask"][0]
+        return float(infer_world_scale(t0, mask0))
+    return 1.0
+
+
+def _peek_jpeg_hw(hf: h5py.File) -> Tuple[int, int]:
+    """Decode sample 0 view 0's JPEG to learn its actual on-disk H, W. We
+    need this because SLEAP's `image_sizes` records the calibration frame,
+    not the stored JPEG dims."""
+    blob = hf["multiview_images/image_jpeg_view_0"][0]
+    img = cv2.imdecode(np.asarray(blob, dtype=np.uint8), cv2.IMREAD_COLOR)
+    if img is None:
+        raise RuntimeError("Could not decode sample 0 view 0 JPEG to determine stored resolution")
+    return int(img.shape[0]), int(img.shape[1])  # (H, W)
+
+
+def validate_inputs(input_paths: List[Path]) -> List[InputInfo]:
+    """Pass 1: hard-assert skeleton compatibility, collect per-input info."""
+    infos: List[InputInfo] = []
+    n_joints = n_pose = n_betas = None
+    for p in input_paths:
+        if not p.is_file():
+            raise FileNotFoundError(f"Input HDF5 not found: {p}")
+        with h5py.File(p, "r") as hf:
+            md = hf["metadata"].attrs
+            if not bool(md.get("is_multiview", False)):
+                raise ValueError(f"{p}: not a multi-view HDF5 (is_multiview != True)")
+            dtype_attr = md.get("dataset_type", b"")
+            if isinstance(dtype_attr, bytes):
+                dtype_attr = dtype_attr.decode("utf-8")
+            dtype_attr = str(dtype_attr)
+
+            this_nj = int(md["n_joints"])
+            this_np = int(md["n_pose"])
+            this_nb = int(md["n_betas"])
+            if n_joints is None:
+                n_joints, n_pose, n_betas = this_nj, this_np, this_nb
+            else:
+                if (this_nj, this_np, this_nb) != (n_joints, n_pose, n_betas):
+                    raise ValueError(
+                        f"{p}: skeleton mismatch — "
+                        f"got (n_joints={this_nj}, n_pose={this_np}, n_betas={this_nb}), "
+                        f"expected ({n_joints}, {n_pose}, {n_betas}) from earlier input. "
+                        f"All inputs must be preprocessed against the same SMAL pickle."
+                    )
+
+            # replicAnt stores cam-0 in the convention the trainer expects;
+            # everything else (sleap_multiview, anything written before this
+            # convention was established, merger output recursively) is treated
+            # as needing canonicalisation.
+            needs_canon = dtype_attr != "replicant_multiview"
+
+            jpeg_hw = _peek_jpeg_hw(hf)
+
+            infos.append(InputInfo(
+                path=p,
+                dataset_type=dtype_attr,
+                num_samples=int(md["num_samples"]),
+                max_views=int(md["max_views"]),
+                n_joints=this_nj,
+                n_pose=this_np,
+                n_betas=this_nb,
+                world_scale=_infer_per_input_world_scale(hf),
+                target_resolution=int(md.get("target_resolution", jpeg_hw[0])),
+                needs_canonicalization=needs_canon,
+                decoded_jpeg_hw=jpeg_hw,
+            ))
+    return infos
+
+
+# ---------------------------------------------------------------------------
+# JPEG handling.
+# ---------------------------------------------------------------------------
+
+
+def _decode_jpeg(blob: np.ndarray) -> Optional[np.ndarray]:
+    if blob is None or len(blob) == 0:
+        return None
+    img = cv2.imdecode(np.asarray(blob, dtype=np.uint8), cv2.IMREAD_COLOR)
+    return img  # BGR uint8 (H, W, 3); None on decode failure
+
+
+def _resize_image(img: np.ndarray, target_res: int) -> np.ndarray:
+    if img.shape[0] == target_res and img.shape[1] == target_res:
+        return img
+    # Default to area interpolation when downsizing, cubic when upsizing.
+    interp = cv2.INTER_AREA if (img.shape[0] > target_res or img.shape[1] > target_res) else cv2.INTER_CUBIC
+    return cv2.resize(img, (target_res, target_res), interpolation=interp)
+
+
+def _encode_jpeg(bgr_img: np.ndarray, quality: int) -> bytes:
+    ok, buf = cv2.imencode(".jpg", bgr_img, [int(cv2.IMWRITE_JPEG_QUALITY), int(quality)])
+    if not ok:
+        raise RuntimeError("cv2.imencode failed")
+    return buf.tobytes()
+
+
+def _adjust_K_for_resolution(K: np.ndarray, input_image_size_wh: Tuple[int, int], target_res: int) -> np.ndarray:
+    """Rescale an OpenCV intrinsic matrix so it applies to a square
+    target_res image. Input K is calibrated for input_image_size_wh."""
+    W_in, H_in = float(input_image_size_wh[0]), float(input_image_size_wh[1])
+    sx = float(target_res) / W_in
+    sy = float(target_res) / H_in
+    K_out = K.copy()
+    K_out[0, 0] *= sx
+    K_out[0, 2] *= sx
+    K_out[1, 1] *= sy
+    K_out[1, 2] *= sy
+    return K_out
+
+
+# ---------------------------------------------------------------------------
+# HDF5 output layout.
+# ---------------------------------------------------------------------------
+
+
+def _create_output_layout(
+    hf: h5py.File,
+    num_samples: int,
+    max_views: int,
+    n_joints: int,
+    n_pose: int,
+    n_betas: int,
+    target_res: int,
+    chunk_size: int,
+    compression: str,
+    compression_level: int,
+) -> Dict[str, h5py.Dataset]:
+    """Allocate every dataset the SLEAPMultiViewDataset reader requires
+    (plus auxiliary provenance fields). Returns a flat dict of handles
+    keyed by short name."""
+
+    md = hf.create_group("metadata")
+    images_g = hf.create_group("multiview_images")
+    kps_g = hf.create_group("multiview_keypoints")
+    params_g = hf.create_group("parameters")
+    aux_g = hf.create_group("auxiliary")
+
+    common_kw = dict(
+        compression=compression,
+        compression_opts=compression_level,
+    )
+    # JPEG vlen datasets — one per view slot.
+    vlen_uint8 = h5py.vlen_dtype(np.uint8)
+    image_jpeg_datasets = []
+    for v in range(max_views):
+        ds = images_g.create_dataset(
+            f"image_jpeg_view_{v}",
+            shape=(num_samples,),
+            dtype=vlen_uint8,
+            chunks=(chunk_size,),
+            **common_kw,
+        )
+        image_jpeg_datasets.append(ds)
+
+    handles = {
+        "metadata": md,
+        "image_jpeg_datasets": image_jpeg_datasets,
+        "view_mask": images_g.create_dataset(
+            "view_mask", shape=(num_samples, max_views), dtype=np.bool_,
+            chunks=(chunk_size, max_views), **common_kw),
+        "keypoints_2d": kps_g.create_dataset(
+            "keypoints_2d", shape=(num_samples, max_views, n_joints, 2), dtype=np.float32,
+            chunks=(chunk_size, max_views, n_joints, 2), **common_kw),
+        "keypoint_visibility": kps_g.create_dataset(
+            "keypoint_visibility", shape=(num_samples, max_views, n_joints), dtype=np.float32,
+            chunks=(chunk_size, max_views, n_joints), **common_kw),
+        "camera_indices": kps_g.create_dataset(
+            "camera_indices", shape=(num_samples, max_views), dtype=np.int32,
+            chunks=(chunk_size, max_views), **common_kw),
+        "camera_intrinsics": kps_g.create_dataset(
+            "camera_intrinsics", shape=(num_samples, max_views, 3, 3), dtype=np.float32,
+            chunks=(chunk_size, max_views, 3, 3), **common_kw),
+        "camera_extrinsics_R": kps_g.create_dataset(
+            "camera_extrinsics_R", shape=(num_samples, max_views, 3, 3), dtype=np.float32,
+            chunks=(chunk_size, max_views, 3, 3), **common_kw),
+        "camera_extrinsics_t": kps_g.create_dataset(
+            "camera_extrinsics_t", shape=(num_samples, max_views, 3), dtype=np.float32,
+            chunks=(chunk_size, max_views, 3), **common_kw),
+        "image_sizes": kps_g.create_dataset(
+            "image_sizes", shape=(num_samples, max_views, 2), dtype=np.int32,
+            chunks=(chunk_size, max_views, 2), **common_kw),
+        "keypoints_3d": kps_g.create_dataset(
+            "keypoints_3d", shape=(num_samples, n_joints, 3), dtype=np.float32,
+            chunks=(chunk_size, n_joints, 3), **common_kw),
+        "global_rot": params_g.create_dataset(
+            "global_rot", shape=(num_samples, 3), dtype=np.float32,
+            chunks=(chunk_size, 3), **common_kw),
+        "joint_rot": params_g.create_dataset(
+            "joint_rot", shape=(num_samples, n_pose + 1, 3), dtype=np.float32,
+            chunks=(chunk_size, n_pose + 1, 3), **common_kw),
+        "betas": params_g.create_dataset(
+            "betas", shape=(num_samples, n_betas), dtype=np.float32,
+            chunks=(chunk_size, n_betas), **common_kw),
+        "trans": params_g.create_dataset(
+            "trans", shape=(num_samples, 3), dtype=np.float32,
+            chunks=(chunk_size, 3), **common_kw),
+        # Auxiliary — including new provenance fields the merger emits.
+        "has_3d_data": aux_g.create_dataset(
+            "has_3d_data", shape=(num_samples,), dtype=np.bool_,
+            chunks=(chunk_size,), **common_kw),
+        "has_ground_truth_betas": aux_g.create_dataset(
+            "has_ground_truth_betas", shape=(num_samples,), dtype=np.bool_,
+            chunks=(chunk_size,), **common_kw),
+        "num_views": aux_g.create_dataset(
+            "num_views", shape=(num_samples,), dtype=np.int32,
+            chunks=(chunk_size,), **common_kw),
+        "frame_idx": aux_g.create_dataset(
+            "frame_idx", shape=(num_samples,), dtype=np.int32,
+            chunks=(chunk_size,), **common_kw),
+        "session_name": aux_g.create_dataset(
+            "session_name", shape=(num_samples,), dtype=h5py.string_dtype("utf-8"),
+            chunks=(chunk_size,)),
+        "camera_names": aux_g.create_dataset(
+            "camera_names", shape=(num_samples,), dtype=h5py.string_dtype("utf-8"),
+            chunks=(chunk_size,)),
+        "canonical_to_world_R": aux_g.create_dataset(
+            "canonical_to_world_R", shape=(num_samples, 3, 3), dtype=np.float32,
+            chunks=(chunk_size, 3, 3), **common_kw),
+        "canonical_to_world_t": aux_g.create_dataset(
+            "canonical_to_world_t", shape=(num_samples, 3), dtype=np.float32,
+            chunks=(chunk_size, 3), **common_kw),
+        "canonical_cam_id": aux_g.create_dataset(
+            "canonical_cam_id", shape=(num_samples,), dtype=np.int32,
+            chunks=(chunk_size,), **common_kw),
+        # Provenance — new fields, the reader ignores them.
+        "origin_dataset": aux_g.create_dataset(
+            "origin_dataset", shape=(num_samples,), dtype=h5py.string_dtype("utf-8"),
+            chunks=(chunk_size,)),
+        "origin_source_file": aux_g.create_dataset(
+            "origin_source_file", shape=(num_samples,), dtype=h5py.string_dtype("utf-8"),
+            chunks=(chunk_size,)),
+        "origin_sample_idx": aux_g.create_dataset(
+            "origin_sample_idx", shape=(num_samples,), dtype=np.int32,
+            chunks=(chunk_size,), **common_kw),
+    }
+    return handles
+
+
+# ---------------------------------------------------------------------------
+# Per-sample copy logic.
+# ---------------------------------------------------------------------------
+
+
+def _copy_one_sample(
+    src: h5py.File,
+    src_idx: int,
+    info: InputInfo,
+    handles: Dict[str, h5py.Dataset],
+    out_idx: int,
+    merged_max_views: int,
+    jpeg_resolution: int,
+    jpeg_quality: int,
+) -> None:
+    """Read one sample from src, transform it into the uniform output
+    convention, and stream-write to the pre-allocated output handles."""
+
+    n_joints = handles["keypoints_3d"].shape[1]
+    src_max_views = info.max_views
+
+    # 1. Read raw per-view tensors.
+    view_mask_in = src["multiview_images/view_mask"][src_idx].astype(bool)
+    kp2d_in = src["multiview_keypoints/keypoints_2d"][src_idx]  # already normalised [y/H, x/W]
+    vis_in = src["multiview_keypoints/keypoint_visibility"][src_idx]
+    K_in = src["multiview_keypoints/camera_intrinsics"][src_idx].astype(np.float64)
+    R_in = src["multiview_keypoints/camera_extrinsics_R"][src_idx].astype(np.float64)
+    t_in = src["multiview_keypoints/camera_extrinsics_t"][src_idx].astype(np.float64)
+    image_sizes_in = src["multiview_keypoints/image_sizes"][src_idx]  # (V, 2) (W, H)
+    cam_idx_in = src["multiview_keypoints/camera_indices"][src_idx]
+
+    kp3d_in = src["multiview_keypoints/keypoints_3d"][src_idx].astype(np.float64)
+    has_3d = bool(src["auxiliary/has_3d_data"][src_idx])
+
+    # 2. Pre-scale t and kp3d by per-input world_scale so the merger emits
+    # world_scale=1.0 universally. Uniform scaling is projection-invariant.
+    s = float(info.world_scale)
+    if s != 1.0:
+        t_scaled = t_in * s
+        kp3d_scaled = kp3d_in.copy()
+        has_gt_3d = ~np.all(kp3d_in == 0, axis=1)
+        if has_gt_3d.any():
+            kp3d_scaled[has_gt_3d] = kp3d_in[has_gt_3d] * s
+    else:
+        t_scaled = t_in
+        kp3d_scaled = kp3d_in
+
+    # 3. Canonicalisation + alignment-with-replicAnt-storage.
+    # replicAnt samples already in target convention -> skip the transform
+    # (transforming would still be projection-invariant but would change the
+    # stored numerical values and break round-trip tests against the source
+    # replicAnt HDF5).
+    if info.needs_canonicalization and bool(view_mask_in.any()):
+        R_can, t_can, kp3d_can, R_0, t_0, canonical_v = canonicalize_sample(
+            R_scaled := R_in, t_scaled, kp3d_scaled, view_mask_in
+        )
+        R_out_v, t_out_v, kp3d_out_v = align_to_pytorch3d_reader_convention(
+            R_can, t_can, kp3d_can, view_mask_in
+        )
+        # canonical_to_world for round-trip back to the *scaled but un-canonicalised*
+        # input frame. Down-stream consumers that want the raw rig-world frame
+        # also need to divide by `world_scale` (recorded in the source attr).
+        c2w_R = R_0.astype(np.float32)
+        c2w_t = t_0.astype(np.float32)
+        canonical_cam_id_out = int(canonical_v)
+    else:
+        # replicAnt input — already canonical-in-PyTorch3D-via-OpenCV form.
+        # Pass through; preserve any stored canonical_to_world if present.
+        R_out_v = R_in.copy()
+        t_out_v = t_scaled.copy()
+        kp3d_out_v = kp3d_scaled.copy()
+        if "canonical_to_world_R" in src["auxiliary"]:
+            c2w_R = src["auxiliary/canonical_to_world_R"][src_idx].astype(np.float32)
+            c2w_t = src["auxiliary/canonical_to_world_t"][src_idx].astype(np.float32) * s
+        else:
+            c2w_R = np.eye(3, dtype=np.float32)
+            c2w_t = np.zeros(3, dtype=np.float32)
+        if "canonical_cam_id" in src["auxiliary"]:
+            canonical_cam_id_out = int(src["auxiliary/canonical_cam_id"][src_idx])
+        else:
+            canonical_cam_id_out = int(np.argmax(view_mask_in))
+
+    # 4. Padded per-view output buffers.
+    kp2d_out = np.zeros((merged_max_views, n_joints, 2), dtype=np.float32)
+    vis_out = np.zeros((merged_max_views, n_joints), dtype=np.float32)
+    K_out = np.zeros((merged_max_views, 3, 3), dtype=np.float32)
+    R_out = np.zeros((merged_max_views, 3, 3), dtype=np.float32)
+    t_out = np.zeros((merged_max_views, 3), dtype=np.float32)
+    sizes_out = np.zeros((merged_max_views, 2), dtype=np.int32)
+    cam_idx_out = np.full((merged_max_views,), -1, dtype=np.int32)
+    view_mask_out = np.zeros((merged_max_views,), dtype=bool)
+
+    # 5. JPEG + K rescale per valid view.
+    for v in range(src_max_views):
+        if not view_mask_in[v]:
+            continue
+        # Resize image to jpeg_resolution and re-encode.
+        blob = src[f"multiview_images/image_jpeg_view_{v}"][src_idx]
+        img = _decode_jpeg(blob)
+        if img is None:
+            # Treat as missing view (defensive: shouldn't happen if view_mask=True).
+            continue
+        img_resized = _resize_image(img, jpeg_resolution)
+        new_blob = _encode_jpeg(img_resized, jpeg_quality)
+
+        # Rescale K from input image_sizes -> jpeg_resolution.
+        W_in_v, H_in_v = int(image_sizes_in[v, 0]), int(image_sizes_in[v, 1])
+        K_rescaled = _adjust_K_for_resolution(K_in[v], (W_in_v, H_in_v), jpeg_resolution)
+
+        # Slot index: use the same slot as the source so that camera_indices
+        # ordering is preserved within a sample. The cross-sample camera_indices
+        # meaning is already lost on a heterogeneous merge.
+        slot = v
+        handles["image_jpeg_datasets"][slot][out_idx] = np.frombuffer(new_blob, dtype=np.uint8)
+        kp2d_out[slot] = kp2d_in[v]            # [y/H, x/W] normalised — same numerically
+        vis_out[slot] = vis_in[v]
+        K_out[slot] = K_rescaled.astype(np.float32)
+        R_out[slot] = R_out_v[v].astype(np.float32)
+        t_out[slot] = t_out_v[v].astype(np.float32)
+        sizes_out[slot] = np.array([jpeg_resolution, jpeg_resolution], dtype=np.int32)
+        cam_idx_out[slot] = int(cam_idx_in[v]) if cam_idx_in[v] >= 0 else slot
+        view_mask_out[slot] = True
+
+    # 6. Shared per-sample fields. SLEAP placeholders (zeros) for trans /
+    # global_rot etc. stay zero (zero is zero in any frame). replicAnt
+    # real values are preserved.
+    global_rot = src["parameters/global_rot"][src_idx].astype(np.float32)
+    joint_rot = src["parameters/joint_rot"][src_idx].astype(np.float32)
+    betas = src["parameters/betas"][src_idx].astype(np.float32)
+    trans = (src["parameters/trans"][src_idx].astype(np.float64) * s).astype(np.float32)
+
+    # 7. Stream-write to output handles.
+    handles["view_mask"][out_idx] = view_mask_out
+    handles["keypoints_2d"][out_idx] = kp2d_out
+    handles["keypoint_visibility"][out_idx] = vis_out
+    handles["camera_indices"][out_idx] = cam_idx_out
+    handles["camera_intrinsics"][out_idx] = K_out
+    handles["camera_extrinsics_R"][out_idx] = R_out
+    handles["camera_extrinsics_t"][out_idx] = t_out
+    handles["image_sizes"][out_idx] = sizes_out
+    handles["keypoints_3d"][out_idx] = kp3d_out_v.astype(np.float32)
+
+    handles["global_rot"][out_idx] = global_rot
+    handles["joint_rot"][out_idx] = joint_rot
+    handles["betas"][out_idx] = betas
+    handles["trans"][out_idx] = trans
+
+    handles["has_3d_data"][out_idx] = has_3d
+    if "has_ground_truth_betas" in src["auxiliary"]:
+        handles["has_ground_truth_betas"][out_idx] = bool(src["auxiliary/has_ground_truth_betas"][src_idx])
+    else:
+        handles["has_ground_truth_betas"][out_idx] = False
+    handles["num_views"][out_idx] = int(view_mask_out.sum())
+    if "frame_idx" in src["auxiliary"]:
+        handles["frame_idx"][out_idx] = int(src["auxiliary/frame_idx"][src_idx])
+    else:
+        handles["frame_idx"][out_idx] = src_idx
+    if "session_name" in src["auxiliary"]:
+        sn = src["auxiliary/session_name"][src_idx]
+        if isinstance(sn, bytes):
+            sn = sn.decode("utf-8")
+        handles["session_name"][out_idx] = f"{info.path.stem}::{sn}"
+    else:
+        handles["session_name"][out_idx] = info.path.stem
+    if "camera_names" in src["auxiliary"]:
+        cn = src["auxiliary/camera_names"][src_idx]
+        if isinstance(cn, bytes):
+            cn = cn.decode("utf-8")
+        handles["camera_names"][out_idx] = cn
+    else:
+        handles["camera_names"][out_idx] = ""
+
+    handles["canonical_to_world_R"][out_idx] = c2w_R
+    handles["canonical_to_world_t"][out_idx] = c2w_t
+    handles["canonical_cam_id"][out_idx] = canonical_cam_id_out
+
+    handles["origin_dataset"][out_idx] = info.dataset_type
+    handles["origin_source_file"][out_idx] = str(info.path.name)
+    handles["origin_sample_idx"][out_idx] = src_idx
+
+
+# ---------------------------------------------------------------------------
+# Top-level merge.
+# ---------------------------------------------------------------------------
+
+
+def merge(
+    input_paths: List[Path],
+    output_path: Path,
+    jpeg_resolution: int,
+    jpeg_quality: int = 95,
+    chunk_size: int = 8,
+    compression: str = "gzip",
+    compression_level: int = 6,
+    backbone_name: str = "vit_large_patch16_224",
+    min_views_per_sample: int = 2,
+    max_samples_per_input: Optional[int] = None,
+    verbose: bool = True,
+) -> Dict[str, int]:
+    infos = validate_inputs(input_paths)
+
+    # Optionally cap each input for smoke testing. The infos' num_samples
+    # is used both for allocation and for the per-input write loop, so a
+    # single cap covers both.
+    if max_samples_per_input is not None:
+        for info in infos:
+            info.num_samples = min(info.num_samples, int(max_samples_per_input))
+
+    n_joints = infos[0].n_joints
+    n_pose = infos[0].n_pose
+    n_betas = infos[0].n_betas
+    merged_max_views = max(i.max_views for i in infos)
+    merged_num_samples = sum(i.num_samples for i in infos)
+
+    if verbose:
+        print(f"Merging {len(infos)} inputs:")
+        for i in infos:
+            print(f"  - {i.path.name}: dtype={i.dataset_type}, samples={i.num_samples}, "
+                  f"max_views={i.max_views}, world_scale={i.world_scale:g}, "
+                  f"jpeg={i.decoded_jpeg_hw[1]}x{i.decoded_jpeg_hw[0]}, "
+                  f"needs_canon={i.needs_canonicalization}")
+        print(f"Output: {merged_num_samples} samples, max_views={merged_max_views}, "
+              f"jpeg_resolution={jpeg_resolution}")
+        print()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with h5py.File(output_path, "w") as out_hf:
+        handles = _create_output_layout(
+            out_hf, merged_num_samples, merged_max_views,
+            n_joints, n_pose, n_betas, jpeg_resolution,
+            chunk_size, compression, compression_level,
+        )
+
+        out_idx = 0
+        per_input_written: Dict[str, int] = {}
+        for info in infos:
+            with h5py.File(info.path, "r") as src:
+                pbar = tqdm(range(info.num_samples), desc=info.path.name, disable=not verbose)
+                for src_idx in pbar:
+                    _copy_one_sample(
+                        src=src, src_idx=src_idx, info=info, handles=handles,
+                        out_idx=out_idx, merged_max_views=merged_max_views,
+                        jpeg_resolution=jpeg_resolution, jpeg_quality=jpeg_quality,
+                    )
+                    out_idx += 1
+                per_input_written[str(info.path)] = info.num_samples
+
+        # Metadata attrs. Schema mirrors the SLEAPMultiViewDataset reader's
+        # expectations. The new value `dataset_type='merged_multiview'` is
+        # not branched on by the reader.
+        md = handles["metadata"]
+        md.attrs["num_samples"] = int(out_idx)
+        md.attrs["max_views"] = int(merged_max_views)
+        md.attrs["n_joints"] = int(n_joints)
+        md.attrs["n_pose"] = int(n_pose)
+        md.attrs["n_betas"] = int(n_betas)
+        md.attrs["target_resolution"] = int(jpeg_resolution)
+        md.attrs["backbone_name"] = backbone_name
+        md.attrs["jpeg_quality"] = int(jpeg_quality)
+        md.attrs["dataset_type"] = "merged_multiview"
+        md.attrs["is_multiview"] = True
+        md.attrs["has_camera_parameters"] = True
+        md.attrs["has_3d_keypoints"] = True
+        md.attrs["load_3d_data"] = True
+        md.attrs["world_scale"] = 1.0
+        md.attrs["min_views_per_sample"] = int(min_views_per_sample)
+        md.attrs["camera_extrinsics_convention"] = "opencv"
+        # Per-slot canonical-camera-order is meaningless cross-source; the reader
+        # has a default fallback so this is mostly cosmetic.
+        md.attrs["canonical_camera_order"] = json.dumps(
+            [f"slot_{v}" for v in range(merged_max_views)]
+        )
+        # Provenance manifest.
+        md.attrs["source_files"] = json.dumps([
+            {"path": str(i.path), "dataset_type": i.dataset_type,
+             "num_samples": i.num_samples, "max_views": i.max_views,
+             "world_scale": i.world_scale,
+             "jpeg_resolution_input": [i.decoded_jpeg_hw[1], i.decoded_jpeg_hw[0]]}
+            for i in infos
+        ])
+
+    if verbose:
+        print(f"\nDone. Wrote {out_idx} samples to {output_path}")
+    return per_input_written
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--inputs", nargs="+", required=True,
+                   help="Input multi-view HDF5 paths. Order is preserved in the output sample axis.")
+    p.add_argument("--output", required=True, help="Output merged HDF5 path.")
+    p.add_argument("--jpeg_resolution", type=int, required=True,
+                   help="Target JPEG resolution (square). All inputs are decoded, "
+                        "resized to this resolution, and re-encoded; K is rescaled to match.")
+    p.add_argument("--jpeg_quality", type=int, default=95)
+    p.add_argument("--chunk_size", type=int, default=8)
+    p.add_argument("--compression", type=str, default="gzip")
+    p.add_argument("--compression_level", type=int, default=6)
+    p.add_argument("--backbone_name", type=str, default="vit_large_patch16_224")
+    p.add_argument("--min_views_per_sample", type=int, default=2)
+    p.add_argument("--max_samples_per_input", type=int, default=None,
+                   help="Cap each input to its first N samples (smoke testing only).")
+    p.add_argument("--quiet", action="store_true")
+    args = p.parse_args()
+
+    input_paths = [Path(s).resolve() for s in args.inputs]
+    output_path = Path(args.output).resolve()
+
+    merge(
+        input_paths=input_paths,
+        output_path=output_path,
+        jpeg_resolution=int(args.jpeg_resolution),
+        jpeg_quality=int(args.jpeg_quality),
+        chunk_size=int(args.chunk_size),
+        compression=str(args.compression),
+        compression_level=int(args.compression_level),
+        backbone_name=str(args.backbone_name),
+        min_views_per_sample=int(args.min_views_per_sample),
+        max_samples_per_input=args.max_samples_per_input,
+        verbose=not args.quiet,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/smal_fitter/sleap_data/prototype_canonicalize_sleap_sample.py
+++ b/smal_fitter/sleap_data/prototype_canonicalize_sleap_sample.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Prototype: canonical-camera-frame transformation for a SLEAP multi-view sample.
+
+Walks one sample from a SLEAPMultiViewDataset-format HDF5 through the
+exact transformation a merger script would apply, and visually + numerically
+verifies that the transformation preserves the camera <-> 3D <-> 2D
+relationship.
+
+What it does:
+
+1. Loads one sample (--sample_idx, default first with has_3d_data and all
+   max_views populated) from a SLEAP multi-view HDF5.
+2. Sanity-projects the stored `keypoints_3d` through the stored `(K, R, t)`
+   cameras and checks they reproduce the stored `keypoints_2d` (this is
+   the "data is internally consistent" baseline; if this fails, nothing
+   else can be trusted).
+3. Computes the canonical-camera-frame transform with `view_mask`'s first
+   True slot as the canonical camera. Formulas (column-vector OpenCV):
+       R'_v   = R_v @ R_0.T
+       t'_v   = t_v - R'_v @ t_0
+       X'_w   = R_0 @ X_w + t_0          (so kp3d' = kp3d @ R_0.T + t_0)
+   Cam 0 becomes (I, 0) by construction.
+4. Reprojects the canonicalized 3D keypoints through the canonicalized
+   cameras and compares to the stored 2D keypoints. Reprojection error
+   must equal the baseline error to within numerical precision (the
+   transform is rigid -> projection-invariant).
+5. Plots:
+     a) For each view: input image + stored 2D (green) + pre-transform
+        reprojection (blue) + post-transform reprojection (red x)
+     b) A 3D plot showing the original 3D keypoints + camera centres,
+        and the canonical-frame 3D + camera centres after the transform.
+     c) A summary panel with per-view max/mean reprojection errors and
+        the canonical-camera identity check.
+
+Usage (from repo root, inside WSL pytorch3d env):
+
+    python smal_fitter/sleap_data/prototype_canonicalize_sleap_sample.py \\
+        --hdf5 SMILymice_3D_6_cam_undistort.h5 \\
+        --sample_idx 0 \\
+        --output_png sleap_canonicalize_proto.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import cv2
+import h5py
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  (registers 3D projection)
+
+# Single source of truth for the canonical-frame transform — used by the
+# merger and by future SLEAP-preprocessor refactor work too.
+_THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_THIS_DIR.parent))  # smal_fitter/ on path
+from multiview_common.canonical_frame import (
+    canonicalize_sample,
+    cam_center_world,
+    project_world_to_pixel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Loading helpers.
+# ---------------------------------------------------------------------------
+
+
+def _decode_jpeg_view(jpeg_bytes: np.ndarray) -> Optional[np.ndarray]:
+    if jpeg_bytes is None or len(jpeg_bytes) == 0:
+        return None
+    bgr = cv2.imdecode(np.asarray(jpeg_bytes, dtype=np.uint8), cv2.IMREAD_COLOR)
+    if bgr is None:
+        return None
+    return cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+
+
+def _pick_sample_idx(hf: h5py.File, want_idx: Optional[int]) -> int:
+    """If user gave a sample_idx, use it. Otherwise pick the first sample with
+    has_3d_data=True AND all max_views slots populated (so the visualisation
+    has every view filled in)."""
+    if want_idx is not None:
+        return int(want_idx)
+
+    n = int(hf["metadata"].attrs["num_samples"])
+    max_views = int(hf["metadata"].attrs["max_views"])
+    has_3d = hf["auxiliary/has_3d_data"][:]
+    view_mask = hf["multiview_images/view_mask"][:]  # (N, max_views)
+
+    for i in range(n):
+        if bool(has_3d[i]) and int(view_mask[i].sum()) == max_views:
+            return i
+    # Fall back: first has_3d_data sample even if some views are masked.
+    for i in range(n):
+        if bool(has_3d[i]):
+            return i
+    raise RuntimeError("No sample with has_3d_data=True in this HDF5")
+
+
+def _load_sample(hdf5_path: Path, sample_idx: int):
+    """Read one sample's per-view fields and 3D keypoints."""
+    with h5py.File(hdf5_path, "r") as hf:
+        if sample_idx < 0:
+            sample_idx = _pick_sample_idx(hf, None)
+        max_views = int(hf["metadata"].attrs["max_views"])
+        n_joints = int(hf["metadata"].attrs["n_joints"])
+
+        view_mask = hf["multiview_images/view_mask"][sample_idx].astype(bool)
+        kp2d = hf["multiview_keypoints/keypoints_2d"][sample_idx].astype(np.float64)  # (V, J, 2) [y/H, x/W]
+        kp_vis = hf["multiview_keypoints/keypoint_visibility"][sample_idx].astype(np.float64)  # (V, J)
+        K = hf["multiview_keypoints/camera_intrinsics"][sample_idx].astype(np.float64)  # (V, 3, 3)
+        R = hf["multiview_keypoints/camera_extrinsics_R"][sample_idx].astype(np.float64)  # (V, 3, 3)
+        t = hf["multiview_keypoints/camera_extrinsics_t"][sample_idx].astype(np.float64)  # (V, 3)
+        image_sizes = hf["multiview_keypoints/image_sizes"][sample_idx].astype(np.int64)  # (V, 2)  (W, H)
+        kp3d = hf["multiview_keypoints/keypoints_3d"][sample_idx].astype(np.float64)  # (J, 3)
+        has_3d = bool(hf["auxiliary/has_3d_data"][sample_idx])
+
+        images = []
+        for v in range(max_views):
+            try:
+                blob = hf[f"multiview_images/image_jpeg_view_{v}"][sample_idx]
+            except KeyError:
+                blob = None
+            images.append(_decode_jpeg_view(blob))
+
+        # Effective world_scale: the SLEAP preprocessor doesn't write it; the
+        # reader heuristic kicks in when ||t|| > 50 and multiplies by 1e-3. We
+        # apply the same heuristic for the prototype so the reprojection check
+        # matches the reader's working frame.
+        world_scale_attr = hf["metadata"].attrs.get("world_scale", None)
+        if world_scale_attr is None:
+            t_norms = np.linalg.norm(t[view_mask], axis=1)
+            if t_norms.size and float(t_norms.max()) > 50.0:
+                world_scale = 1.0e-3
+            else:
+                world_scale = 1.0
+        else:
+            world_scale = float(world_scale_attr)
+
+    return {
+        "sample_idx": sample_idx,
+        "n_joints": n_joints,
+        "max_views": max_views,
+        "view_mask": view_mask,
+        "kp2d_norm_yx": kp2d,
+        "kp_vis": kp_vis,
+        "K": K,
+        "R": R,
+        "t": t,
+        "image_sizes": image_sizes,  # (V, 2) (W, H)
+        "kp3d": kp3d,
+        "has_3d": has_3d,
+        "images": images,
+        "world_scale": world_scale,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reprojection comparison.
+# ---------------------------------------------------------------------------
+
+
+def _kp2d_norm_yx_to_pixel_xy(kp2d_norm_yx: np.ndarray, img_W: int, img_H: int) -> np.ndarray:
+    """SLEAP stores 2D keypoints as normalized [y/H, x/W]. Convert to pixel [x, y]."""
+    px = kp2d_norm_yx[:, 1] * float(img_W)
+    py = kp2d_norm_yx[:, 0] * float(img_H)
+    return np.stack([px, py], axis=1)
+
+
+def per_view_reproj_error(
+    sample: dict, R: np.ndarray, t: np.ndarray, kp3d: np.ndarray
+) -> dict:
+    """Project kp3d through (K, R, t) for each valid view, compare to stored
+    2D. Returns per-view max/mean error in pixels (over visible AND has_gt_3d
+    joints only).
+
+    Note: no world_scale multiplier here. The reader scales both `t` and
+    `kp3d` uniformly at load time, which is a no-op for projection accuracy
+    (the z divides out). Projecting at raw units keeps the check honest.
+    """
+    view_mask = sample["view_mask"]
+    kp_vis = sample["kp_vis"]
+    image_sizes = sample["image_sizes"]
+    K_all = sample["K"]
+    kp2d_norm = sample["kp2d_norm_yx"]
+
+    has_gt_3d = ~np.all(kp3d == 0, axis=1)
+
+    per_view = {}
+    for v in range(len(R)):
+        if not view_mask[v]:
+            continue
+        W, H = int(image_sizes[v, 0]), int(image_sizes[v, 1])
+        gt_pix = _kp2d_norm_yx_to_pixel_xy(kp2d_norm[v], W, H)  # (J, 2)
+        pred_pix = project_world_to_pixel(kp3d, R[v], t[v], K_all[v])  # (J, 2)
+        mask = has_gt_3d & (kp_vis[v] > 0)
+        if not mask.any():
+            per_view[v] = {"max": np.nan, "mean": np.nan, "n": 0}
+            continue
+        err = np.linalg.norm(pred_pix[mask] - gt_pix[mask], axis=1)
+        per_view[v] = {
+            "max": float(np.nanmax(err)),
+            "mean": float(np.nanmean(err)),
+            "n": int(mask.sum()),
+        }
+    return per_view
+
+
+# ---------------------------------------------------------------------------
+# Plotting.
+# ---------------------------------------------------------------------------
+
+
+# cam_center_world is imported from multiview_common.canonical_frame.
+_cam_center = cam_center_world
+
+
+def make_plot(
+    sample: dict,
+    R_orig: np.ndarray,
+    t_orig: np.ndarray,
+    kp3d_orig: np.ndarray,
+    R_can: np.ndarray,
+    t_can: np.ndarray,
+    kp3d_can: np.ndarray,
+    canonical_v: int,
+    err_pre: dict,
+    err_post: dict,
+    out_png: Path,
+) -> None:
+    view_mask = sample["view_mask"]
+    image_sizes = sample["image_sizes"]
+    K = sample["K"]
+    kp2d_norm = sample["kp2d_norm_yx"]
+    kp_vis = sample["kp_vis"]
+    images = sample["images"]
+    valid_v = [int(v) for v in np.where(view_mask)[0]]
+    V = len(valid_v)
+
+    fig = plt.figure(figsize=(4 * V, 14))
+    gs = fig.add_gridspec(3, max(V, 2), height_ratios=[1.2, 1.0, 0.8])
+
+    # Row 1: per-view image overlays.
+    # Note: SLEAP HDF5 stores the resized 224x224 JPEG but the calibration K +
+    # 2D keypoints are in the original 1280x1024 frame. We stretch the image
+    # over the calibration extent so the keypoint overlays land correctly.
+    for col, v in enumerate(valid_v):
+        ax = fig.add_subplot(gs[0, col])
+        W, H = int(image_sizes[v, 0]), int(image_sizes[v, 1])
+        img = images[v]
+        if img is None:
+            ax.set_facecolor("gray")
+            ax.set_xlim(0, W)
+            ax.set_ylim(H, 0)
+        else:
+            ax.imshow(img, extent=(0, W, H, 0))
+        gt_pix = _kp2d_norm_yx_to_pixel_xy(kp2d_norm[v], W, H)
+        pre_pix = project_world_to_pixel(kp3d_orig, R_orig[v], t_orig[v], K[v])
+        post_pix = project_world_to_pixel(kp3d_can, R_can[v], t_can[v], K[v])
+        vis = (kp_vis[v] > 0) & ~np.all(kp3d_orig == 0, axis=1)
+        ax.scatter(gt_pix[vis, 0], gt_pix[vis, 1], s=22, marker="o",
+                   facecolors="none", edgecolors="lime", linewidths=1.5, label="stored 2D")
+        ax.scatter(pre_pix[vis, 0], pre_pix[vis, 1], s=10, marker="s",
+                   c="cornflowerblue", label="proj (original)")
+        ax.scatter(post_pix[vis, 0], post_pix[vis, 1], s=24, marker="x",
+                   c="red", linewidths=1.2, label="proj (canonical)")
+        title = f"view {v} ({'canonical' if v == canonical_v else 'other'})\n"
+        title += f"pre max={err_pre[v]['max']:.3g}px  post max={err_post[v]['max']:.3g}px"
+        ax.set_title(title, fontsize=9)
+        ax.set_xticks([]); ax.set_yticks([])
+        if col == 0:
+            ax.legend(loc="lower right", fontsize=7)
+
+    # Row 2: 3D views (left = original world, right = canonical frame).
+    has_gt_3d = ~np.all(kp3d_orig == 0, axis=1)
+
+    ax3d_a = fig.add_subplot(gs[1, : max(V // 2, 1)], projection="3d")
+    ax3d_a.set_title("Original world frame", fontsize=10)
+    ax3d_a.scatter(kp3d_orig[has_gt_3d, 0],
+                   kp3d_orig[has_gt_3d, 1],
+                   kp3d_orig[has_gt_3d, 2],
+                   c="black", s=8, label="kp3d")
+    for v in valid_v:
+        c = _cam_center(R_orig[v], t_orig[v])
+        col = "red" if v == canonical_v else "gray"
+        ax3d_a.scatter(c[0], c[1], c[2], c=col, s=30, marker="^")
+        ax3d_a.text(c[0], c[1], c[2], f" cam{v}", fontsize=7, color=col)
+    ax3d_a.set_xlabel("X"); ax3d_a.set_ylabel("Y"); ax3d_a.set_zlabel("Z")
+
+    ax3d_b = fig.add_subplot(gs[1, max(V // 2, 1):], projection="3d")
+    ax3d_b.set_title(f"Canonical frame (cam {canonical_v} at origin)", fontsize=10)
+    ax3d_b.scatter(kp3d_can[has_gt_3d, 0],
+                   kp3d_can[has_gt_3d, 1],
+                   kp3d_can[has_gt_3d, 2],
+                   c="black", s=8)
+    for v in valid_v:
+        c = _cam_center(R_can[v], t_can[v])
+        col = "red" if v == canonical_v else "gray"
+        ax3d_b.scatter(c[0], c[1], c[2], c=col, s=30, marker="^")
+        ax3d_b.text(c[0], c[1], c[2], f" cam{v}", fontsize=7, color=col)
+    ax3d_b.set_xlabel("X"); ax3d_b.set_ylabel("Y"); ax3d_b.set_zlabel("Z")
+
+    # Row 3: text summary.
+    ax_txt = fig.add_subplot(gs[2, :])
+    ax_txt.axis("off")
+    lines = [
+        f"sample_idx = {sample['sample_idx']}",
+        f"max_views (HDF5)   = {sample['max_views']}",
+        f"valid views        = {len(valid_v)} -> {valid_v}",
+        f"canonical view     = {canonical_v}",
+        f"keypoints with GT 3D = {int(has_gt_3d.sum())} / {len(kp3d_orig)}",
+        "",
+        "Cam canonical identity check (post-transform):",
+        f"  ||R_can[{canonical_v}] - I||_max = {np.max(np.abs(R_can[canonical_v] - np.eye(3))):.3e}",
+        f"  ||t_can[{canonical_v}]||_max     = {np.max(np.abs(t_can[canonical_v])):.3e}",
+        "",
+        "Per-view reprojection error (pixels):",
+    ]
+    for v in valid_v:
+        a, b = err_pre[v], err_post[v]
+        lines.append(
+            f"  cam {v:>2}: pre max={a['max']:8.4g}, post max={b['max']:8.4g} "
+            f"| pre mean={a['mean']:8.4g}, post mean={b['mean']:8.4g} (n={a['n']})"
+        )
+    pre_max_all = np.nanmax([err_pre[v]["max"] for v in valid_v])
+    post_max_all = np.nanmax([err_post[v]["max"] for v in valid_v])
+    lines.append("")
+    lines.append(f"  ALL views: pre max = {pre_max_all:.4g} px, post max = {post_max_all:.4g} px")
+    lines.append(f"  delta (post - pre, max) = {post_max_all - pre_max_all:+.4g} px")
+    ax_txt.text(0.0, 1.0, "\n".join(lines), family="monospace", fontsize=9, va="top")
+
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=110)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--hdf5", required=True, help="SLEAP multi-view HDF5 path")
+    p.add_argument("--sample_idx", type=int, default=-1,
+                   help="Sample to use (default: first with has_3d_data=True and all views populated)")
+    p.add_argument("--output_png", type=str, default="sleap_canonicalize_proto.png")
+    p.add_argument("--no_world_scale", action="store_true",
+                   help="Skip the SLEAP reader's mm->m world_scale heuristic (debugging)")
+    args = p.parse_args()
+
+    hdf5_path = Path(args.hdf5)
+    if not hdf5_path.is_file():
+        print(f"HDF5 not found: {hdf5_path}", file=sys.stderr)
+        sys.exit(2)
+
+    sample = _load_sample(hdf5_path, args.sample_idx)
+    if args.no_world_scale:
+        sample["world_scale"] = 1.0
+
+    print(f"Loaded sample {sample['sample_idx']} from {hdf5_path.name}")
+    print(f"  max_views = {sample['max_views']}, valid = {int(sample['view_mask'].sum())}")
+    print(f"  has_3d_data = {sample['has_3d']}")
+
+    R_orig = sample["R"]
+    t_orig = sample["t"]
+    kp3d_orig = sample["kp3d"]
+
+    # Baseline reprojection (no canonical transform). Operates on raw units —
+    # world_scale is a uniform train-time rescale, so it doesn't affect
+    # projection accuracy and we omit it here for honesty.
+    err_pre = per_view_reproj_error(sample, R_orig, t_orig, kp3d_orig)
+
+    # Canonical-frame transform.
+    R_can, t_can, kp3d_can, R_0, t_0, canonical_v = canonicalize_sample(
+        R_orig, t_orig, kp3d_orig, sample["view_mask"]
+    )
+
+    err_post = per_view_reproj_error(sample, R_can, t_can, kp3d_can)
+
+    # Identity sanity.
+    R_id_err = float(np.max(np.abs(R_can[canonical_v] - np.eye(3))))
+    t_id_err = float(np.max(np.abs(t_can[canonical_v])))
+    print(f"Canonical view = {canonical_v}")
+    print(f"  ||R'_{canonical_v} - I||_max = {R_id_err:.3e}")
+    print(f"  ||t'_{canonical_v}||_max     = {t_id_err:.3e}")
+
+    print("Per-view reprojection error (pixels, on visible+has_3d joints):")
+    valid_v = [int(v) for v in np.where(sample["view_mask"])[0]]
+    for v in valid_v:
+        a, b = err_pre[v], err_post[v]
+        print(f"  cam {v:>2}: pre max={a['max']:8.4g} mean={a['mean']:8.4g} | "
+              f"post max={b['max']:8.4g} mean={b['mean']:8.4g} (n={a['n']})")
+    pre_max_all = float(np.nanmax([err_pre[v]["max"] for v in valid_v]))
+    post_max_all = float(np.nanmax([err_post[v]["max"] for v in valid_v]))
+    print(f"  ALL views: pre max={pre_max_all:.4g}px, post max={post_max_all:.4g}px, "
+          f"delta={post_max_all - pre_max_all:+.4g}px")
+
+    make_plot(sample, R_orig, t_orig, kp3d_orig, R_can, t_can, kp3d_can,
+              canonical_v, err_pre, err_post, Path(args.output_png))
+    print(f"Plot written to {args.output_png}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a cross-source multi-view dataset merger that produces a single uniform-convention HDF5 from an arbitrary combination of SLEAP-format and replicAnt-format inputs. The trainer reads the merged file via the existing `SLEAPMultiViewDataset` unchanged.

Also lands a shared `multiview_common` module with the canonical-camera-frame geometry math and a per-sample diagnostic prototype — both useful on their own and required by the merger.

### Why a merger is non-trivial

The two source formats agree on the on-disk schema but differ on three load-bearing conventions. Naively concatenating samples produces a file that breaks the trainer's shared `trans` head because the same image features are forced to map to different ground-truth values across batches:

1. **Camera + 3D frame.** replicAnt stores cam-0 in OpenCV form ≈ `Rz_180` so the reader's PyTorch3D inverse hands the trainer cam-0 = `(I, 0)` — the convention the model is trained against. SLEAP stores raw rig-world calibration, giving an arbitrary per-session cam-0. Mixed-source training without normalisation breaks consistency.
2. **`world_scale`.** SLEAP omits the attribute; the reader infers `0.001` from `||t|| > 50` (mm → m). replicAnt writes `1.0` and bakes `translation_factor=0.1` in at load time.
3. **JPEG vs `image_sizes` / `K` resolution.** SLEAP stores 224×224 JPEGs with `K` calibrated for the original 1280×1024 frame. replicAnt is self-consistent at native 512×512.

### What landed

#### `multiview_common.canonical_frame` (`49be2d0`)

Single source of truth for column-vector OpenCV canonical-camera-frame math:

- `canonicalize_sample(R, t, kp3d, view_mask)` — picks the lowest-index valid view as canonical, re-expresses every other view + the 3D keypoints in that camera's frame. `(0, 0, 0)` sentinel for joints without GT preserved exactly.
- `align_to_pytorch3d_reader_convention(...)` — applies the `Rz_180` world-frame shift so post-canonicalise OpenCV cam-0 lands at `Rz_180`, matching what the replicAnt preprocessor emits. With this alignment, the reader's PyTorch3D inverse gives cam-0 = `(I, 0)` for every sample regardless of source.
- `infer_world_scale(t, view_mask)` — mirrors the `SLEAPMultiViewDataset` reader's `||t|| > 50` heuristic.
- `project_world_to_pixel`, `cam_center_world`, `RZ_180`.

Docstrings reference HMR (Kanazawa et al., CVPR 2018), ExPose (Choutas et al., ECCV 2020), AGORA (Patel et al., CVPR 2021), 4D-Humans / SLAHMR (Goel et al., ICCV 2023), FreeMan (Wang et al., CVPR 2024), and EFT (Joo et al., 3DV 2021) for canonical-camera-frame convention; Hartley & Zisserman ch. 6 + OpenCV docs for projection algebra.

#### SLEAP canonicalization prototype (`aa78d50`)

[`smal_fitter/sleap_data/prototype_canonicalize_sleap_sample.py`](smal_fitter/sleap_data/prototype_canonicalize_sleap_sample.py) — loads one sample from a SLEAP HDF5, runs it through `canonicalize_sample`, reprojects the canonicalised 3D keypoints through the canonicalised cameras, and writes a per-view + 3D overlay plot. Verifies cam-0 self-check and that the transform is geometrically lossless (post-transform error matches pre-transform error to within numerical noise).

Two SLEAP-specific quirks surfaced during prototype work and noted in code comments:

- Standard column-vector OpenCV (`X_cam = R @ X_world + t`) is correct. The 3D loader's `use_alternative_convention` flag empirically produces 250-2400 px reprojection error on disk-stored SLEAP data — do not enable it for the merger.
- `K`, `image_sizes`, and 2D keypoints are in the original calibration frame; `image_jpeg_view_v` is at `target_resolution`. For overlay plots stretch the JPEG to the calibration extent at draw time.

#### Cross-source merger (`e0c1e79`)

[`smal_fitter/multiview_common/merge_multiview_datasets.py`](smal_fitter/multiview_common/merge_multiview_datasets.py) — full merger script with CLI.

- Validates skeleton compatibility hard (`n_joints`, `n_pose`, `n_betas` must agree; refuses mismatched SMAL pickles).
- Pre-applies per-input `world_scale` to `t` and `kp3d` so the output declares `world_scale=1.0` universally.
- For non-`replicant_multiview` inputs: `canonicalize_sample` + `align_to_pytorch3d_reader_convention`. For `replicant_multiview`: passthrough (already in target convention).
- Decodes / resizes / re-encodes every JPEG to `--jpeg_resolution`; rescales `K` accordingly. Fixes SLEAP's internal `K`-vs-JPEG mismatch as a side effect.
- Per-sample variable view counts handled via `view_mask` / `camera_indices=-1` padding.
- Per-sample provenance: `/auxiliary/origin_dataset`, `origin_source_file`, `origin_sample_idx`. `/metadata/source_files` JSON manifest.

CLI:
```
python smal_fitter/multiview_common/merge_multiview_datasets.py \
    --inputs SMILymice_3D_6_cam_undistort.h5 replicant_multiview_mice.h5 \
    --output merged.h5 \
    --jpeg_resolution 512
```

`--max_samples_per_input N` available for smoke testing.

## Test plan

- [x] **Cam-0 alignment, OpenCV form** (10-sample smoke): max `||R - Rz_180||` = 1.2e-7, max `||t||` = 1.7e-6 across both source types.
- [x] **Cam-0 alignment, PyTorch3D form (post-reader)**: max `||R - I||` = 1.2e-7 for both SLEAP and replicAnt samples. Uniform world frame downstream.
- [x] **Reprojection preserved**:
  - replicAnt samples (passthrough): max 0.0003 px (numerical precision).
  - SLEAP samples: 67 px @ 1280×1024 → 16 px @ 256×256 — error scales with resolution, no merger artefact (residual is inherent SLEAP calibration noise).
- [x] **Reader compatibility**: `SLEAPMultiViewDataset` reads `merged_smoke.h5` without errors; SLEAP samples return 6 views, replicAnt samples return 12 views, `view_mask` filtering works.
- [x] **Provenance**: `/auxiliary/origin_dataset`, `origin_source_file`, `origin_sample_idx`, and `num_views` per sample all populate correctly.
- [x] **Schema hard-assertions**: skeleton mismatch refused with a clear error.

## What's deferred

- **Training SMOKE on a merged HDF5**: out of scope for this PR — the merger produces a uniform-frame file the trainer can already consume via `SLEAPMultiViewDataset`. Worth running on a real merge before kicking off a production multi-source training run.
- **SLEAP preprocessor refactor**: the SLEAP-side preprocessor still emits raw rig-world extrinsics and the calibration-vs-JPEG resolution mismatch. The merger fixes both at write time, so this isn't blocking. A future PR can move the canonicalisation upstream into the preprocessor using the same `multiview_common.canonical_frame` helpers (zero-duplication).
- **Reader-time normalisation**: an alternative architecture would push canonicalisation into `SLEAPMultiViewDataset`. Out of scope; the merger is the minimum delta for cross-source training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
