### PR TITLE
Streamlit dataset viewer + SMAL mesh renderer

### DIFF
--- a/smal_fitter/multiview_common/canonical_frame.py
+++ b/smal_fitter/multiview_common/canonical_frame.py
@@ -194,6 +194,22 @@ def cam_center_world(R: np.ndarray, t: np.ndarray) -> np.ndarray:
     return -np.asarray(R, dtype=np.float64).T @ np.asarray(t, dtype=np.float64)
 
 
+def kp2d_norm_yx_to_pixel_xy(kp2d_norm_yx: np.ndarray, img_W: int, img_H: int) -> np.ndarray:
+    """Convert SLEAP/replicAnt-stored 2D keypoints from normalized `[y/H, x/W]`
+    to pixel `[x, y]` coordinates.
+
+    Both preprocessor paths store 2D keypoints with the intentional axis
+    swap `(kp[:, 0] = y/H, kp[:, 1] = x/W)` — see
+    `smal_fitter/Unreal2Pytorch3D.py` and the SLEAP `map_keypoints_to_smal_model`.
+    This helper inverts the swap for projection / overlay drawing /
+    comparison against `project_world_to_pixel` output.
+    """
+    kp = np.asarray(kp2d_norm_yx, dtype=np.float64)
+    px = kp[..., 1] * float(img_W)
+    py = kp[..., 0] * float(img_H)
+    return np.stack([px, py], axis=-1)
+
+
 # Rz_180: 180-degree rotation about the world Z-axis. The replicAnt-side
 # multi-view preprocessor (see smal_fitter/replicAnt_data/preprocess_…)
 # applies this when converting its loader's PyTorch3D-row-vector canonical

--- a/smal_fitter/multiview_common/dataset_viewer.py
+++ b/smal_fitter/multiview_common/dataset_viewer.py
@@ -40,8 +40,19 @@ _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE.parent))  # smal_fitter/ on path
 from multiview_common.canonical_frame import (  # noqa: E402
     cam_center_world,
+    kp2d_norm_yx_to_pixel_xy,
     project_world_to_pixel,
 )
+# SMAL rendering is an optional add-on (model + PyTorch3D). Failure to
+# import does NOT block the viewer; we just disable the SMAL features.
+try:
+    from multiview_common.smal_render import SMALRendererWrapper, overlay_silhouette  # noqa: E402
+    _SMAL_AVAILABLE = True
+except Exception as _e:  # pragma: no cover
+    SMALRendererWrapper = None  # type: ignore
+    overlay_silhouette = None  # type: ignore
+    _SMAL_AVAILABLE = False
+    _SMAL_IMPORT_ERR = str(_e)
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +205,170 @@ def _decode_jpeg(blob) -> Optional[np.ndarray]:
 
 
 # ---------------------------------------------------------------------------
+# SMAL forward + silhouette rendering (cached).
+# ---------------------------------------------------------------------------
+
+
+def _auto_detect_smal_pkl(meta: Dict[str, object]) -> Optional[str]:
+    """Return a SMAL pkl path if any preprocessor recorded one in /metadata.
+    Checks several plausible attr names. None of the current preprocessors
+    write this attr — left as forward-compatible hook."""
+    for key in ("smal_file", "smal_model_path", "smal_pkl", "smal_file_path"):
+        v = meta.get(key)
+        if v is None:
+            continue
+        s = v.decode("utf-8") if isinstance(v, bytes) else str(v)
+        if s and Path(s).is_file():
+            return s
+    return None
+
+
+# Repo root inferred from this file's location: smal_fitter/multiview_common/dataset_viewer.py
+_REPO_ROOT_FOR_PKL_SCAN = _HERE.parent.parent
+
+
+@st.cache_data(show_spinner=False)
+def _discover_smal_pkls() -> list:
+    """Scan a few likely locations under the repo for .pkl candidates.
+    Returns relative-path strings sorted for stable presentation. Avoids
+    a recursive walk of the whole tree — too slow on large checkouts."""
+    candidates: list = []
+    scan_dirs = [
+        _REPO_ROOT_FOR_PKL_SCAN / "3D_model_prep",
+        _REPO_ROOT_FOR_PKL_SCAN / "smal_model" / "data",
+        _REPO_ROOT_FOR_PKL_SCAN,   # top-level only, no recursion
+    ]
+    seen = set()
+    for d in scan_dirs:
+        if not d.is_dir():
+            continue
+        # Only direct children to keep this cheap and predictable.
+        for f in sorted(d.glob("*.pkl")):
+            rel = str(f.resolve())
+            if rel in seen:
+                continue
+            seen.add(rel)
+            candidates.append(rel)
+    return candidates
+
+
+def _normalize_path_for_wsl(path_str: str) -> str:
+    """Convert a Windows-style path (e.g. C:\\Users\\Fabian\\foo) to its
+    WSL equivalent (/mnt/c/Users/Fabian/foo) when running inside WSL.
+    No-op on POSIX inputs or when not running in WSL."""
+    if not path_str:
+        return path_str
+    s = path_str.strip().strip('"').strip("'")
+    # Windows drive-letter form: "C:\path\to\file" or "C:/path/to/file".
+    if len(s) >= 3 and s[1] == ":" and s[2] in ("\\", "/"):
+        drive = s[0].lower()
+        tail = s[2:].replace("\\", "/")
+        return f"/mnt/{drive}{tail}"
+    return s.replace("\\", "/")
+
+
+def _sample_has_real_pose(sample: Dict[str, object]) -> bool:
+    """True iff the per-sample SMAL parameters look like real ground truth
+    rather than the zero placeholder SLEAP samples carry."""
+    # We probe the parameters group on demand because the cached sample
+    # dict doesn't include them by default. The caller is responsible for
+    # providing these fields.
+    jr = sample.get("joint_rot")
+    gr = sample.get("global_rot")
+    if jr is None or gr is None:
+        return False
+    return bool(np.any(np.asarray(jr) != 0.0) or np.any(np.asarray(gr) != 0.0))
+
+
+@st.cache_data(show_spinner=False)
+def _read_pose_params(path: str, sample_idx: int) -> Dict[str, np.ndarray]:
+    """Extra per-sample pose params needed for SMAL forward. Cached
+    separately from `_read_sample` so the SMAL path is opt-in."""
+    with h5py.File(path, "r") as f:
+        return {
+            "betas": f["parameters/betas"][sample_idx].astype(np.float32),
+            "global_rot": f["parameters/global_rot"][sample_idx].astype(np.float32),
+            "joint_rot": f["parameters/joint_rot"][sample_idx].astype(np.float32),
+            "trans": f["parameters/trans"][sample_idx].astype(np.float32),
+        }
+
+
+@st.cache_resource(show_spinner="Loading SMAL model…")
+def _get_smal_renderer(smal_pkl: str, render_size: int):
+    """Load the SMAL pkl + PyTorch3D Renderer once per (pkl, render_size).
+    Streamlit reruns the script on every interaction; this cache keeps the
+    expensive model load from re-firing."""
+    if not _SMAL_AVAILABLE:
+        return None
+    return SMALRendererWrapper(
+        smal_file=smal_pkl, render_size=int(render_size), device="cpu",
+    )
+
+
+@st.cache_data(show_spinner=False)
+def _smal_forward_for_sample(path: str, sample_idx: int, smal_pkl: str) -> Optional[Dict[str, np.ndarray]]:
+    """SMAL forward for one sample. Cached by (path, sample_idx, pkl) so the
+    forward only fires when one of those changes."""
+    if not _SMAL_AVAILABLE:
+        return None
+    params = _read_pose_params(path, sample_idx)
+    if not (np.any(params["joint_rot"] != 0) or np.any(params["global_rot"] != 0)):
+        return None
+    renderer = _get_smal_renderer(smal_pkl, render_size=256)
+    if renderer is None:
+        return None
+    try:
+        posed = renderer.forward(
+            betas=params["betas"],
+            global_rot=params["global_rot"],
+            joint_rot=params["joint_rot"],
+            trans=params["trans"],
+            propagate_scaling=False,
+        )
+    except Exception as e:
+        st.warning(f"SMAL forward failed: {type(e).__name__}: {e}")
+        return None
+    return {
+        "vertices_world": posed.vertices_world,
+        "joints_world": posed.joints_world,
+        "faces": posed.faces,
+    }
+
+
+@st.cache_data(show_spinner="Rendering silhouettes…")
+def _render_silhouettes_for_sample(
+    path: str, sample_idx: int, smal_pkl: str, render_size: int,
+) -> Optional[Dict[int, np.ndarray]]:
+    """Per-view silhouette mask in [0, 1], one per valid view.
+    Cached by (path, sample_idx, pkl, render_size) so the click-to-render
+    button only does work the first time."""
+    if not _SMAL_AVAILABLE:
+        return None
+    forward = _smal_forward_for_sample(path, sample_idx, smal_pkl)
+    if forward is None:
+        return None
+    renderer = _get_smal_renderer(smal_pkl, render_size=int(render_size))
+    if renderer is None:
+        return None
+    sample = _read_sample(path, sample_idx)
+    sils: Dict[int, np.ndarray] = {}
+    for v in range(sample["max_views"]):
+        if not sample["view_mask"][v]:
+            continue
+        try:
+            sil = renderer.render_silhouette(
+                verts_world=forward["vertices_world"],
+                faces=forward["faces"],
+                R_cv=sample["R"][v], t_cv=sample["t"][v], K=sample["K"][v],
+                image_size_wh=sample["image_sizes_wh"][v],
+            )
+            sils[v] = sil
+        except Exception as e:
+            st.warning(f"Silhouette render failed on view {v}: {type(e).__name__}: {e}")
+    return sils
+
+
+# ---------------------------------------------------------------------------
 # Per-view overlay rendering.
 # ---------------------------------------------------------------------------
 
@@ -207,6 +382,8 @@ def _draw_overlay(
     image_sizes_wh: Tuple[int, int],  # (W_calib, H_calib) — K is calibrated for this
     show_gt: bool,
     show_reproj: bool,
+    smal_joints_world: Optional[np.ndarray] = None,   # (J, 3) — posed SMAL joints
+    silhouette: Optional[np.ndarray] = None,          # (S, S) [0, 1]
 ) -> np.ndarray:
     """Stretch the JPEG to the calibration frame's aspect, then overlay GT
     and projected-3D keypoints. Visibility codes opacity / fill.
@@ -228,13 +405,14 @@ def _draw_overlay(
 
     has_gt_3d = ~np.all(kp3d == 0, axis=1)
     n_joints = kp2d_norm_yx.shape[0]
+    gt_pixels = kp2d_norm_yx_to_pixel_xy(kp2d_norm_yx, W_calib, H_calib)  # (J, 2) [x, y]
 
     if show_gt:
         for j in range(n_joints):
             if kp_vis[j] <= 0:
                 continue
-            px = int(round(float(kp2d_norm_yx[j, 1]) * W_calib))
-            py = int(round(float(kp2d_norm_yx[j, 0]) * H_calib))
+            px = int(round(float(gt_pixels[j, 0])))
+            py = int(round(float(gt_pixels[j, 1])))
             if not (0 <= px < W_calib and 0 <= py < H_calib):
                 continue
             cv2.circle(canvas, (px, py), max(3, W_calib // 200), (60, 220, 60), 2)
@@ -255,6 +433,31 @@ def _draw_overlay(
             cv2.line(canvas, (px - r, py - r), (px + r, py + r), (230, 60, 60), 2)
             cv2.line(canvas, (px - r, py + r), (px + r, py - r), (230, 60, 60), 2)
 
+    if silhouette is not None and overlay_silhouette is not None:
+        canvas = overlay_silhouette(
+            canvas, silhouette, np.array([W_calib, H_calib]),
+            colour=(255, 130, 30), alpha=0.40,
+        )
+
+    if smal_joints_world is not None:
+        proj_smal = project_world_to_pixel(smal_joints_world, R, t, K)
+        for j in range(len(proj_smal)):
+            xy = proj_smal[j]
+            if np.any(np.isnan(xy)):
+                continue
+            px = int(round(float(xy[0])))
+            py = int(round(float(xy[1])))
+            if not (0 <= px < W_calib and 0 <= py < H_calib):
+                continue
+            r = max(3, W_calib // 220)
+            # Filled orange triangle (cv2 has no triangle marker, draw polygon).
+            pts = np.array([
+                [px, py - r],
+                [px - r, py + r],
+                [px + r, py + r],
+            ], dtype=np.int32)
+            cv2.fillPoly(canvas, [pts], (255, 165, 0))
+
     return canvas
 
 
@@ -269,10 +472,7 @@ def _per_view_reproj_max(sample: Dict[str, object]) -> Dict[int, float]:
         if not view_mask[v]:
             continue
         W, H = int(sample["image_sizes_wh"][v, 0]), int(sample["image_sizes_wh"][v, 1])
-        gt = np.stack([
-            sample["kp2d_norm_yx"][v, :, 1] * W,
-            sample["kp2d_norm_yx"][v, :, 0] * H,
-        ], axis=1)
+        gt = kp2d_norm_yx_to_pixel_xy(sample["kp2d_norm_yx"][v], W, H)
         pr = project_world_to_pixel(kp3d, sample["R"][v], sample["t"][v], sample["K"][v])
         mask = has_gt_3d & (sample["kp_vis"][v] > 0)
         if not mask.any():
@@ -288,7 +488,10 @@ def _per_view_reproj_max(sample: Dict[str, object]) -> Dict[int, float]:
 # ---------------------------------------------------------------------------
 
 
-def _build_3d_figure(sample: Dict[str, object]) -> go.Figure:
+def _build_3d_figure(
+    sample: Dict[str, object],
+    smal_forward: Optional[Dict[str, np.ndarray]] = None,
+) -> go.Figure:
     R = sample["R"]
     t = sample["t"]
     kp3d = sample["kp3d"]
@@ -303,6 +506,24 @@ def _build_3d_figure(sample: Dict[str, object]) -> go.Figure:
             marker=dict(size=4, color="black"),
             name=f"kp3d (n={int(has_gt_3d.sum())})",
         ))
+
+    if smal_forward is not None:
+        verts = smal_forward["vertices_world"]
+        faces = smal_forward["faces"]
+        joints = smal_forward["joints_world"]
+        fig.add_trace(go.Mesh3d(
+            x=verts[:, 0], y=verts[:, 1], z=verts[:, 2],
+            i=faces[:, 0], j=faces[:, 1], k=faces[:, 2],
+            color="orange", opacity=0.35, flatshading=True,
+            name="SMAL mesh", showscale=False,
+        ))
+        fig.add_trace(go.Scatter3d(
+            x=joints[:, 0], y=joints[:, 1], z=joints[:, 2],
+            mode="markers",
+            marker=dict(size=4, color="orange", symbol="diamond"),
+            name=f"SMAL joints (n={len(joints)})",
+        ))
+
     cam_xyz, cam_labels = [], []
     for v in range(len(R)):
         if not view_mask[v]:
@@ -368,7 +589,7 @@ def _all_sample_reproj_errors(path: str, max_samples: int) -> Dict[str, np.ndarr
                 if not use.any():
                     continue
                 W, H = int(sz_d[i, v, 0]), int(sz_d[i, v, 1])
-                gt = np.stack([kp2d_d[i, v, :, 1] * W, kp2d_d[i, v, :, 0] * H], axis=1)
+                gt = kp2d_norm_yx_to_pixel_xy(kp2d_d[i, v], W, H)
                 pr = project_world_to_pixel(kp3d, R_d[i, v], t_d[i, v], K_d[i, v])
                 err = float(np.nanmax(np.linalg.norm(pr[use] - gt[use], axis=1)))
                 if err > best:
@@ -410,9 +631,25 @@ def _ui_metadata(meta: Dict[str, object]) -> None:
         st.json(rendered)
 
 
-def _ui_sample(path: str, sample_idx: int, show_2d: bool, show_reproj: bool, show_3d: bool) -> None:
+def _ui_sample(
+    path: str,
+    sample_idx: int,
+    show_2d: bool,
+    show_reproj: bool,
+    show_3d: bool,
+    show_smal_3d: bool,
+    show_smal_2d: bool,
+    smal_pkl: Optional[str],
+    silhouettes: Optional[Dict[int, np.ndarray]],
+) -> None:
     sample = _read_sample(path, sample_idx)
     valid_v = [int(v) for v in np.where(sample["view_mask"])[0]]
+
+    # SMAL forward (cached). Returns None when SMAL is unavailable, the
+    # sample has only placeholder joint angles, or the forward errored.
+    smal_forward: Optional[Dict[str, np.ndarray]] = None
+    if smal_pkl and (show_smal_3d or show_smal_2d or silhouettes is not None):
+        smal_forward = _smal_forward_for_sample(path, sample_idx, smal_pkl)
 
     st.subheader(f"Sample {sample['sample_idx']}")
     info_cols = st.columns(4)
@@ -445,6 +682,14 @@ def _ui_sample(path: str, sample_idx: int, show_2d: bool, show_reproj: bool, sho
                 if img is None:
                     st.warning(f"view {v}: image missing")
                     continue
+                smal_joints_for_view = (
+                    smal_forward["joints_world"]
+                    if (smal_forward is not None and show_smal_2d)
+                    else None
+                )
+                sil_for_view = (
+                    silhouettes.get(v) if silhouettes is not None else None
+                )
                 drawn = _draw_overlay(
                     img,
                     sample["kp2d_norm_yx"][v],
@@ -456,6 +701,8 @@ def _ui_sample(path: str, sample_idx: int, show_2d: bool, show_reproj: bool, sho
                     sample["image_sizes_wh"][v],
                     show_gt=show_2d,
                     show_reproj=show_reproj,
+                    smal_joints_world=smal_joints_for_view,
+                    silhouette=sil_for_view,
                 )
                 err_str = ""
                 if v in per_view_err and not np.isnan(per_view_err[v]):
@@ -467,8 +714,11 @@ def _ui_sample(path: str, sample_idx: int, show_2d: bool, show_reproj: bool, sho
                 )
 
     if show_3d:
-        st.markdown("**3D scene** — black ● = kp3d, red ◆ = camera centres (drag to rotate)")
-        fig = _build_3d_figure(sample)
+        legend = "black ● = kp3d, red ◆ = camera centres"
+        if smal_forward is not None and show_smal_3d:
+            legend += ", orange surface = SMAL mesh, orange ◆ = SMAL joints"
+        st.markdown(f"**3D scene** — {legend} (drag to rotate)")
+        fig = _build_3d_figure(sample, smal_forward if show_smal_3d else None)
         st.plotly_chart(fig, width="stretch")
 
     with st.expander("Per-view camera parameters", expanded=False):
@@ -651,15 +901,115 @@ def main() -> None:
 
         st.divider()
         st.header("Display")
-        show_2d = st.checkbox("Show 2D keypoints", value=True)
-        show_reproj = st.checkbox("Show reprojection overlay", value=True)
+        show_2d = st.checkbox("Show 2D keypoints (green ○)", value=True)
+        show_reproj = st.checkbox("Show kp3d reprojection (red ✕)", value=True)
         show_3d = st.checkbox("Show 3D viewer", value=True)
+
+        st.divider()
+        st.header("SMAL forward model")
+        if not _SMAL_AVAILABLE:
+            st.caption(f"SMAL render unavailable: {_SMAL_IMPORT_ERR}")
+            smal_pkl: Optional[str] = None
+            show_smal_2d = show_smal_3d = False
+        else:
+            discovered = _discover_smal_pkls()
+            CUSTOM = "🗂  custom path…"
+            NONE = "— (disable SMAL features)"
+
+            # Build the dropdown's options.
+            #  - "(none)" disables everything (default for SLEAP-only files)
+            #  - Each discovered .pkl as a relative-to-repo string
+            #  - "custom path…" reveals a text input below
+            choices = [NONE]
+            choices.extend(discovered)
+            choices.append(CUSTOM)
+
+            # Default selection: previous session value -> auto-detect -> none.
+            previously = st.session_state.get("smal_pkl")
+            auto = _auto_detect_smal_pkl(meta)
+            default_pkl = previously or auto
+            default_idx = 0
+            if default_pkl in discovered:
+                default_idx = discovered.index(default_pkl) + 1   # +1 for the NONE sentinel
+            elif default_pkl:
+                default_idx = len(choices) - 1   # "custom path…"
+
+            picked = st.selectbox(
+                "SMAL pkl",
+                options=choices,
+                index=default_idx,
+                format_func=lambda p: (
+                    p if p in (NONE, CUSTOM)
+                    else str(Path(p).relative_to(_REPO_ROOT_FOR_PKL_SCAN))
+                    if Path(p).is_relative_to(_REPO_ROOT_FOR_PKL_SCAN)
+                    else p
+                ),
+                help="Picks from .pkl files discovered under 3D_model_prep/, "
+                     "smal_model/data/, and the repo root. Choose '🗂 custom path…' "
+                     "to enter an absolute path.",
+            )
+
+            if picked == NONE:
+                smal_pkl = None
+            elif picked == CUSTOM:
+                raw_input = st.text_input(
+                    "Custom pkl path",
+                    value=default_pkl if (default_pkl and default_pkl not in discovered) else "",
+                    help="Accepts WSL paths (/mnt/c/...) or Windows paths "
+                         "(C:\\Users\\...); the latter are auto-converted.",
+                )
+                norm = _normalize_path_for_wsl(raw_input) if raw_input else ""
+                if norm and Path(norm).is_file():
+                    smal_pkl = norm
+                    if norm != raw_input:
+                        st.caption(f"Normalised to `{norm}`")
+                elif norm:
+                    st.warning(f"Not found: `{norm}`")
+                    smal_pkl = None
+                else:
+                    smal_pkl = None
+            else:
+                smal_pkl = picked
+
+            if smal_pkl:
+                st.session_state["smal_pkl"] = smal_pkl
+
+            show_smal_3d = st.checkbox(
+                "Add SMAL mesh + joints to 3D viewer",
+                value=True if smal_pkl else False,
+                disabled=smal_pkl is None,
+            )
+            show_smal_2d = st.checkbox(
+                "Overlay SMAL joints on per-view images (orange ▲)",
+                value=True if smal_pkl else False,
+                disabled=smal_pkl is None,
+            )
 
     tab_sample, tab_stats = st.tabs(["Sample inspector", "Dataset stats"])
     with tab_sample:
         _ui_metadata(meta)
         st.divider()
-        _ui_sample(str(path), int(sample_idx), show_2d, show_reproj, show_3d)
+        # Silhouette render is button-gated per sample (PyTorch3D rasterise is
+        # the expensive op in this whole viewer; never auto-fire).
+        silhouettes: Optional[Dict[int, np.ndarray]] = None
+        sil_cache_key = f"sil:{path}:{int(sample_idx)}"
+        if smal_pkl and st.button(
+            "🎨 Render SMAL silhouette overlay for this sample",
+            help="Rasterises the posed mesh through each stored camera and "
+                 "alpha-blends onto the input images. Takes a few seconds.",
+            disabled=not smal_pkl,
+        ):
+            st.session_state[sil_cache_key] = True
+        if smal_pkl and st.session_state.get(sil_cache_key):
+            silhouettes = _render_silhouettes_for_sample(
+                str(path), int(sample_idx), smal_pkl, render_size=256,
+            )
+        _ui_sample(
+            str(path), int(sample_idx),
+            show_2d=show_2d, show_reproj=show_reproj, show_3d=show_3d,
+            show_smal_3d=show_smal_3d, show_smal_2d=show_smal_2d,
+            smal_pkl=smal_pkl, silhouettes=silhouettes,
+        )
     with tab_stats:
         _ui_stats(str(path), summary)
 

--- a/smal_fitter/multiview_common/dataset_viewer.py
+++ b/smal_fitter/multiview_common/dataset_viewer.py
@@ -1,0 +1,668 @@
+"""Streamlit viewer for multi-view SMIL HDF5 datasets.
+
+Launch:
+
+    streamlit run smal_fitter/multiview_common/dataset_viewer.py
+
+Or with a default path:
+
+    streamlit run smal_fitter/multiview_common/dataset_viewer.py -- --hdf5 path.h5
+
+Supports any HDF5 with the SLEAPMultiViewDataset schema — that includes
+SLEAP-preprocessor output, replicAnt-preprocessor output, and the merger's
+output. The per-sample inspector shows decoded JPEGs with 2D-keypoint and
+reprojection overlays, a 3D Plotly viewer for kp3d + camera centres, and a
+metadata + per-view-parameters card. The dataset-stats tab shows num_views
+distribution, has_3d_data ratio, origin_dataset distribution (for merged
+files), and an on-demand reprojection-error histogram across all samples.
+
+Directory-based formats (raw replicAnt flat dir, single-view JSON) and
+SMAL mesh rendering land in follow-up phases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import h5py
+import numpy as np
+import plotly.graph_objects as go
+import streamlit as st
+
+
+# Make multiview_common importable when streamlit launches the module directly.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))  # smal_fitter/ on path
+from multiview_common.canonical_frame import (  # noqa: E402
+    cam_center_world,
+    project_world_to_pixel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cached I/O.
+# ---------------------------------------------------------------------------
+
+
+@st.cache_resource(show_spinner=False)
+def _open_hdf5(path: str) -> h5py.File:
+    """One file handle per path, cached across reruns."""
+    return h5py.File(path, "r")
+
+
+@st.cache_data(show_spinner=False)
+def _read_metadata(path: str) -> Dict[str, object]:
+    """All /metadata attrs in a plain dict, with bytes decoded to str."""
+    out: Dict[str, object] = {}
+    with h5py.File(path, "r") as f:
+        if "metadata" not in f:
+            return out
+        for k, v in f["metadata"].attrs.items():
+            if isinstance(v, bytes):
+                v = v.decode("utf-8", errors="replace")
+            elif isinstance(v, np.ndarray) and v.dtype.kind in ("S", "O"):
+                v = [
+                    e.decode("utf-8", errors="replace") if isinstance(e, bytes) else e
+                    for e in v
+                ]
+            out[k] = v
+    return out
+
+
+@st.cache_data(show_spinner=False)
+def _dataset_summary(path: str) -> Dict[str, object]:
+    """Cheap per-sample arrays loaded once: view_mask sums, has_3d_data,
+    origin_dataset (if present). Used for filter widgets and stats."""
+    with h5py.File(path, "r") as f:
+        n = int(f["metadata"].attrs["num_samples"])
+        mv = int(f["metadata"].attrs["max_views"])
+        out = {
+            "num_samples": n,
+            "max_views": mv,
+            "num_views": (
+                f["auxiliary/num_views"][:]
+                if "auxiliary/num_views" in f
+                else f["multiview_images/view_mask"][:].sum(axis=1)
+            ).astype(int),
+            "has_3d_data": (
+                f["auxiliary/has_3d_data"][:].astype(bool)
+                if "auxiliary/has_3d_data" in f
+                else np.zeros(n, dtype=bool)
+            ),
+        }
+        if "auxiliary/origin_dataset" in f:
+            origins = f["auxiliary/origin_dataset"][:]
+            out["origin_dataset"] = np.array([
+                s.decode("utf-8", errors="replace") if isinstance(s, bytes) else str(s)
+                for s in origins
+            ])
+        else:
+            out["origin_dataset"] = None
+        if "auxiliary/origin_source_file" in f:
+            srcs = f["auxiliary/origin_source_file"][:]
+            out["origin_source_file"] = np.array([
+                s.decode("utf-8", errors="replace") if isinstance(s, bytes) else str(s)
+                for s in srcs
+            ])
+        else:
+            out["origin_source_file"] = None
+        if "auxiliary/session_name" in f:
+            sns = f["auxiliary/session_name"][:]
+            out["session_name"] = np.array([
+                s.decode("utf-8", errors="replace") if isinstance(s, bytes) else str(s)
+                for s in sns
+            ])
+        else:
+            out["session_name"] = None
+    return out
+
+
+@st.cache_data(show_spinner=False)
+def _read_sample(path: str, sample_idx: int) -> Dict[str, object]:
+    """Read everything we need for one sample in one shot. Cached per idx."""
+    with h5py.File(path, "r") as f:
+        max_views = int(f["metadata"].attrs["max_views"])
+        view_mask = f["multiview_images/view_mask"][sample_idx].astype(bool)
+        kp2d = f["multiview_keypoints/keypoints_2d"][sample_idx].astype(np.float64)
+        kp_vis = f["multiview_keypoints/keypoint_visibility"][sample_idx].astype(np.float64)
+        K = f["multiview_keypoints/camera_intrinsics"][sample_idx].astype(np.float64)
+        R = f["multiview_keypoints/camera_extrinsics_R"][sample_idx].astype(np.float64)
+        t = f["multiview_keypoints/camera_extrinsics_t"][sample_idx].astype(np.float64)
+        image_sizes = f["multiview_keypoints/image_sizes"][sample_idx].astype(np.int64)
+        kp3d = f["multiview_keypoints/keypoints_3d"][sample_idx].astype(np.float64)
+        camera_indices = f["multiview_keypoints/camera_indices"][sample_idx].astype(np.int64)
+
+        images = []
+        for v in range(max_views):
+            try:
+                blob = f[f"multiview_images/image_jpeg_view_{v}"][sample_idx]
+            except KeyError:
+                blob = None
+            images.append(_decode_jpeg(blob))
+
+        has_3d = (
+            bool(f["auxiliary/has_3d_data"][sample_idx])
+            if "auxiliary/has_3d_data" in f
+            else not bool(np.all(kp3d == 0))
+        )
+        frame_idx = (
+            int(f["auxiliary/frame_idx"][sample_idx])
+            if "auxiliary/frame_idx" in f
+            else int(sample_idx)
+        )
+        origin_dataset = None
+        if "auxiliary/origin_dataset" in f:
+            v = f["auxiliary/origin_dataset"][sample_idx]
+            origin_dataset = v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
+        session = None
+        if "auxiliary/session_name" in f:
+            v = f["auxiliary/session_name"][sample_idx]
+            session = v.decode("utf-8", errors="replace") if isinstance(v, bytes) else str(v)
+
+    return {
+        "sample_idx": int(sample_idx),
+        "max_views": max_views,
+        "view_mask": view_mask,
+        "kp2d_norm_yx": kp2d,
+        "kp_vis": kp_vis,
+        "K": K,
+        "R": R,
+        "t": t,
+        "image_sizes_wh": image_sizes,
+        "kp3d": kp3d,
+        "images_rgb": images,
+        "camera_indices": camera_indices,
+        "has_3d": has_3d,
+        "frame_idx": frame_idx,
+        "origin_dataset": origin_dataset,
+        "session_name": session,
+    }
+
+
+def _decode_jpeg(blob) -> Optional[np.ndarray]:
+    if blob is None or len(blob) == 0:
+        return None
+    bgr = cv2.imdecode(np.asarray(blob, dtype=np.uint8), cv2.IMREAD_COLOR)
+    if bgr is None:
+        return None
+    return cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+
+
+# ---------------------------------------------------------------------------
+# Per-view overlay rendering.
+# ---------------------------------------------------------------------------
+
+
+def _draw_overlay(
+    img_rgb: np.ndarray,
+    kp2d_norm_yx: np.ndarray,        # (J, 2) — [y/H_calib, x/W_calib]
+    kp_vis: np.ndarray,              # (J,)
+    R: np.ndarray, t: np.ndarray, K: np.ndarray,
+    kp3d: np.ndarray,                # (J, 3) world frame
+    image_sizes_wh: Tuple[int, int],  # (W_calib, H_calib) — K is calibrated for this
+    show_gt: bool,
+    show_reproj: bool,
+) -> np.ndarray:
+    """Stretch the JPEG to the calibration frame's aspect, then overlay GT
+    and projected-3D keypoints. Visibility codes opacity / fill.
+
+    SLEAP HDF5s have JPEG dims != image_sizes; replicAnt are self-consistent.
+    Drawing in the calibration frame and then resampling to a fixed display
+    size makes both formats render identically.
+    """
+    W_calib, H_calib = int(image_sizes_wh[0]), int(image_sizes_wh[1])
+    H_jpeg, W_jpeg = img_rgb.shape[:2]
+
+    # Resize the decoded JPEG into the calibration frame so K-based projection
+    # lands on the right anatomy. Cheap interpolation - this is just for
+    # display.
+    if (H_jpeg, W_jpeg) != (H_calib, W_calib):
+        canvas = cv2.resize(img_rgb, (W_calib, H_calib), interpolation=cv2.INTER_AREA)
+    else:
+        canvas = img_rgb.copy()
+
+    has_gt_3d = ~np.all(kp3d == 0, axis=1)
+    n_joints = kp2d_norm_yx.shape[0]
+
+    if show_gt:
+        for j in range(n_joints):
+            if kp_vis[j] <= 0:
+                continue
+            px = int(round(float(kp2d_norm_yx[j, 1]) * W_calib))
+            py = int(round(float(kp2d_norm_yx[j, 0]) * H_calib))
+            if not (0 <= px < W_calib and 0 <= py < H_calib):
+                continue
+            cv2.circle(canvas, (px, py), max(3, W_calib // 200), (60, 220, 60), 2)
+
+    if show_reproj and has_gt_3d.any():
+        proj = project_world_to_pixel(kp3d, R, t, K)  # pixels in calibration frame
+        for j in range(n_joints):
+            if not has_gt_3d[j]:
+                continue
+            xy = proj[j]
+            if np.any(np.isnan(xy)):
+                continue
+            px = int(round(float(xy[0])))
+            py = int(round(float(xy[1])))
+            if not (0 <= px < W_calib and 0 <= py < H_calib):
+                continue
+            r = max(2, W_calib // 250)
+            cv2.line(canvas, (px - r, py - r), (px + r, py + r), (230, 60, 60), 2)
+            cv2.line(canvas, (px - r, py + r), (px + r, py - r), (230, 60, 60), 2)
+
+    return canvas
+
+
+def _per_view_reproj_max(sample: Dict[str, object]) -> Dict[int, float]:
+    """Per-view max reprojection error in calibration pixels, for the
+    visible+has_GT joints. Used for the sample-card summary."""
+    kp3d = sample["kp3d"]
+    view_mask = sample["view_mask"]
+    has_gt_3d = ~np.all(kp3d == 0, axis=1)
+    out: Dict[int, float] = {}
+    for v in range(len(sample["R"])):
+        if not view_mask[v]:
+            continue
+        W, H = int(sample["image_sizes_wh"][v, 0]), int(sample["image_sizes_wh"][v, 1])
+        gt = np.stack([
+            sample["kp2d_norm_yx"][v, :, 1] * W,
+            sample["kp2d_norm_yx"][v, :, 0] * H,
+        ], axis=1)
+        pr = project_world_to_pixel(kp3d, sample["R"][v], sample["t"][v], sample["K"][v])
+        mask = has_gt_3d & (sample["kp_vis"][v] > 0)
+        if not mask.any():
+            out[v] = float("nan")
+            continue
+        err = np.linalg.norm(pr[mask] - gt[mask], axis=1)
+        out[v] = float(np.nanmax(err))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 3D viewer (Plotly).
+# ---------------------------------------------------------------------------
+
+
+def _build_3d_figure(sample: Dict[str, object]) -> go.Figure:
+    R = sample["R"]
+    t = sample["t"]
+    kp3d = sample["kp3d"]
+    view_mask = sample["view_mask"]
+    has_gt_3d = ~np.all(kp3d == 0, axis=1)
+
+    fig = go.Figure()
+    if has_gt_3d.any():
+        fig.add_trace(go.Scatter3d(
+            x=kp3d[has_gt_3d, 0], y=kp3d[has_gt_3d, 1], z=kp3d[has_gt_3d, 2],
+            mode="markers",
+            marker=dict(size=4, color="black"),
+            name=f"kp3d (n={int(has_gt_3d.sum())})",
+        ))
+    cam_xyz, cam_labels = [], []
+    for v in range(len(R)):
+        if not view_mask[v]:
+            continue
+        c = cam_center_world(R[v], t[v])
+        cam_xyz.append(c)
+        cam_labels.append(f"cam {v}")
+    if cam_xyz:
+        cam_xyz = np.stack(cam_xyz, axis=0)
+        fig.add_trace(go.Scatter3d(
+            x=cam_xyz[:, 0], y=cam_xyz[:, 1], z=cam_xyz[:, 2],
+            mode="markers+text",
+            marker=dict(size=6, color="firebrick", symbol="diamond"),
+            text=cam_labels,
+            textposition="top center",
+            name="cameras",
+        ))
+    fig.update_layout(
+        height=520,
+        margin=dict(l=0, r=0, t=20, b=0),
+        scene=dict(
+            xaxis_title="X", yaxis_title="Y", zaxis_title="Z",
+            aspectmode="data",
+        ),
+        legend=dict(orientation="h", y=-0.05),
+    )
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Dataset stats (cheap to derive; reprojection histogram is opt-in).
+# ---------------------------------------------------------------------------
+
+
+@st.cache_data(show_spinner="Computing per-sample reprojection error...")
+def _all_sample_reproj_errors(path: str, max_samples: int) -> Dict[str, np.ndarray]:
+    """Pass once over up to `max_samples` and compute per-sample max
+    reprojection error (over all valid views, visible+has_GT joints).
+    Returns dict with 'idx' and 'max_err' arrays."""
+    with h5py.File(path, "r") as f:
+        n_total = int(f["metadata"].attrs["num_samples"])
+        n = min(n_total, max_samples)
+        idx_arr = np.arange(n)
+        max_err = np.full(n, np.nan, dtype=np.float64)
+        vm = f["multiview_images/view_mask"]
+        kp2d_d = f["multiview_keypoints/keypoints_2d"]
+        K_d = f["multiview_keypoints/camera_intrinsics"]
+        R_d = f["multiview_keypoints/camera_extrinsics_R"]
+        t_d = f["multiview_keypoints/camera_extrinsics_t"]
+        sz_d = f["multiview_keypoints/image_sizes"]
+        vis_d = f["multiview_keypoints/keypoint_visibility"]
+        kp3d_d = f["multiview_keypoints/keypoints_3d"]
+        for i in range(n):
+            mask = vm[i].astype(bool)
+            kp3d = kp3d_d[i].astype(np.float64)
+            has_gt = ~np.all(kp3d == 0, axis=1)
+            best = 0.0
+            counted = False
+            for v in range(len(mask)):
+                if not mask[v]:
+                    continue
+                use = has_gt & (vis_d[i, v].astype(np.float64) > 0)
+                if not use.any():
+                    continue
+                W, H = int(sz_d[i, v, 0]), int(sz_d[i, v, 1])
+                gt = np.stack([kp2d_d[i, v, :, 1] * W, kp2d_d[i, v, :, 0] * H], axis=1)
+                pr = project_world_to_pixel(kp3d, R_d[i, v], t_d[i, v], K_d[i, v])
+                err = float(np.nanmax(np.linalg.norm(pr[use] - gt[use], axis=1)))
+                if err > best:
+                    best = err
+                counted = True
+            max_err[i] = best if counted else np.nan
+    return {"idx": idx_arr, "max_err": max_err}
+
+
+# ---------------------------------------------------------------------------
+# UI sections.
+# ---------------------------------------------------------------------------
+
+
+def _ui_metadata(meta: Dict[str, object]) -> None:
+    st.subheader("Metadata")
+    headline_keys = [
+        "dataset_type", "num_samples", "max_views", "n_joints",
+        "target_resolution", "world_scale", "min_views_per_sample",
+        "is_multiview", "has_camera_parameters", "has_3d_keypoints",
+    ]
+    headline = {k: meta.get(k, "—") for k in headline_keys}
+    cols = st.columns(5)
+    chip_items = list(headline.items())
+    for i, (k, v) in enumerate(chip_items):
+        cols[i % 5].metric(label=k, value=str(v))
+
+    with st.expander("All metadata attrs (raw)", expanded=False):
+        # Try to JSON-decode nested manifests; otherwise show as-is.
+        rendered = {}
+        for k, v in meta.items():
+            if isinstance(v, str) and v.startswith(("[", "{")):
+                try:
+                    rendered[k] = json.loads(v)
+                    continue
+                except json.JSONDecodeError:
+                    pass
+            rendered[k] = v if not isinstance(v, np.ndarray) else v.tolist()
+        st.json(rendered)
+
+
+def _ui_sample(path: str, sample_idx: int, show_2d: bool, show_reproj: bool, show_3d: bool) -> None:
+    sample = _read_sample(path, sample_idx)
+    valid_v = [int(v) for v in np.where(sample["view_mask"])[0]]
+
+    st.subheader(f"Sample {sample['sample_idx']}")
+    info_cols = st.columns(4)
+    info_cols[0].metric("source frame", sample["frame_idx"])
+    info_cols[1].metric("valid views", f"{len(valid_v)} / {sample['max_views']}")
+    info_cols[2].metric("has_3d_data", str(sample["has_3d"]))
+    info_cols[3].metric("origin", sample["origin_dataset"] or "—")
+    if sample["session_name"]:
+        st.caption(f"session: `{sample['session_name']}`")
+
+    if not valid_v:
+        st.warning("This sample has no valid views (view_mask is all False).")
+        return
+
+    per_view_err = _per_view_reproj_max(sample) if sample["has_3d"] else {}
+
+    # Per-view grid.
+    st.markdown("**Per-view images** — green ○ = stored 2D GT, red ✕ = projected stored 3D")
+    n_cols = min(len(valid_v), 4)
+    rows = (len(valid_v) + n_cols - 1) // n_cols
+    for r in range(rows):
+        cols = st.columns(n_cols)
+        for c in range(n_cols):
+            i = r * n_cols + c
+            if i >= len(valid_v):
+                break
+            v = valid_v[i]
+            img = sample["images_rgb"][v]
+            with cols[c]:
+                if img is None:
+                    st.warning(f"view {v}: image missing")
+                    continue
+                drawn = _draw_overlay(
+                    img,
+                    sample["kp2d_norm_yx"][v],
+                    sample["kp_vis"][v],
+                    sample["R"][v],
+                    sample["t"][v],
+                    sample["K"][v],
+                    sample["kp3d"],
+                    sample["image_sizes_wh"][v],
+                    show_gt=show_2d,
+                    show_reproj=show_reproj,
+                )
+                err_str = ""
+                if v in per_view_err and not np.isnan(per_view_err[v]):
+                    err_str = f"  |  max reproj = {per_view_err[v]:.2f} px"
+                st.image(
+                    drawn,
+                    caption=f"view {v} ({int(sample['image_sizes_wh'][v, 0])}×{int(sample['image_sizes_wh'][v, 1])} calib){err_str}",
+                    width="stretch",
+                )
+
+    if show_3d:
+        st.markdown("**3D scene** — black ● = kp3d, red ◆ = camera centres (drag to rotate)")
+        fig = _build_3d_figure(sample)
+        st.plotly_chart(fig, width="stretch")
+
+    with st.expander("Per-view camera parameters", expanded=False):
+        for v in valid_v:
+            st.markdown(f"**view {v}**  (camera_indices = {int(sample['camera_indices'][v])})")
+            K, R, t = sample["K"][v], sample["R"][v], sample["t"][v]
+            c1, c2, c3 = st.columns(3)
+            c1.code(f"K =\n{np.array2string(K, precision=3, suppress_small=True)}")
+            c2.code(f"R =\n{np.array2string(R, precision=4, suppress_small=True)}")
+            c3.code(f"t = {np.array2string(t, precision=4, suppress_small=True)}\n"
+                    f"||t|| = {float(np.linalg.norm(t)):.4g}")
+
+
+def _ui_stats(path: str, summary: Dict[str, object]) -> None:
+    st.subheader("Dataset stats")
+    n = int(summary["num_samples"])
+    mv = int(summary["max_views"])
+
+    # num_views distribution.
+    nv = summary["num_views"]
+    nv_counts = np.bincount(nv, minlength=mv + 1)
+    fig_nv = go.Figure(go.Bar(x=list(range(len(nv_counts))), y=nv_counts.tolist()))
+    fig_nv.update_layout(
+        height=260,
+        margin=dict(l=0, r=0, t=24, b=0),
+        title="Valid views per sample",
+        xaxis_title="num_views", yaxis_title="count",
+    )
+
+    # has_3d_data ratio.
+    has3d = summary["has_3d_data"]
+    pct = float(has3d.mean()) if has3d.size else 0.0
+    fig_h3 = go.Figure(go.Pie(
+        labels=["has_3d_data", "no 3D"],
+        values=[int(has3d.sum()), int((~has3d).sum())],
+        hole=0.45,
+    ))
+    fig_h3.update_layout(
+        height=260, margin=dict(l=0, r=0, t=24, b=0),
+        title=f"has_3d_data ({pct:.0%})",
+    )
+
+    c1, c2 = st.columns(2)
+    c1.plotly_chart(fig_nv, width="stretch")
+    c2.plotly_chart(fig_h3, width="stretch")
+
+    origin = summary.get("origin_dataset")
+    if origin is not None and len(origin) > 0:
+        uniq, counts = np.unique(origin, return_counts=True)
+        fig_o = go.Figure(go.Bar(x=uniq.tolist(), y=counts.tolist()))
+        fig_o.update_layout(
+            height=260, margin=dict(l=0, r=0, t=24, b=0),
+            title="origin_dataset distribution (merged file)",
+            xaxis_title="origin", yaxis_title="count",
+        )
+        st.plotly_chart(fig_o, width="stretch")
+
+    src = summary.get("origin_source_file")
+    if src is not None and len(src) > 0:
+        uniq, counts = np.unique(src, return_counts=True)
+        if len(uniq) > 1:
+            fig_s = go.Figure(go.Bar(x=uniq.tolist(), y=counts.tolist()))
+            fig_s.update_layout(
+                height=260, margin=dict(l=0, r=0, t=24, b=0),
+                title="origin_source_file (merged file)",
+                xaxis_title="source", yaxis_title="count",
+            )
+            st.plotly_chart(fig_s, width="stretch")
+
+    sess = summary.get("session_name")
+    if sess is not None and len(sess) > 0:
+        uniq, counts = np.unique(sess, return_counts=True)
+        if len(uniq) > 1 and len(uniq) <= 50:
+            fig_se = go.Figure(go.Bar(x=uniq.tolist(), y=counts.tolist()))
+            fig_se.update_layout(
+                height=260, margin=dict(l=0, r=0, t=24, b=0),
+                title="session distribution",
+                xaxis_title="session", yaxis_title="count",
+            )
+            st.plotly_chart(fig_se, width="stretch")
+
+    st.markdown("---")
+    st.markdown("**Reprojection error histogram** (one pass over the dataset)")
+    # number_input handles n==1 cleanly (slider needs min < max).
+    default_n = min(n, 1000)
+    max_n = int(st.number_input(
+        "Max samples to scan",
+        min_value=1, max_value=max(n, 1), value=default_n, step=max(1, n // 100),
+        help="Scanning thousands of samples is expensive; limit for speed.",
+    ))
+    if st.button("Compute reprojection error histogram"):
+        data = _all_sample_reproj_errors(path, int(max_n))
+        errs = data["max_err"]
+        valid_errs = errs[~np.isnan(errs)]
+        if valid_errs.size == 0:
+            st.warning("No samples with computable reprojection error in this range.")
+            return
+        fig_err = go.Figure(go.Histogram(x=valid_errs.tolist(), nbinsx=60))
+        fig_err.update_layout(
+            height=320, margin=dict(l=0, r=0, t=24, b=0),
+            title=f"Per-sample max reprojection error (n={valid_errs.size}, "
+                  f"median={float(np.median(valid_errs)):.2f}px, "
+                  f"p95={float(np.percentile(valid_errs, 95)):.2f}px, "
+                  f"max={float(valid_errs.max()):.2f}px)",
+            xaxis_title="px (calibration frame)", yaxis_title="count",
+        )
+        st.plotly_chart(fig_err, width="stretch")
+
+
+# ---------------------------------------------------------------------------
+# App entry.
+# ---------------------------------------------------------------------------
+
+
+def _parse_cli_default_path() -> Optional[str]:
+    """`streamlit run viewer.py -- --hdf5 path.h5` plumbing."""
+    if "--hdf5" in sys.argv:
+        i = sys.argv.index("--hdf5")
+        if i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+    return None
+
+
+def main() -> None:
+    st.set_page_config(
+        page_title="SMILify multi-view dataset viewer",
+        layout="wide",
+    )
+    st.title("Multi-view dataset viewer")
+
+    default_path = _parse_cli_default_path() or ""
+    with st.sidebar:
+        st.header("Dataset")
+        path_str = st.text_input("HDF5 path", value=default_path,
+                                 help="Path to a SLEAPMultiViewDataset-format HDF5 "
+                                      "(SLEAP, replicAnt, or merger output).")
+        if not path_str:
+            st.info("Enter an HDF5 path to begin.")
+            return
+        path = Path(path_str)
+        if not path.is_file():
+            st.error(f"File not found: {path}")
+            return
+
+        meta = _read_metadata(str(path))
+        if not meta:
+            st.error("No /metadata group in this HDF5 — not a recognised multi-view file.")
+            return
+        summary = _dataset_summary(str(path))
+        n = int(summary["num_samples"])
+
+        st.divider()
+        st.header("Sample")
+        # Use session_state-keyed widget so prev/next buttons update the
+        # number_input cleanly without re-running into the default value.
+        if "sample_idx" not in st.session_state:
+            st.session_state.sample_idx = 0
+
+        def _clamp(value: int) -> int:
+            return max(0, min(int(value), max(n - 1, 0)))
+
+        st.session_state.sample_idx = _clamp(st.session_state.sample_idx)
+
+        st.number_input(
+            "index", min_value=0, max_value=max(n - 1, 0), step=1,
+            key="sample_idx",
+            help=f"0 .. {max(n - 1, 0)}",
+        )
+        sample_idx = int(st.session_state.sample_idx)
+
+        prev_col, next_col = st.columns(2)
+        prev_col.button(
+            "◀ prev", width="stretch", disabled=sample_idx <= 0,
+            on_click=lambda: st.session_state.update(sample_idx=_clamp(st.session_state.sample_idx - 1)),
+        )
+        next_col.button(
+            "next ▶", width="stretch", disabled=sample_idx >= n - 1,
+            on_click=lambda: st.session_state.update(sample_idx=_clamp(st.session_state.sample_idx + 1)),
+        )
+
+        st.divider()
+        st.header("Display")
+        show_2d = st.checkbox("Show 2D keypoints", value=True)
+        show_reproj = st.checkbox("Show reprojection overlay", value=True)
+        show_3d = st.checkbox("Show 3D viewer", value=True)
+
+    tab_sample, tab_stats = st.tabs(["Sample inspector", "Dataset stats"])
+    with tab_sample:
+        _ui_metadata(meta)
+        st.divider()
+        _ui_sample(str(path), int(sample_idx), show_2d, show_reproj, show_3d)
+    with tab_stats:
+        _ui_stats(str(path), summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/smal_fitter/multiview_common/smal_render.py
+++ b/smal_fitter/multiview_common/smal_render.py
@@ -1,0 +1,229 @@
+"""SMAL forward + PyTorch3D mesh/silhouette rendering for the dataset viewer.
+
+Thin wrapper around `smal_model.smal_torch.SMAL` (the SMAL/SMIL forward
+model) and `smal_fitter.p3d_renderer.Renderer` (the existing PyTorch3D
+silhouette/colour renderer used by `SMALFitter`). The viewer uses this to:
+
+- Forward (betas, global_rot, joint_rot, trans) from an HDF5 sample into
+  posed vertices + joints.
+- Add a Mesh3d trace + posed-joint scatter to the Plotly 3D viewer.
+- Project posed joints through each stored camera for a per-view overlay
+  (cheap — pure numpy).
+- Rasterise the posed mesh through each stored camera into a silhouette
+  mask and alpha-blend onto the input image (slow — gated behind a
+  button in the viewer).
+
+Conventions
+-----------
+
+Stored cameras are in OpenCV column-vector form (see
+multiview_common/canonical_frame.py). The SLEAPMultiViewDataset reader's
+`_sleap_to_pytorch3d_camera` converts to PyTorch3D row-vector form
+(`X_cam = X_world @ R_p3d + T_p3d`, `fov_y` in degrees, `aspect_ratio`
+for non-square pixels). We use the SAME conversion here so silhouette
+overlays land on the same anatomy as the stored 2D keypoints.
+
+The SMAL model holds load-bearing global state in `config.SMAL_FILE`
+(via `apply_smal_file_override`). Callers must apply the override
+BEFORE instantiating SMAL; this wrapper does that in the constructor.
+Loading a SECOND pkl with a different path mutates the same global —
+fine for the viewer (one dataset at a time) but be aware.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+
+
+@dataclass
+class PosedSample:
+    """The output of a single SMAL forward + translate call."""
+    vertices_world: np.ndarray   # (V, 3)
+    joints_world: np.ndarray     # (J, 3)
+    faces: np.ndarray            # (F, 3) int
+
+
+class SMALRendererWrapper:
+    """SMAL forward + (optional) PyTorch3D silhouette rendering.
+
+    Construct once per SMAL pkl path. `forward(...)` is cheap (CPU
+    matmul). `render_silhouette(...)` is the expensive PyTorch3D call;
+    callers should gate it behind a button.
+    """
+
+    def __init__(self, smal_file: str, render_size: int, device: str = "cpu",
+                 shape_family: Optional[int] = None) -> None:
+        # The SMAL constructor reads `config.SMAL_FILE` (global). Apply the
+        # override BEFORE the import-chain touches config.dd. We also have
+        # to make sure `smal_fitter/` is on sys.path so the import works
+        # when streamlit launches us as `multiview_common.smal_render`.
+        _smal_fitter_dir = Path(__file__).resolve().parent.parent
+        if str(_smal_fitter_dir) not in sys.path:
+            sys.path.insert(0, str(_smal_fitter_dir))
+        _repo_root = _smal_fitter_dir.parent
+        if str(_repo_root) not in sys.path:
+            sys.path.insert(0, str(_repo_root))
+
+        # Defer these until paths are set.
+        from neuralSMIL.configs.config_utils import apply_smal_file_override  # noqa: E402
+        apply_smal_file_override(smal_file, shape_family=shape_family)
+
+        import config  # noqa: E402  — re-imported after override so attrs reflect the pkl
+        from smal_model.smal_torch import SMAL  # noqa: E402
+        from p3d_renderer import Renderer  # noqa: E402
+
+        self.device = torch.device(device)
+        self.smal = SMAL(self.device, shape_family_id=shape_family if shape_family is not None else -1)
+        self.smal.eval()
+        # The Renderer constructor uses a single integer image_size (square
+        # rendering target). Calibration frames may be non-square but the
+        # FoVPerspectiveCameras `aspect_ratio` parameter handles that; the
+        # rendered silhouette is square and we stretch it to the calibration
+        # extent at overlay time.
+        self.render_size = int(render_size)
+        self.renderer = Renderer(self.render_size, self.device)
+        self.config = config
+        self.smal_file = str(smal_file)
+
+    # ------------------------------------------------------------------
+    # SMAL forward.
+    # ------------------------------------------------------------------
+
+    def forward(
+        self,
+        betas: np.ndarray,           # (n_betas,)
+        global_rot: np.ndarray,      # (3,) axis-angle
+        joint_rot: np.ndarray,       # (n_pose+1, 3) or (n_pose, 3) axis-angle (we strip the leading row if it matches global_rot)
+        trans: np.ndarray,           # (3,)
+        propagate_scaling: bool = False,
+    ) -> PosedSample:
+        """Run SMAL once on CPU and return world-frame vertices + joints."""
+        betas_t = torch.as_tensor(betas, dtype=torch.float32, device=self.device).reshape(1, -1)
+        global_t = torch.as_tensor(global_rot, dtype=torch.float32, device=self.device).reshape(1, 1, 3)
+        joints_t = torch.as_tensor(joint_rot, dtype=torch.float32, device=self.device).reshape(-1, 3)
+
+        # The HDF5 stores joint_rot with the global rotation already pulled
+        # out into its own field — but some preprocessors stash the global
+        # rotation as the leading row of joint_rot. Detect by row count:
+        # n_joints expected by SMAL is `config.N_POSE + 1` (root + the
+        # posable joints). If we already have that many rows, the leading
+        # one IS the global rotation; strip it and we'll re-prepend
+        # `global_rot`. Otherwise concat as-is.
+        n_pose = int(self.config.N_POSE) if hasattr(self.config, "N_POSE") else (joints_t.shape[0] - 1 if joints_t.shape[0] >= 1 else 0)
+        if joints_t.shape[0] == n_pose + 1:
+            # Drop the existing leading row, replace with the explicit global.
+            joints_t = joints_t[1:]
+        theta = torch.cat([global_t, joints_t.unsqueeze(0)], dim=1)  # (1, n_pose+1, 3)
+
+        with torch.no_grad():
+            verts, joints, _, _ = self.smal(
+                betas_t, theta, propagate_scaling=propagate_scaling,
+            )
+
+        # Recenter at the posed root joint before adding trans. This matches
+        # the use_ue_scaling=True and `allow_mesh_scaling` branches in
+        # `multiview_smil_regressor` (lines ~2147-2156), which always do
+        #     (verts - root_joint) * scale + trans
+        # so the body root lands at `trans`. The HDF5 stores `parameters/trans`
+        # as the GT root joint position in canonical-frame world coords, so
+        # not recentering puts the mesh at `rest_root + trans` and produces a
+        # consistent offset (e.g. the SMAL Falkner-conv mouse pkl has rest
+        # root at (0, 0.72, 0.24) — that exact offset shows up on every view
+        # without this recenter).
+        # The `verts + trans` branch in the trainer is only reachable when the
+        # model is trained to predict `trans` that already compensates for
+        # `rest_root` — irrelevant for the viewer, which always consumes the
+        # raw GT params from disk.
+        trans_t = torch.as_tensor(trans, dtype=torch.float32, device=self.device).reshape(1, 1, 3)
+        root_joint = joints[:, 0:1, :]  # (1, 1, 3)
+        verts = (verts - root_joint) + trans_t
+        joints = (joints - root_joint) + trans_t
+
+        faces = self.smal.faces.detach().cpu().numpy().astype(np.int64)
+        return PosedSample(
+            vertices_world=verts[0].detach().cpu().numpy().astype(np.float32),
+            joints_world=joints[0].detach().cpu().numpy().astype(np.float32),
+            faces=faces,
+        )
+
+    # ------------------------------------------------------------------
+    # Silhouette rendering (expensive — gate behind a UI button).
+    # ------------------------------------------------------------------
+
+    def render_silhouette(
+        self,
+        verts_world: np.ndarray,     # (V, 3)
+        faces: np.ndarray,           # (F, 3) int
+        R_cv: np.ndarray, t_cv: np.ndarray, K: np.ndarray,
+        image_size_wh: np.ndarray,   # (W, H) of the calibration frame
+    ) -> np.ndarray:
+        """Rasterise the posed mesh through one OpenCV camera and return
+        a (render_size, render_size) silhouette mask in [0, 1] (float32).
+
+        The renderer is square; for non-square calibration frames the
+        caller stretches the result to the calibration extent before
+        overlay. The aspect_ratio plumbed into FoVPerspectiveCameras
+        handles the non-square camera intrinsics correctly.
+
+        The OpenCV column-vec -> PyTorch3D row-vec conversion is the
+        same one `SLEAPMultiViewDataset._sleap_to_pytorch3d_camera`
+        does at trainer load-time; we import that to keep the viewer's
+        projection convention byte-equivalent to the trainer's.
+        """
+        # Imported lazily so module-import doesn't pull in h5py + the
+        # whole SLEAPMultiViewDataset class graph when callers only
+        # need `forward(...)`.
+        from sleap_data.sleap_multiview_dataset import SLEAPMultiViewDataset
+        R_p3d, T_p3d, fov_y, aspect_ratio = SLEAPMultiViewDataset._sleap_to_pytorch3d_camera(
+            R_cv, t_cv, K, image_size_wh
+        )
+        R_t = torch.from_numpy(R_p3d).unsqueeze(0).to(self.device)
+        T_t = torch.from_numpy(T_p3d).unsqueeze(0).to(self.device)
+        fov_t = torch.tensor([fov_y], dtype=torch.float32, device=self.device)
+        self.renderer.set_camera_parameters(R_t, T_t, fov_t, aspect_ratio=aspect_ratio)
+
+        verts_t = torch.as_tensor(verts_world, dtype=torch.float32, device=self.device).unsqueeze(0)
+        faces_t = torch.as_tensor(faces, dtype=torch.long, device=self.device).unsqueeze(0)
+        # Renderer.forward needs a `points` arg even when we don't care;
+        # pass the verts again as a placeholder.
+        with torch.no_grad():
+            sil, _ = self.renderer(verts_t, verts_t, faces_t)
+        # sil: (1, 1, H, W) in [0, 1] (the alpha from SoftSilhouetteShader)
+        sil_np = sil[0, 0].detach().cpu().numpy().astype(np.float32)
+        return np.clip(sil_np, 0.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper for the viewer.
+# ---------------------------------------------------------------------------
+
+
+def overlay_silhouette(
+    canvas_rgb: np.ndarray,         # (H_calib, W_calib, 3) uint8
+    silhouette: np.ndarray,         # (S, S) float32 in [0, 1]
+    image_size_wh: np.ndarray,      # (W_calib, H_calib)
+    colour: Tuple[int, int, int] = (255, 60, 60),
+    alpha: float = 0.45,
+) -> np.ndarray:
+    """Alpha-blend a square silhouette mask onto a (typically non-square)
+    canvas. Stretches the silhouette to the canvas's calibration extent."""
+    import cv2
+    W_calib, H_calib = int(image_size_wh[0]), int(image_size_wh[1])
+    if silhouette.shape != (H_calib, W_calib):
+        sil_full = cv2.resize(silhouette, (W_calib, H_calib), interpolation=cv2.INTER_LINEAR)
+    else:
+        sil_full = silhouette
+    sil_full = np.clip(sil_full, 0.0, 1.0)[..., None]   # (H, W, 1)
+    colour_img = np.zeros_like(canvas_rgb, dtype=np.float32)
+    colour_img[..., 0] = colour[0]
+    colour_img[..., 1] = colour[1]
+    colour_img[..., 2] = colour[2]
+    blended = (canvas_rgb.astype(np.float32) * (1.0 - alpha * sil_full)
+               + colour_img * (alpha * sil_full))
+    return np.clip(blended, 0, 255).astype(np.uint8)

--- a/smal_fitter/sleap_data/prototype_canonicalize_sleap_sample.py
+++ b/smal_fitter/sleap_data/prototype_canonicalize_sleap_sample.py
@@ -64,6 +64,7 @@ sys.path.insert(0, str(_THIS_DIR.parent))  # smal_fitter/ on path
 from multiview_common.canonical_frame import (
     canonicalize_sample,
     cam_center_world,
+    kp2d_norm_yx_to_pixel_xy,
     project_world_to_pixel,
 )
 
@@ -167,11 +168,10 @@ def _load_sample(hdf5_path: Path, sample_idx: int):
 # ---------------------------------------------------------------------------
 
 
-def _kp2d_norm_yx_to_pixel_xy(kp2d_norm_yx: np.ndarray, img_W: int, img_H: int) -> np.ndarray:
-    """SLEAP stores 2D keypoints as normalized [y/H, x/W]. Convert to pixel [x, y]."""
-    px = kp2d_norm_yx[:, 1] * float(img_W)
-    py = kp2d_norm_yx[:, 0] * float(img_H)
-    return np.stack([px, py], axis=1)
+# `_kp2d_norm_yx_to_pixel_xy` previously lived here as a local helper. Promoted
+# to `multiview_common.canonical_frame.kp2d_norm_yx_to_pixel_xy` so the merger,
+# viewer, and this prototype share one definition.
+_kp2d_norm_yx_to_pixel_xy = kp2d_norm_yx_to_pixel_xy  # back-compat alias for callers below
 
 
 def per_view_reproj_error(


### PR DESCRIPTION
## Summary

Adds a Streamlit dataset viewer for any SLEAPMultiViewDataset-format HDF5 (SLEAP preprocessor output, replicAnt preprocessor output, or the cross-source merger from #22), plus a SMAL forward + PyTorch3D silhouette renderer that overlays the posed mesh on samples whose `/parameters/{global_rot,joint_rot,betas,trans}` carry real GT values.

Useful as a pre-flight check before kicking off multi-hour multi-view training runs: spot bad keypoints, mis-calibrated cameras, frame-convention regressions, and per-sample SMAL alignment in one place. Five commits, dependency-ordered:

### `b74eb39` — Streamlit viewer v1

Per-sample inspector for any multi-view HDF5. Reads the shared schema unchanged:

- Metadata card with the load-bearing `/metadata` attrs at top + raw attr expander.
- Per-view image grid (responsive layout). Decoded JPEGs are stretched to the calibration extent before overlay so K-based projections land on the right anatomy regardless of the SLEAP HDF5's known JPEG-vs-`image_sizes` mismatch.
- 2D GT keypoints rendered as green ○ (visibility-gated); stored 3D keypoints projected through the stored cameras and rendered as red ✕ (only on joints with GT 3D — preserves the (0,0,0) sentinel).
- Plotly 3D viewer with kp3d + camera centres, drag-to-rotate.
- Per-sample reprojection summary in the tile captions.
- Per-view (K, R, t, ‖t‖) expander.
- Dataset-stats tab: `num_views` distribution, `has_3d_data` ratio, `origin_dataset` distribution for merger output, plus an opt-in per-sample reprojection error histogram across up to N samples.

Imports `project_world_to_pixel` + `cam_center_world` from `multiview_common.canonical_frame` — single source of truth for the column-vector OpenCV geometry. Streamlit caches the HDF5 file handle (`@cache_resource`) and per-sample reads (`@cache_data`).

Launch: `streamlit run smal_fitter/multiview_common/dataset_viewer.py` (or `... -- --hdf5 path.h5`). On WSL-with-Windows-mount setups, add `--server.fileWatcherType poll` so edits hot-reload (inotify on `/mnt/c/` doesn't fire reliably).

### `bcb5263` — `kp2d_norm_yx_to_pixel_xy` shared helper

Promotes the `[y/H, x/W] → [x, y]` pixel-coord conversion to `multiview_common.canonical_frame`. Both preprocessor paths store 2D keypoints with the intentional axis swap (`kp[:, 0] = y/H, kp[:, 1] = x/W`); the inverse swap was getting open-coded inline everywhere 2D keypoints needed to be drawn or compared against `project_world_to_pixel` output.

### `9526c37` — Drop the prototype's local copy

The SLEAP canonicalisation prototype now imports the shared helper. End-to-end smoke check on `SMILymice_3D_6_cam_undistort.h5` sample 0 stays byte-equivalent post-refactor (cam-0 identity `||R'_0 - I|| = 5.085e-08`, all 6 views' per-view residuals unchanged, canonical transform delta = 4.194e-6 px).

### `b3c2e33` — SMAL forward + silhouette renderer wrapper

Thin layer in `smal_fitter/multiview_common/smal_render.py` over `smal_model.smal_torch.SMAL` and `smal_fitter.p3d_renderer.Renderer`. The wrapper:

- Applies `apply_smal_file_override(smal_file)` before instantiating SMAL so `config.dd` reflects the right skeleton.
- Recovers `theta = [global, joint_locals]` from the HDF5 layout (the replicAnt loader emits a zero-placeholder in `joint_rot[0]` because the trainer concatenates `global_rot` with `joint_rot[1:]` — see `smal_fitter.smal_fitter` ~line 262).
- **Recenters at the posed root before applying trans**: `verts = (verts - root_joint) + trans`. This matches the trainer's `use_ue_scaling=True` and `mesh_scaling` branches in `multiview_smil_regressor` (~lines 2147–2156). Without the recenter, the SMAL Falkner-conv mouse pkl's rest root at `(0, 0.72, 0.24)` produces an exactly-`(0, 0.72, 0.24)` body offset on every replicAnt sample — empirically diagnosed during this PR.
- **Silhouette rendering** rasterises the posed mesh through one OpenCV camera and returns a `(render_size, render_size)` mask in `[0, 1]`. Imports `SLEAPMultiViewDataset._sleap_to_pytorch3d_camera` lazily for the OpenCV→PyTorch3D camera conversion — avoids yet-another in-tree copy of that math.

Empirical sanity on `merged_smoke.h5` sample 5 (replicAnt origin, post-recenter):

- SMAL joint[0]+trans matches stored `kp3d[0]` to 1.9e-6
- Median diff over 31 GT joints ~0; max 0.15 = the documented mouse asset noise
- Silhouette coverage 2.158% on view 2 (mouse-sized chunk)

### `ec74727` — Wire SMAL features into the viewer

The viewer gains three optional visualisations gated by sidebar widgets:

1. **3D Plotly viewer**: adds a `Mesh3d` trace (posed verts + faces) and a `Scatter3d` trace (posed joints) alongside the existing kp3d and camera-centre traces.
2. **Per-view 2D overlay**: orange ▲ for projected SMAL joints, next to green ○ stored GT and red ✕ projected kp3d.
3. **🎨 Per-sample silhouette button**: PyTorch3D rasterises through every valid view's stored OpenCV camera and alpha-blends the mask onto the per-view image grid. Cached per `(sample_idx, smal_pkl, render_size)`; the only meaningfully slow op in the viewer, never auto-fires.

Sidebar additions:

- **SMAL pkl dropdown** lists `.pkl` files discovered under `3D_model_prep/` and `smal_model/data/` (relative paths shown for legibility). A `🗂 custom path…` entry reveals a text field that auto-converts Windows-style paths (`C:\Users\...` → `/mnt/c/...`) — empirically the friction that the v1 text-input had.
- Two checkboxes for the cheap mesh + 2D-joint overlays.
- Auto-detect hook reads `/metadata/smal_file` if any preprocessor records it (none currently do; forward-compatible).

Streamlit caching: `@cache_resource` on the SMAL model load, `@cache_data` on the SMAL forward and the silhouette pass.

## Test plan

- [x] **v1 viewer**: end-to-end smoke on `merged_smoke.h5` (5 SLEAP + 5 replicAnt samples) — metadata card, per-view image grid with overlays, 3D viewer, dataset stats all render cleanly. Internal helper smoke confirms summary/sample reads, 3D figure construction, per-view reprojection helper.
- [x] **Shared helper byte-equivalence**: SLEAP canonicalisation prototype post-refactor reproduces every pre-refactor number on `SMILymice_3D_6_cam_undistort.h5` sample 0.
- [x] **SMAL forward correctness**: on `merged_smoke.h5` sample 5, `joint[0]+trans = stored kp3d[0]` to 1.9e-6. Median diff over 31 GT joints is ~0. Without the recenter, the diff is exactly `(0, 0.721, 0.241)` = the rest root position.
- [x] **Silhouette rendering**: coverage 2.158% on view 2 (matches a pre-refactor run's 2.218% to float32/64 noise).
- [x] **Cross-source SMAL handling**: SLEAP samples (placeholder pose) auto-skip the SMAL path cleanly; replicAnt samples render the mesh.
- [x] **Path UX**: Windows-style path inputs auto-convert to WSL paths; dropdown of discovered pkls shown for low-friction selection.

## What's deferred

- **Directory-based formats** (raw replicAnt flat dir, raw JSON) — listed in v1 scope but landing later.
- **Wide-repo redundancy** kept on the TODO list: `Rz_180` is defined 4 times in-tree (3 in trainer-tested code); JPEG encode/decode helpers exist 7+ times across preprocessors. Touching either is a wider refactor with real regression risk.

## Recovery note

The five commits in this PR were originally pushed to `cross-source-multiview-merger` on top of #22, but #22 merged at the merger commit before the viewer arrived. Re-cherry-picked onto a fresh branch from current master; no semantic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
