### PR TITLE
fix(train): don't reset to epoch 0 when resuming with a different batch size

### DIFF
--- a/smal_fitter/neuralSMIL/train_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/train_smil_regressor.py
@@ -1144,7 +1144,33 @@ def load_checkpoint(checkpoint_path, model, optimizer, device, is_distributed=Fa
                 new_state_dict[new_key] = value
             model_state_dict = new_state_dict
 
-        model.load_state_dict(model_state_dict, strict=False)
+        # Drop checkpoint entries whose shape doesn't match the current model.
+        # `strict=False` only suppresses missing/unexpected keys, NOT shape
+        # mismatches on matched keys — those raise a RuntimeError and abort the
+        # entire load. The batch-sized per-frame scratch params inherited from
+        # SMALFitter (global_rotation, trans, joint_rotations, log_beta_scales,
+        # betas_trans) carry a leading dim equal to the batch size, so resuming
+        # with a different batch size than the checkpoint was made with would
+        # otherwise silently fall back to training from scratch. These params are
+        # overwritten every forward pass, so skipping them loses nothing.
+        current_state = model.state_dict()
+        filtered_state_dict = {}
+        skipped_shape_mismatch = []
+        for key, value in model_state_dict.items():
+            if key in current_state and current_state[key].shape != value.shape:
+                skipped_shape_mismatch.append((key, tuple(value.shape), tuple(current_state[key].shape)))
+                continue
+            filtered_state_dict[key] = value
+
+        if skipped_shape_mismatch:
+            log(
+                f"Skipping {len(skipped_shape_mismatch)} checkpoint param(s) with shape mismatch "
+                "(kept current-model init; typically batch-sized scratch params):"
+            )
+            for key, ckpt_shape, model_shape in skipped_shape_mismatch:
+                log(f"  ~ {key}: checkpoint={ckpt_shape}, model={model_shape}")
+
+        model.load_state_dict(filtered_state_dict, strict=False)
         log("Model state loaded successfully")
 
         # Get epoch information first (before trying to load optimizer)


### PR DESCRIPTION
## What & why

Resuming neural-SMIL training from a checkpoint **silently reset training to epoch 0** whenever the run's `batch_size` differed from the checkpoint's. The log said `Starting training from scratch...`, but weights were actually still copied in-place — what got lost was `start_epoch`, and with it the **loss curriculum stage, LR schedule position, optimizer momentum, and best-val/history**. The result looked like the model regressing.

Fixes #71.

## Root cause

`SMALFitter` registers five per-frame tensors as `nn.Parameter` sized to the batch (`global_rotation`, `trans`, `joint_rotations`, `log_beta_scales`, `betas_trans`). In the regressor these are pure per-batch scratch buffers (rewritten every forward pass) but still land in the `state_dict` carrying the batch dim.

`load_checkpoint` used `load_state_dict(..., strict=False)`. `strict=False` suppresses *missing/unexpected* keys only — a **shape mismatch on a matched key still raises `RuntimeError`**, which the broad `except Exception` swallowed into a false "from scratch" fallback (`start_epoch=0`).

## The fix

Pre-filter checkpoint entries whose shape doesn't match the current model (logging what was skipped) before calling `load_state_dict`. Batch-size-independent weights (backbone, head, betas, fov) load normally; the vestigial batch-sized scratch params are dropped — they carry no learned information — so `start_epoch` and the curriculum survive a batch-size change.

## Verification

- `python -c "import ast; ast.parse(...)"` — parses; `ruff check` — clean.
- Round-trip unit check (checkpoint `bs=6` → model `bs=16`):
  - no exception raised,
  - batch-sized scratch param (`buf`) skipped, current `bs=16` init retained,
  - batch-independent `head.weight` loaded correctly (`3.14`).

## Follow-up (not in this PR)

Register those five buffers with `persistent=False` (or exclude them at save time) so they never enter the checkpoint at all.
