### PR TITLE
docs: fix triangulation solver docstring to reflect normal equations,…

### DIFF
--- a/smal_fitter/neuralSMIL/multiview_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/multiview_smil_regressor.py
@@ -1679,7 +1679,7 @@ class MultiViewSMILImageRegressor(SMILImageRegressor):
         Triangulate 3D joint positions from multi-view 2D keypoints using DLT.
 
         Uses the predicted camera parameters to build projection matrices, then
-        solves the linear triangulation system per joint via SVD.
+        solves the linear triangulation system per joint via damped normal equations (Tikhonov-regularized least squares).
 
         Args:
             keypoints_2d: GT 2D keypoints ``(B, V, J, 2)`` normalised to [0, 1].


### PR DESCRIPTION
Fixes #31. The triangulate_3d_joints docstring claimed the solver uses SVD, but the implementation actually solves via damped normal equations (Tikhonov-regularized least squares) using torch.linalg.solve. Verified no other incorrect SVD references exist for this specific solver elsewhere in the codebase.