### PR TITLE
chore: post-purge fixes + contributor/fork guidance (#84)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Shell scripts must always check out with LF, regardless of core.autocrlf.
+# With autocrlf=true on Windows these were checked out CRLF, which makes them
+# unrunnable in bash/WSL ("syntax error near unexpected token $'do\r'") and on
+# the Linux HPC cluster. Git already stores them as LF; this pins the checkout.
+*.sh text eol=lf
+
+# Same reasoning for other Unix-executed text.
+*.sbatch text eol=lf
+
+# PowerShell is Windows-side; keep CRLF.
+*.ps1 text eol=crlf
+
+# Never touch line endings inside binary assets. Parametric models, meshes and
+# archives are byte-sensitive: a stray CRLF conversion corrupts them.
+*.pkl binary
+*.npz binary
+*.npy binary
+*.h5 binary
+*.pth binary
+*.blend binary
+*.glb binary
+*.zip binary
+*.avi binary
+*.mp4 binary
+*.gif binary
+*.png binary
+*.jpg binary

--- a/docs/THIRD_PARTY_MODELS.md
+++ b/docs/THIRD_PARTY_MODELS.md
@@ -42,23 +42,90 @@ naming prefix. They are **not** SMPL and are unaffected by the above:
 - `data/priors/unity_*` — generated from our own replicAnt synthetic data by
   [`data/priors/prepare_shape_prior.py`](../data/priors/prepare_shape_prior.py).
 
-## Purging them from git history
+## The history purge (done 2026-07-16)
 
-Untracking these files stops them being distributed *going forward*, but every
-historical commit still carries the blobs, so they remain downloadable. Fully
-removing them means rewriting all history:
+These files were not only untracked but purged from **all** git history. `master`
+is now `626bb22`, and a fresh clone contains none of the licensed blobs.
+
+The tooling is kept in [`scripts/purge_licensed_blobs.sh`](../scripts/purge_licensed_blobs.sh)
+in case it is ever needed again:
 
 ```bash
 ./scripts/purge_licensed_blobs.sh            # dry run: report only
 ./scripts/purge_licensed_blobs.sh --execute  # rewrite a mirror clone locally
 ```
 
-Neither mode writes to the remote — `--execute` rewrites a throwaway mirror
-clone and prints the force-push commands for you to run deliberately.
+Neither mode writes to the remote — `--execute` rewrites a mirror clone and
+prints the force-push commands to run deliberately.
 
 A rewrite alone is **not** sufficient: GitHub still serves unreachable blobs by
 SHA and from forks, so it must be followed by a GitHub Support ticket and
-coordination with fork owners. The script prints the full checklist.
+coordination with fork owners.
+
+## What contributors and fork owners need to do
+
+Because all history was rewritten, **every commit has a new SHA**. Old clones and
+forks still contain the licensed blobs and will reintroduce them if pushed.
+
+> **Back up your model files first.** These files are git-ignored now, but if
+> your clone predates the purge they were *tracked*, so `git reset --hard` onto
+> the rewritten history **deletes them from disk**. Copy them somewhere safe
+> before you start, then copy them back afterwards.
+
+### If you have a clone
+
+Simplest and safest is to **re-clone**. To keep an existing clone instead:
+
+```bash
+cp -r smal_model/smpl/models /tmp/model-backup          # back up (see warning)
+cp data/priors/*_pose_prior_with_cov_35parts*.pkl /tmp/model-backup/
+
+git fetch origin
+git checkout master
+git reset --hard origin/master                          # deletes the files above
+git reflog expire --expire=now --expire-unreachable=now --all
+git repack -ad && git prune --expire=now                # `gc` alone is NOT enough
+
+cp -r /tmp/model-backup/models smal_model/smpl/         # restore your copies
+cp /tmp/model-backup/*.pkl data/priors/
+```
+
+`git gc --prune=now` does **not** remove the blobs — they sit in an existing
+pack, and only `git repack -ad` rewrites it to evict them. Verify with:
+
+```bash
+git cat-file -e f5337df59c61c6825ec1dda302d38bfa09dcacc4 && echo "STILL PRESENT" || echo "purged"
+```
+
+Any local branch created before the purge still carries the blobs. Rebase it
+onto the rewritten `master` (`git rebase --onto origin/master <old-base> <branch>`)
+rather than merging, and never force-push a pre-purge branch.
+
+### If you have a fork
+
+A force-push to this repository does **not** touch forks, and GitHub keeps forks
+in a shared object store — so blobs can stay reachable through a fork even after
+the parent is clean. Please either:
+
+- **Delete the fork** and re-fork if you still need it (cleanest), or
+- Reset it onto the rewritten history and force-push your own fork:
+
+  ```bash
+  git remote add upstream https://github.com/FabianPlum/SMILify.git
+  git fetch upstream
+  git checkout master && git reset --hard upstream/master
+  git push --force origin master
+  ```
+
+Open PRs raised from pre-purge branches must be rebased onto the new `master`
+or closed and reopened; their old commits no longer exist upstream.
+
+### Note on the contribution graph
+
+The rewrite gives every commit a new SHA while preserving author dates, so
+GitHub credits the rewritten commits *in addition to* the originals. Profile
+commit counts are inflated as a result. This is cosmetic — no work was
+duplicated or lost — and is inherent to any `filter-repo` history rewrite.
 
 ## Please don't re-add them
 

--- a/scripts/purge_licensed_blobs.sh
+++ b/scripts/purge_licensed_blobs.sh
@@ -10,23 +10,39 @@
 #   ./scripts/purge_licensed_blobs.sh            # dry run: report only, no writes
 #   ./scripts/purge_licensed_blobs.sh --execute  # rewrite a mirror clone locally
 #
-# Even --execute does NOT touch the remote. It rewrites a throwaway mirror clone
-# under /tmp and prints the force-push commands for you to run deliberately.
+# Even --execute does NOT touch the remote. It rewrites a mirror clone and
+# prints the force-push commands for you to run deliberately.
+#
+# STATUS: this purge was executed on 2026-07-16. master is now 626bb22 and a
+# fresh clone carries none of the licensed blobs. The notes below are kept for
+# anyone re-running it (e.g. if blobs are ever reintroduced).
 #
 # READ THIS FIRST -- a rewrite is NOT sufficient on its own:
-#   1. Force-pushing rewrites all 14 branches. Open PRs (#79, #81) will need
-#      rebasing; every existing clone must re-clone. Coordinate first.
-#   2. GitHub keeps unreachable blobs reachable by SHA and serves them from the
-#      5 forks. After force-pushing you MUST open a GitHub Support ticket asking
+#   1. Force-pushing rewrites every branch. Open PRs need rebasing and every
+#      existing clone must re-clone. Coordinate first.
+#   2. GitHub keeps unreachable blobs reachable by SHA and serves them from
+#      forks. After force-pushing you MUST open a GitHub Support ticket asking
 #      them to purge cached views, and ask fork owners to delete/re-fork.
 #   3. Treat the SMPL/SMAL copies as having been public. If that matters
 #      contractually, tell MPI rather than relying on a silent rewrite.
+#   4. A force-push INFLATES the GitHub contribution graph: rewritten commits
+#      keep their author dates but get new SHAs, so GitHub credits them again
+#      on top of the originals. Cosmetic, but expect ~1 extra "commit" per
+#      rewritten commit on your profile. There is no clean fix short of asking
+#      GitHub Support.
+#   5. Merge any pending PR BEFORE purging. Otherwise its base and head are both
+#      rewritten and the PR breaks; and master ends up with the blobs stripped
+#      but without the .gitignore guard that lives on the PR branch.
 #
 set -euo pipefail
 
 # Source to clone. Override to rehearse the rewrite against a local copy
 # without hitting the network, e.g.  PURGE_SOURCE=. ./scripts/purge_licensed_blobs.sh --execute
 PURGE_SOURCE="${PURGE_SOURCE:-https://github.com/FabianPlum/SMILify}"
+
+# Where a deliberate force-push would go. Kept separate from PURGE_SOURCE so a
+# local-path rehearsal (PURGE_SOURCE=.) still prints the real remote.
+PUSH_REMOTE="${PUSH_REMOTE:-https://github.com/FabianPlum/SMILify.git}"
 
 # Deliberately NOT /tmp: the rewritten mirror must survive between the rewrite
 # and the force-push, and /tmp is wiped on WSL session restart (observed during
@@ -130,16 +146,30 @@ if [[ $fail -ne 0 ]]; then
   echo; echo "Verification FAILED -- do not push. Inspect ${MIRROR}"; exit 1
 fi
 
+# git-filter-repo deliberately removes the 'origin' remote after rewriting, to
+# stop you force-pushing by reflex. Re-add it so the commands printed below
+# actually run; this does NOT push anything.
+git -C "$MIRROR" remote remove origin 2>/dev/null || true
+git -C "$MIRROR" remote add origin "$PUSH_REMOTE"
+
 cat <<EOF
 
 --- Rewrite complete and verified, locally only. ---
 Rewritten mirror: ${MIRROR}
+Origin re-added : ${PUSH_REMOTE}  (nothing pushed)
 
 Nothing has been pushed. When you have coordinated with collaborators and
 fork owners, push deliberately from the mirror:
 
-    git -C "${MIRROR}" push --force --all
-    git -C "${MIRROR}" push --force --tags
+    git -C "${MIRROR}" push --force --all origin
+    git -C "${MIRROR}" push --force --tags origin
+
+Both are required: tags are branch archives here and pin old commits, so
+pushing branches alone would leave the blobs reachable via tags.
+
+The pushing clone needs credentials for the remote. A mirror cloned over
+plain https in a bare WSL shell typically has none and will hang on a
+credential prompt; push from wherever your git/gh auth already works.
 
 Then, and only then:
   - Open a GitHub Support ticket to purge cached blob views + fork copies.


### PR DESCRIPTION
Follow-up to #85. The history purge has been **executed**: `master` is now `626bb22` and a fresh clone contains none of the licensed blobs. This fixes bugs found while running it for real, and answers "what do contributors and fork owners need to do?"

## Bugs fixed in `scripts/purge_licensed_blobs.sh`

Found by actually executing the purge — the script worked, but its *instructions* were wrong:

- **The printed push commands could not run.** `git-filter-repo` removes the `origin` remote by design, so `git -C <mirror> push --force --all` failed. Now re-added automatically (still pushes nothing).
- **Tags were under-emphasised.** All 30 tags are `archive/*` branch archives that pin old commits — pushing branches alone would have left the blobs reachable via tags. Both pushes are now printed with the reason.
- **Credential hang.** A bare mirror cloned over https has no auth and hangs silently on a credential prompt with zero output. Now documented.
- Documents two things learned the hard way: merge pending PRs **before** purging (otherwise the PR's base and head are both rewritten and master gets the blobs stripped without the `.gitignore` guard), and that a force-push **inflates the GitHub contribution graph**.

## Contributor + fork guidance (`docs/THIRD_PARTY_MODELS.md`)

Every commit has a new SHA, so old clones/forks still hold the blobs and will reintroduce them if pushed.

- **Forks aren't touched by the parent's force-push**, and GitHub keeps forks in a shared object store — so blobs stay reachable through a fork even after the parent is clean. Fork owners should delete/re-fork, or reset onto the rewritten history and force-push their own fork.
- **Back up your model files before `git reset --hard`.** In pre-purge clones these files were *tracked*, so resetting onto the rewritten history **deletes them from disk**. I hit exactly this during the purge and had to restore them from the old blobs.
- **`git gc --prune=now` does NOT evict the blobs.** They sit in an existing pack; only `git repack -ad` rewrites it. This cost real time to diagnose — `gc` reported success while leaving all 5 blobs present. A one-line verification command is included.

## New `.gitattributes`

**Pre-existing bug, not introduced by this work.** The repo had no `.gitattributes`, so with `core.autocrlf=true` every `*.sh` checked out CRLF on Windows and died in bash/WSL:

```
syntax error near unexpected token $'do\r'
```

`hpc_files/install.sh` is meant to run on the Linux cluster, so this was a live hazard. Now pins `*.sh`/`*.sbatch` to LF, `*.ps1` to CRLF, and marks binary assets (`*.pkl`, `*.npz`, `*.blend`, …) as `binary` so no EOL conversion can ever corrupt a parametric model.

## Verification

- All three shell scripts pass `bash -n` and run.
- The purge script's own dry-run now reports **0 commits touching any licensed path** (was 3 each) — an independent confirmation the purge took.
- Fast test suite unchanged: **78 passed, 6 skipped**.
- Committed blobs confirmed LF; script retains mode `100755`.

## Note on the contribution graph

The rewrite gives every commit a new SHA while preserving author dates, so GitHub credits the rewritten commits *in addition to* the originals — inflating profile commit counts by roughly the number of rewritten commits. It is cosmetic (no work duplicated or lost) and inherent to any `filter-repo` rewrite. Documented rather than fixed; only GitHub Support can reconcile it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
