### PR TITLE
set CUDA_VISIBLE_DEVICES before `import torch` in neuralSMIL entrypoints (#73)

### DIFF
--- a/smal_fitter/neuralSMIL/main.py
+++ b/smal_fitter/neuralSMIL/main.py
@@ -1,9 +1,12 @@
-import torch
 import os
-
+import config
 # Add the parent directories to the path to import modules
 # not very pretty, but it works.
 
+os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", config.GPU_IDS)
+
+import torch
 from smal_fitter.neuralSMIL.smil_datasets import replicAntSMILDataset
 from smal_fitter.neuralSMIL.smil_image_regressor import SMILImageRegressor
 import config
@@ -95,10 +98,6 @@ def demonstrate_smil_regressor():
 
 
 if __name__ == "__main__":
-    # set the device to use (first available GPU by default)
-    os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-    os.environ["CUDA_VISIBLE_DEVICES"] = config.GPU_IDS
-
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
     # Demonstrate the SMIL Image Regressor

--- a/smal_fitter/neuralSMIL/test_smil_regressor_ground_truth.py
+++ b/smal_fitter/neuralSMIL/test_smil_regressor_ground_truth.py
@@ -15,10 +15,26 @@ This test ensures that:
 - The optimization doesn't introduce errors
 """
 
-import torch
-import numpy as np
 import os
 import sys
+import config
+
+# Pre-parse --device before importing torch so CVD is set correctly.
+# argparse's full parse happens later in main();
+if "--device" in sys.argv:
+    _i = sys.argv.index("--device")
+    _dev = sys.argv[_i + 1] if _i + 1 < len(sys.argv) else "cpu"
+else:
+    _dev = "cpu"
+
+if _dev == "cuda":
+    os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+    os.environ.setdefault("CUDA_VISIBLE_DEVICES", config.GPU_IDS)
+
+
+import torch
+import numpy as np
+
 import cv2
 from typing import Dict, Any
 
@@ -1247,8 +1263,6 @@ def main():
 
     # Set up environment
     if args.device == "cuda":
-        os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-        os.environ["CUDA_VISIBLE_DEVICES"] = config.GPU_IDS
         device = "cuda" if torch.cuda.is_available() else "cpu"
         if device == "cpu":
             print("Warning: CUDA requested but not available, using CPU")

--- a/smal_fitter/neuralSMIL/train_multiview_regressor.py
+++ b/smal_fitter/neuralSMIL/train_multiview_regressor.py
@@ -11,9 +11,18 @@ Key Features:
 - Per-view 2D keypoint loss with visibility weighting
 """
 
+# ===== CRITICAL: CUDA env vars BEFORE any torch import =====
+import os
+import config as _cfg_for_env
+
+os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", _cfg_for_env.GPU_IDS)
+del _cfg_for_env
+
 # ===== CRITICAL: Force IPv4 BEFORE any other imports =====
 # This prevents "Address family not supported by protocol" (errno: 97) errors
 # on HPC systems that don't have full IPv6 support
+
 import socket
 
 _original_getaddrinfo = socket.getaddrinfo
@@ -2273,7 +2282,6 @@ def main(config: dict):
     if device_override:
         device = device_override
     else:
-        os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
         device = "cuda" if torch.cuda.is_available() else "cpu"
 
     if rank == 0:

--- a/smal_fitter/neuralSMIL/train_smil_regressor.py
+++ b/smal_fitter/neuralSMIL/train_smil_regressor.py
@@ -27,6 +27,14 @@ if "CUDA_VISIBLE_DEVICES" not in os.environ:
     except Exception:
         pass
 
+# Single-GPU default: set CVD before any torch import. setdefault means the
+# multi-GPU branch above and any externally-set CVD both take precedence.
+import config as _cfg_for_env
+
+os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", _cfg_for_env.GPU_IDS)
+del _cfg_for_env
+
 # Set matplotlib backend BEFORE any other imports to prevent tkinter issues
 import matplotlib
 
@@ -1520,10 +1528,6 @@ def main(dataset_name=None, checkpoint_path=None, config_override=None):
         if not is_distributed or rank == 0:
             print(f"Using device override: {device}")
     else:
-        # setdefault so an external CUDA_VISIBLE_DEVICES (e.g. "0,1" for multi-GPU)
-        # is respected instead of being force-pinned to config.GPU_IDS.
-        os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
-        os.environ.setdefault("CUDA_VISIBLE_DEVICES", config.GPU_IDS)
         device = "cuda" if torch.cuda.is_available() else "cpu"
         if not is_distributed or rank == 0:
             print(f"Using device: {device}")

--- a/smal_fitter/optimize_to_joints.py
+++ b/smal_fitter/optimize_to_joints.py
@@ -1,15 +1,15 @@
 import os
 
-# Set CUDA device visibility BEFORE importing torch: torch >= 2.3 raises an INTERNAL
-# ASSERT ("device >= 0 && device < num_gpus") if CUDA_VISIBLE_DEVICES is changed after
-# CUDA has been initialized. config.py imports no torch, so this is safe here.
-# Use setdefault so an explicit external CUDA_VISIBLE_DEVICES (e.g. "0,1" for
-# multi-GPU DDP training) is respected — importing this module must NOT silently
-# pin visibility to a single GPU.
-import config
+# CUDA_VISIBLE_DEVICES must be set before `import torch` (torch >= 2.3 raises
+# an INTERNAL ASSERT if CVD changes after CUDA init). Guarded on __main__ so
+# importing this module as a library has no CVD side-effect on the importer.
+# See issue #73.
+if __name__ == "__main__":
+    import config as _cfg_for_env
 
-os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", config.GPU_IDS)
+    os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+    os.environ.setdefault("CUDA_VISIBLE_DEVICES", _cfg_for_env.GPU_IDS)
+    del _cfg_for_env
 
 import numpy as np
 import argparse
@@ -24,8 +24,6 @@ from smal_fitter.data_loader import load_badja_sequence, load_stanford_sequence,
 import trimesh
 
 from tqdm import trange
-
-import os
 
 
 class ImageExporter:
@@ -185,4 +183,13 @@ def main():
 
 
 if __name__ == "__main__":
+    # Set CVD before torch touches CUDA. Safe here because __main__ runs after
+    # imports, but torch.cuda has not been initialized yet in typical use, any
+    # entrypoint that needs strict pre-torch CVD should set it in its own
+    # top-of-file block (see train_smil_regressor.py, benchmark_model.py).
+    import config as _cfg_for_env
+
+    os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+    os.environ.setdefault("CUDA_VISIBLE_DEVICES", _cfg_for_env.GPU_IDS)
+    del _cfg_for_env
     main()


### PR DESCRIPTION
# fix(cuda): set CUDA_VISIBLE_DEVICES before `import torch` in neuralSMIL entrypoints (#73)

`torch >= 2.3` raises `"device >= 0 && device < num_gpus INTERNAL ASSERT FAILED"` if `CUDA_VISIBLE_DEVICES` changes after CUDA initialization. This PR normalizes CVD handling repo-wide so it is set before any `torch` import, and removes the import-time CVD side-effect from `optimize_to_joints.py`.

### Changes Implemented

* **`smal_fitter/neuralSMIL/main.py`**
  * Moved CVD setup above `import torch`.
  * Dropped late direct-assignment writes in `main()`.
* **`smal_fitter/neuralSMIL/test_smil_regressor_ground_truth.py`**
  * Peek `--device` from `sys.argv` before the `torch` import.
  * Dropped late write in `main()`.
* **`smal_fitter/neuralSMIL/train_multiview_regressor.py`**
  * Set `CUDA_DEVICE_ORDER` and CVD (`setdefault`) at the top of the file.
  * Dropped late `CUDA_DEVICE_ORDER` write in `main()`.
* **`smal_fitter/neuralSMIL/train_smil_regressor.py`**
  * Added unconditional single-GPU CVD `setdefault` after the existing multi-GPU branch.
  * Dropped late `setdefault` block in `main()`.
* **`smal_fitter/optimize_to_joints.py`**
  * Guarded the top-of-file CVD write behind a `if __name__ == "__main__":` block so importing the module no longer writes `CUDA_VISIBLE_DEVICES` on downstream importers.

> [!NOTE]
> All writes now use `.setdefault()` so that an externally-set CVD (e.g., from a cluster job scheduler or multi-GPU DDP) is properly respected.

Fixes #73