### PR TITLE
Docs: clarify behavior of --export_animation flag in inference scripts

### DIFF
--- a/docs/design/animation_export_plan.md
+++ b/docs/design/animation_export_plan.md
@@ -22,6 +22,7 @@ those trajectories first-class, shareable outputs.
 1. **Phase 1 — Lossless Python export.** ✅ Done — AMASS-compatible `.npz`
    + human-readable `.json` sidecar, written from both inference scripts behind
    a `--export_animation PATH` flag.
+   *(Note: The flag takes any string as a literal path stem with no type/format checking — so passing something like `True` or `test` will silently create `True.npz`/`test.npz` rather than erroring.)*
 2. **Phase 2 — Blender addon importer.** ✅ Operator implemented and
    registered; awaiting end-to-end test in Blender 4.2 with a real `.npz`.
 3. **Phase 3 — Addon-side export to shareable formats.** ⏳ Not started —

--- a/smal_fitter/neuralSMIL/run_multiview_inference.py
+++ b/smal_fitter/neuralSMIL/run_multiview_inference.py
@@ -1517,7 +1517,9 @@ def main():
     parser.add_argument("--export_animation", type=str, default=None,
                         help="Optional output path stem for SMIL animation export. "
                              "Writes <stem>.npz + <stem>.json with raw (pre-smoothing) parameters "
-                             "and per-view cameras. Gathered to rank 0 in multi-GPU runs.")
+                             "and per-view cameras. Gathered to rank 0 in multi-GPU runs. "
+                             "NOTE: any string is accepted as-is (e.g. \"True\" writes True.npz) — "
+                             "no validation is performed, so pass a real path/filename stem.")
     parser.add_argument("--render_resolution", type=int, default=None,
                         help="Square pixel resolution for the single-view mesh visualization. "
                              "The mesh is rendered and the background footage interpolated up to "

--- a/smal_fitter/neuralSMIL/run_singleview_inference.py
+++ b/smal_fitter/neuralSMIL/run_singleview_inference.py
@@ -1474,7 +1474,9 @@ Supported video formats: mp4, avi, mov, mkv (anything supported by OpenCV)
     parser.add_argument('--export_animation', type=str, default=None,
                        help='Optional output path stem for SMIL animation export. '
                             'Writes <stem>.npz + <stem>.json alongside the MP4. '
-                            'Only active when --input_video is used.')
+                            'Only active when --input_video is used. '
+                            'NOTE: any string is accepted as-is (e.g. "True" writes True.npz) — '
+                            'no validation is performed, so pass a real path/filename stem.')
 
     args = parser.parse_args()
     


### PR DESCRIPTION
## Summary

Clarifies the `--export_animation` flag's behavior in both inference scripts
and the animation export design doc. No logic changes.

Closes #35

## Context

`--export_animation` is `type=str` with no validation — it's passed straight
through to `AnimationRecorder`, which does `Path(output_path).with_suffix(...)`.
So `--export_animation True` silently creates `True.npz` / `True.json` instead
of erroring, since any string is a valid path stem.

Per the tracker note on this (C7 in CODE_FIXES_TODO.md), the intended
resolution is documentation rather than added validation, so this PR only
updates help text and docs to make the behavior explicit up front.

## Changes

- `smal_fitter/neuralSMIL/run_singleview_inference.py`: expanded
  `--export_animation` help string to note any string is accepted as-is,
  with no format/type checking.
- `smal_fitter/neuralSMIL/run_multiview_inference.py`: same help string
  clarification.
- `docs/design/animation_export_plan.md`: added a note under the Phase 1
  section documenting the no-validation behavior.

## Verification

- `python run_singleview_inference.py --help` / `run_multiview_inference.py --help`
  — confirmed updated help text renders cleanly.
- Confirmed the described behavior: `Path("True").with_suffix(".npz")` →
  `True.npz`, matching what's now documented.
- `git diff --stat` — confirms only help-string/doc lines changed, no logic
  touched.
- `pytest tests/test_animation_export.py -v` — existing tests unaffected, all
  passing.
