### PR TITLE
fix: define CHECKPOINT_NAME and require checkpoint via CLI or config

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ BADJA_PATH = "data/BADJA"
 STANFORD_EXTRA_PATH = "data/StanfordExtra"
 REPLICANT_PATH = "data/replicAnt_trials/SMIL_COCO"
 OUTPUT_DIR = "checkpoints/{0}".format(time.strftime("%Y%m%d-%H%M%S"))
-# Basename of a completed fit under checkpoints/; used by smal_fitter/generate_video.py (or pass --checkpoint-name).
+# Basename of a completed fit under checkpoints/; used by smal_fitter/generate_video.py (or pass --checkpoint_name).
 CHECKPOINT_NAME = None
 
 CROP_SIZE = 512  # image resolution for output

--- a/config.py
+++ b/config.py
@@ -11,6 +11,8 @@ BADJA_PATH = "data/BADJA"
 STANFORD_EXTRA_PATH = "data/StanfordExtra"
 REPLICANT_PATH = "data/replicAnt_trials/SMIL_COCO"
 OUTPUT_DIR = "checkpoints/{0}".format(time.strftime("%Y%m%d-%H%M%S"))
+# Basename of a completed fit under checkpoints/; used by smal_fitter/generate_video.py (or pass --checkpoint-name).
+CHECKPOINT_NAME = None
 
 CROP_SIZE = 512  # image resolution for output
 VIS_FREQUENCY = 50  # every how many iterations the model plots are to be generated

--- a/smal_fitter/generate_video.py
+++ b/smal_fitter/generate_video.py
@@ -40,7 +40,21 @@ class ImageExporter():
             pkl.dump(img_parameters, f)
 
 def main():
-    OUTPUT_DIR = os.path.join("exported", config.CHECKPOINT_NAME, config.EPOCH_NAME)
+    parser = argparse.ArgumentParser(description="Export visualization frames from a fitted checkpoint")
+    parser.add_argument(
+        "--checkpoint-name",
+        default=getattr(config, "CHECKPOINT_NAME", None),
+        help="Checkpoint folder name under checkpoints/ (e.g. timestamp from a training run)",
+    )
+    args = parser.parse_args()
+    checkpoint_name = args.checkpoint_name
+    if not checkpoint_name:
+        sys.exit(
+            "error: checkpoint name required — set config.CHECKPOINT_NAME or pass --checkpoint-name "
+            "(see legacy/README.md)"
+        )
+
+    OUTPUT_DIR = os.path.join("exported", checkpoint_name, config.EPOCH_NAME)
 
     # CUDA_VISIBLE_DEVICES is set at the top of this file, before torch is imported.
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
@@ -72,7 +86,7 @@ def main():
     image_exporter = ImageExporter(OUTPUT_DIR)
     model = SMALFitter(device, data, config.WINDOW_SIZE, config.SHAPE_FAMILY, use_unity_prior)
 
-    model.load_checkpoint(os.path.join("checkpoints", config.CHECKPOINT_NAME), config.EPOCH_NAME)
+    model.load_checkpoint(os.path.join("checkpoints", checkpoint_name), config.EPOCH_NAME)
     model.generate_visualization(image_exporter) # Final stage
 
 if __name__ == '__main__':

--- a/smal_fitter/generate_video.py
+++ b/smal_fitter/generate_video.py
@@ -42,7 +42,7 @@ class ImageExporter():
 def main():
     parser = argparse.ArgumentParser(description="Export visualization frames from a fitted checkpoint")
     parser.add_argument(
-        "--checkpoint-name",
+        "--checkpoint_name",
         default=getattr(config, "CHECKPOINT_NAME", None),
         help="Checkpoint folder name under checkpoints/ (e.g. timestamp from a training run)",
     )
@@ -50,7 +50,7 @@ def main():
     checkpoint_name = args.checkpoint_name
     if not checkpoint_name:
         sys.exit(
-            "error: checkpoint name required — set config.CHECKPOINT_NAME or pass --checkpoint-name "
+            "error: checkpoint name required — set config.CHECKPOINT_NAME or pass --checkpoint_name "
             "(see legacy/README.md)"
         )
 


### PR DESCRIPTION
Fixes #29

`generate_video.py` referenced `config.CHECKPOINT_NAME`, which was never defined in `config.py`, causing `AttributeError` on run.

- Define `CHECKPOINT_NAME = None` in `config.py` with a short comment.
- Add `--checkpoint-name` CLI argument; exit with a clear error if still unset.

Matches legacy/README guidance for checkpoint naming.