### PR TITLE
Fix issue #24

### DIFF
--- a/3D_model_prep/smil_importer/core_mesh.py
+++ b/3D_model_prep/smil_importer/core_mesh.py
@@ -9,10 +9,7 @@ import bpy
 import numpy as np
 from mathutils import Vector
 
-try:
-    from scipy.spatial import KDTree
-except ImportError:  # pragma: no cover
-    KDTree = None
+from .dependencies import require_scipy_kdtree
 
 
 def ensure_mesh(func):
@@ -545,7 +542,9 @@ def compute_symmetric_pairs(vertices, axis="y", tolerance=0.01):
     reflected_vertices = vertices.copy()
     reflected_vertices[:, sym_axis_idx] *= -1
 
-    # Build KDTree for the reflected vertices
+    # Build KDTree for the reflected vertices (scipy resolved lazily; raises a
+    # clean missing-deps message if scipy is unavailable — issue #92-16).
+    KDTree = require_scipy_kdtree()
     tree = KDTree(reflected_vertices)
 
     # Find symmetric pairs within the tolerance

--- a/3D_model_prep/smil_importer/dependencies.py
+++ b/3D_model_prep/smil_importer/dependencies.py
@@ -59,6 +59,49 @@ def get_missing():
     return [pip_name for mod, pip_name in DEPENDENCIES if importlib.util.find_spec(mod) is None]
 
 
+def require_scipy_kdtree():
+    """Return scipy's ``KDTree``, resolving the import lazily at call time.
+
+    Binding scipy/sklearn once at add-on registration froze them to ``None`` for
+    the whole session: right after "Install dependencies", ``find_spec`` reports
+    the package as present (so the operator gates pass) while the frozen module
+    binding is still ``None`` -> opaque ``TypeError: 'NoneType' object is not
+    callable`` (issue #92-16). Resolving here retries once after refreshing the
+    import caches, then raises a clean, actionable message instead.
+    """
+    try:
+        from scipy.spatial import KDTree
+    except ImportError:
+        user_modules_dir()
+        importlib.invalidate_caches()
+        try:
+            from scipy.spatial import KDTree
+        except ImportError:
+            raise RuntimeError(MISSING_MESSAGE)
+    return KDTree
+
+
+def require_sklearn():
+    """Return ``(PCA, EmpiricalCovariance)`` from scikit-learn, imported lazily.
+
+    Same import-then-retry-once pattern as :func:`require_scipy_kdtree`, so the
+    PCA features work in the same session after installing dependencies without a
+    Blender restart.
+    """
+    try:
+        from sklearn.decomposition import PCA
+        from sklearn.covariance import EmpiricalCovariance
+    except ImportError:
+        user_modules_dir()
+        importlib.invalidate_caches()
+        try:
+            from sklearn.decomposition import PCA
+            from sklearn.covariance import EmpiricalCovariance
+        except ImportError:
+            raise RuntimeError(MISSING_MESSAGE)
+    return PCA, EmpiricalCovariance
+
+
 def _python_executable():
     """Path to the Python interpreter bundled with Blender.
 

--- a/3D_model_prep/smil_importer/measurements.py
+++ b/3D_model_prep/smil_importer/measurements.py
@@ -42,6 +42,10 @@ def store_smpl_data(context, data, obj=None):
     try:
         obj[SMPL_DATA_PROP] = _encode_smpl_data(data)
         obj["has_smpl_data"] = True
+        # Cheap flag so the "Apply Pose Correctives" poll can gate the operator
+        # without unpickling the whole blob on every UI redraw (issue #24 / #92-15).
+        posedirs = data.get("posedirs")
+        obj["has_posedirs"] = bool(isinstance(posedirs, np.ndarray) and posedirs.size > 0)
         context.scene.smpl_tool.has_smpl_data = True
     except Exception as e:
         print(f"Failed to embed SMPL data on {obj.name!r}: {e}")

--- a/3D_model_prep/smil_importer/model_build.py
+++ b/3D_model_prep/smil_importer/model_build.py
@@ -71,14 +71,43 @@ def load_npz_file(filepath):
         return None
 
 
-def apply_pose_correctives(obj, posedirs, base_vertices):
+def apply_pose_correctives(obj, posedirs, base_vertices, joint_names=None):
     """
-    Apply pose-dependent corrective shape keys based on current armature pose.
+    Apply pose-dependent corrective shape keys based on the current armature pose.
+
+    This reproduces the SMPL/SMAL pose-blend-shape term used in
+    ``smal_model/smal_torch.py``::
+
+        pose_feature = flatten( R_local[j] - I  for j in 1..J-1 )   # model frame
+        v_offset     = reshape( pose_feature @ posedirs_mat , [V, 3] )
+        v_posed      = v_template + v_offset                        # BEFORE skinning
+
+    The correctives are written back into the REST mesh (``obj.data.vertices.co``);
+    the Armature modifier then applies linear-blend skinning on top, exactly like
+    the reference pipeline where correctives are added to the un-posed vertices.
+
+    Two things must match the reference for the offsets to be correct (issue #24):
+
+    1. **Rotation frame.** ``pose_bone.matrix_basis`` is the pose rotation expressed
+       in the bone's *local* rest frame ``B`` (the armature builder points every
+       bone along +Z via ``tail = head + [0, 0, 0.1]``, so ``B != I``). The SMPL
+       posedirs expect the joint rotation in the *model* frame, so we conjugate:
+       ``R_model = B @ matrix_basis @ B.T``. Feeding ``matrix_basis`` directly (the
+       previous behaviour) applied the correction in the wrong basis.
+
+    2. **Joint order.** The pose_feature blocks must follow the kintree/joint-index
+       order the posedirs were built in, so we look bones up by ``joint_names`` in
+       order and skip the root (joint 0), matching ``Rs[:, 1:]`` in smal_torch.
 
     Args:
-    - obj (bpy.types.Object): The mesh object to apply corrections to
-    - posedirs (numpy.ndarray): Array of shape (num_vertices, 3, num_joints * 9) containing pose-dependent deformations
-    - base_vertices (numpy.ndarray): Array of shape (num_vertices, 3) containing base vertex positions
+    - obj (bpy.types.Object): The mesh object to apply corrections to.
+    - posedirs (numpy.ndarray): Array of shape (num_vertices, 3, (num_joints-1) * 9)
+      containing the pose-dependent deformation basis.
+    - base_vertices (numpy.ndarray): Array of shape (num_vertices, 3) with the base
+      (rest / v_template) vertex positions. Correctives are added on top of these,
+      so re-running is idempotent.
+    - joint_names (list[str] | None): Bone names in joint-index order (index 0 is the
+      root). If None, falls back to the armature's pose-bone order (legacy behaviour).
     """
     # Find the armature
     armature = obj.find_armature()
@@ -90,73 +119,74 @@ def apply_pose_correctives(obj, posedirs, base_vertices):
     bpy.context.view_layer.objects.active = armature
     bpy.ops.object.mode_set(mode="POSE")
 
-    # Get pose bones (excluding root)
-    pose_bones = armature.pose.bones[1:]  # Skip root bone
+    # Select the pose bones in joint-index order (skipping the root, joint 0) so the
+    # pose_feature blocks line up with the posedirs basis. Fall back to collection
+    # order only if we were not told the joint order.
+    if joint_names is not None:
+        pose_bones = []
+        for name in joint_names[1:]:
+            pb = armature.pose.bones.get(name)
+            if pb is None:
+                print(f"Warning: pose bone '{name}' not found; skipping.")
+                continue
+            pose_bones.append(pb)
+    else:
+        pose_bones = list(armature.pose.bones[1:])  # legacy fallback: skip root bone
 
-    # Store current vertex positions (these are the skinned positions without correctives)
-    if "base_skinned_positions" not in obj:
-        # Get current deformed vertex positions (from regular skinning)
-        world_matrix = np.array(obj.matrix_world)
-        world_matrix_inv = np.array(obj.matrix_world.inverted())
-        base_skinned_positions = np.array([np.array(obj.matrix_world @ v.co) for v in obj.data.vertices])
-        # Store these positions for future resets
-        obj["base_skinned_positions"] = base_skinned_positions.tobytes()
-        obj["world_matrix"] = world_matrix.tobytes()
-        obj["world_matrix_inv"] = world_matrix_inv.tobytes()
-
-    # Prepare pose feature vector
+    # Prepare pose feature vector: (R_model - I) flattened per non-root joint.
     pose_feature = []
     for bone in pose_bones:
-        # Get bone's current rotation matrix in local space and convert to numpy
-        R = np.array(bone.matrix_basis.to_3x3())
-        # Compute difference from identity
-        R_diff = R - np.eye(3)
-        # Flatten and add to pose feature vector
-        pose_feature.extend(R_diff.flatten())
+        # Pose rotation in the bone's LOCAL rest frame.
+        # Use the quaternion to discard any accidental pose scale/shear.
+        M_basis = np.array(bone.matrix_basis.to_quaternion().to_matrix())
+        # Bone rest orientation (bone-local -> armature/model space).
+        B = np.array(bone.bone.matrix_local.to_3x3())
+        # Conjugate the local rotation into the model frame the posedirs live in.
+        R_model = B @ M_basis @ B.T
+        # Compute difference from identity, flatten (row-major), append.
+        pose_feature.extend((R_model - np.eye(3)).flatten())
 
     pose_feature = np.array(pose_feature)
     print(f"Generated pose feature vector of length: {len(pose_feature)}")
 
-    # Reshape posedirs if needed
+    # Reshape posedirs to (num_vertices * 3, num_pose_basis) if given as (V, 3, P).
     if len(posedirs.shape) == 3:
         num_vertices, _, num_pose_basis = posedirs.shape
         posedirs_reshaped = np.reshape(posedirs, [-1, num_pose_basis])
     else:
         posedirs_reshaped = posedirs
+        num_pose_basis = posedirs_reshaped.shape[-1]
 
     print(f"Posedirs shape: {posedirs_reshaped.shape}")
     print(f"Pose feature shape: {pose_feature.shape}")
 
-    # Calculate vertex offsets
+    if pose_feature.shape[0] != num_pose_basis:
+        print(
+            f"Warning: pose feature length ({pose_feature.shape[0]}) does not match "
+            f"posedirs basis size ({num_pose_basis}). Correctives not applied."
+        )
+        bpy.ops.object.mode_set(mode="OBJECT")
+        return
+
+    # Corrective offsets in the model (== object-local) frame. Identical math to
+    # smal_torch: pose_feature @ posedirs_mat, where posedirs_mat = posedirs_reshaped.T.
     vertex_offsets = np.reshape(np.matmul(pose_feature, posedirs_reshaped.T), [-1, 3])
 
-    # Switch to object mode to modify vertices
+    # Switch to object mode to modify the rest mesh.
     bpy.ops.object.mode_set(mode="OBJECT")
     bpy.context.view_layer.objects.active = obj
 
-    # Restore base skinned positions
-    base_skinned_positions = np.frombuffer(obj["base_skinned_positions"]).reshape(-1, 3)
-    world_matrix = np.frombuffer(obj["world_matrix"]).reshape(4, 4)
-    world_matrix_inv = np.frombuffer(obj["world_matrix_inv"]).reshape(4, 4)
-
-    # Apply offsets to vertices
+    # Add the correctives to the base rest vertices (object-local space). The
+    # Armature modifier applies skinning afterwards, mirroring v_posed -> LBS.
+    base_vertices = np.asarray(base_vertices, dtype=np.float64)
     for idx, offset in enumerate(vertex_offsets):
-        # Get the base skinned position
-        skinned_pos = base_skinned_positions[idx]
-        # Add corrective offset to the skinned position
-        final_pos = skinned_pos + offset
-        # Update vertex position (convert back to local space)
-        local_pos = world_matrix_inv @ np.append(final_pos, 1.0)
-        obj.data.vertices[idx].co = local_pos[:3]
+        obj.data.vertices[idx].co = base_vertices[idx] + offset
 
-        # Print debug info for first vertex
         if idx == 0:
             print("First vertex:")
-            print(f"  Base position: {base_vertices[idx]}")
-            print(f"  Base skinned position: {skinned_pos}")
-            print(f"  Pose offset: {offset}")
-            print(f"  Final position: {final_pos}")
-            print(f"  Local position: {local_pos[:3]}")
+            print(f"  Base (rest) position: {base_vertices[idx]}")
+            print(f"  Pose offset:          {offset}")
+            print(f"  Final rest position:  {base_vertices[idx] + offset}")
 
     obj.data.update()
     print("Applied pose-dependent corrective shape keys")

--- a/3D_model_prep/smil_importer/operators.py
+++ b/3D_model_prep/smil_importer/operators.py
@@ -1460,7 +1460,19 @@ class SMPL_OT_ApplyPoseCorrectivesOperator(bpy.types.Operator):
                 self.report({"ERROR"}, "No SMPL data found. Please import a SMPL model first.")
                 return {"CANCELLED"}
 
-            apply_pose_correctives(obj, data["posedirs"], data["v_template"])
+            # Bone/joint order must match the posedirs basis (kintree/joint index
+            # order). Reproduce the importer's naming: use stored J_names if present,
+            # otherwise the "J_{i}" fallback that create_armature_and_weights assigns.
+            joint_names = data.get("J_names")
+            if joint_names is None:
+                joints = data.get("J")
+                if joints is not None and hasattr(joints, "__len__"):
+                    num_joints = len(joints)
+                else:
+                    num_joints = int(np.asarray(data["kintree_table"]).shape[1])
+                joint_names = [f"J_{i}" for i in range(num_joints)]
+
+            apply_pose_correctives(obj, data["posedirs"], data["v_template"], joint_names)
             self.report({"INFO"}, "Applied pose correctives successfully.")
             return {"FINISHED"}
         except Exception as e:

--- a/3D_model_prep/smil_importer/operators.py
+++ b/3D_model_prep/smil_importer/operators.py
@@ -9,11 +9,6 @@ import bpy
 import numpy as np
 from mathutils import Vector
 
-try:
-    from sklearn.decomposition import PCA
-except ImportError:  # pragma: no cover
-    PCA = None
-
 from . import state
 from . import dependencies
 from .core_mesh import apply_updated_joint_positions, cleanup_mesh, export_J_regressor_to_npy, make_symmetrical
@@ -884,6 +879,8 @@ class SMPL_OT_LoadAllUnposedMeshes(bpy.types.Operator):
                 requested_components = int(getattr(smpl_tool, "number_of_PC", 1))
                 n_components = max(1, min(requested_components, X.shape[0], X.shape[1]))
 
+                # scikit-learn resolved lazily — issue #92-16.
+                PCA, _ = dependencies.require_sklearn()
                 pca = PCA(n_components=n_components)
                 pca.fit(X)
                 components = pca.components_  # (k, num_joints*6)
@@ -1435,21 +1432,13 @@ class SMPL_OT_ApplyPoseCorrectivesOperator(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        # Only enable if we have an active mesh object with an armature
+        # Enable only for a posed mesh whose embedded SMPL data carries posedirs.
+        # Gate on the cheap ``has_posedirs`` flag written by store_smpl_data rather
+        # than unpickling the whole blob on every redraw (issue #24 / #92-15). The
+        # old ``smpl_data_path`` requirement was never set by the embedded store, so
+        # the operator stayed permanently disabled for newly imported models.
         obj = context.active_object
-        if not (
-            obj and obj.type == "MESH" and obj.find_armature() and "has_smpl_data" in obj and "smpl_data_path" in obj
-        ):
-            return False
-
-        # Check if posedirs exists and is not empty
-        data = get_smpl_data(context)
-        if not data or "posedirs" not in data:
-            return False
-
-        # Check if posedirs is not empty (has actual data)
-        posedirs = data["posedirs"]
-        return isinstance(posedirs, np.ndarray) and posedirs.size > 0
+        return bool(obj and obj.type == "MESH" and obj.find_armature() and obj.get("has_posedirs"))
 
     def execute(self, context):
         obj = context.active_object

--- a/3D_model_prep/smil_importer/pca.py
+++ b/3D_model_prep/smil_importer/pca.py
@@ -5,12 +5,7 @@ import csv
 
 import numpy as np
 
-try:
-    from sklearn.decomposition import PCA
-    from sklearn.covariance import EmpiricalCovariance
-except ImportError:  # pragma: no cover
-    PCA = None
-    EmpiricalCovariance = None
+from .dependencies import require_sklearn
 
 
 def apply_pca_and_create_shapekeys(
@@ -26,7 +21,8 @@ def apply_pca_and_create_shapekeys(
     # Reshape the scans into (n, v*3)
     scans_reshaped = scans.reshape(n, v * 3)
 
-    # Perform PCA
+    # Perform PCA (scikit-learn resolved lazily — issue #92-16).
+    PCA, EmpiricalCovariance = require_sklearn()
     pca = PCA(n_components=num_components)
     pca.fit(scans_reshaped)
 
@@ -231,7 +227,8 @@ def apply_entangled_pca_and_create_shapekeys(
     print(f"Combined features range: {np.min(combined_features):.6f} to {np.max(combined_features):.6f}")
     print("Skipping normalization - feature magnitudes are similar")
 
-    # Perform PCA on normalized features
+    # Perform PCA on normalized features (scikit-learn resolved lazily — #92-16).
+    PCA, EmpiricalCovariance = require_sklearn()
     pca = PCA(n_components=num_components)
     pca.fit(combined_features)
 

--- a/diagnostics/blender_posedirs_check.py
+++ b/diagnostics/blender_posedirs_check.py
@@ -1,0 +1,162 @@
+"""In-Blender verification for the pose-corrective (posedirs) fix -- issue #24.
+
+HOW TO RUN
+----------
+1. Install/enable the ``smil_importer`` add-on in Blender (Edit > Preferences >
+   Add-ons > Install..., pick the zip from ``python 3D_model_prep/build_addon.py``),
+   OR make sure ``smil_importer`` is importable from Blender's Python.
+2. Open Blender's *Scripting* workspace, load this file in the Text Editor, press
+   *Run Script*. Read results in the system console (Window > Toggle System Console
+   on Windows) or the Blender console.
+
+WHAT IT CHECKS
+--------------
+It builds a small synthetic model with the add-on's OWN ``create_mesh_from_pkl`` +
+``create_armature_and_weights`` (so every bone gets the real +Z rest orientation
+that made ``matrix_basis`` live in the wrong frame). It then:
+
+  * sets each non-root bone to a KNOWN model-frame rotation R_model via
+    ``matrix_basis = B^-1 @ R_model @ B``  (B = bone rest matrix),
+  * runs the fixed ``apply_pose_correctives``,
+  * reads the resulting REST vertices back and subtracts v_template to recover the
+    applied corrective offset,
+  * compares against an independent NumPy reference computed straight from posedirs
+    and the same R_model (the smal_torch formula).
+
+PASS  = max abs error ~ 1e-6 or below (float rounding through mathutils).
+It also re-runs to confirm idempotency.
+
+If this passes, Blender's real matrix_local / matrix_basis / to_quaternion
+conventions agree with the fix, and the add-on applies SMPL-style correctives
+correctly. To test the actual SMPL *human* model instead of synthetic data,
+replace the "SYNTHETIC MODEL" block with ``data = load_pkl_file(<path>)`` for
+``basicModel_f_lbs_10_207_0_v1.0.0.pkl`` (needs the add-on's chumpy-aware loader),
+convert arrays with ``np.array(...)``, and reuse the rest unchanged.
+"""
+
+import numpy as np
+import bpy
+from mathutils import Matrix
+
+# --- locate the add-on's functions ---------------------------------------- #
+try:
+    from smil_importer.model_build import (
+        apply_pose_correctives,
+        create_mesh_from_pkl,
+        create_armature_and_weights,
+    )
+except Exception as exc:  # pragma: no cover
+    raise RuntimeError(
+        "Could not import smil_importer. Install/enable the add-on, or add its "
+        "parent folder to sys.path before running this script."
+    ) from exc
+
+
+def rodrigues(axis, angle):
+    axis = np.asarray(axis, dtype=np.float64)
+    axis = axis / (np.linalg.norm(axis) + 1e-12)
+    x, y, z = axis
+    K = np.array([[0, -z, y], [z, 0, -x], [-y, x, 0]], dtype=np.float64)
+    return np.eye(3) + np.sin(angle) * K + (1 - np.cos(angle)) * (K @ K)
+
+
+def reference_offset(posedirs, R_local_model):
+    """smal_torch formula: (V,3,P) posedirs, R_local_model list len J-1 (model frame)."""
+    V, _, P = posedirs.shape
+    posedirs_mat = np.reshape(posedirs, [-1, P]).T  # (P, V*3)
+    pose_feature = np.concatenate([(R - np.eye(3)).flatten() for R in R_local_model])
+    return np.reshape(pose_feature @ posedirs_mat, [V, 3])
+
+
+def clean_scene():
+    for obj in list(bpy.data.objects):
+        bpy.data.objects.remove(obj, do_unlink=True)
+
+
+def build_synthetic_data(seed=0):
+    rng = np.random.default_rng(seed)
+    J = 4  # 1 root + 3 posed joints
+    # joints along +X, so bones are non-trivially oriented (tail = head + +Z)
+    Jloc = np.stack([np.array([i * 0.3, 0.0, 0.0]) for i in range(J)]).astype(np.float64)
+    # a little cloud of vertices around the joints
+    V_per = 6
+    verts = []
+    for j in range(J):
+        verts.append(Jloc[j] + rng.normal(scale=0.05, size=(V_per, 3)))
+    v_template = np.concatenate(verts, axis=0).astype(np.float64)
+    V = v_template.shape[0]
+    # trivial faces (triangles) just so a mesh can be built
+    faces = [(i, (i + 1) % V, (i + 2) % V) for i in range(0, V - 2, 3)]
+    # one-hot skin weights: each vertex bound to its joint
+    weights = np.zeros((V, J), dtype=np.float64)
+    for j in range(J):
+        weights[j * V_per : (j + 1) * V_per, j] = 1.0
+    # chain kintree 0->1->2->3
+    kintree = np.array([[-1, 0, 1, 2], [0, 1, 2, 3]], dtype=np.int64)
+    P = (J - 1) * 9
+    posedirs = (rng.normal(size=(V, 3, P)) * 0.02).astype(np.float64)
+    data = {
+        "v_template": v_template,
+        "f": faces,
+        "J": Jloc,
+        "weights": weights,
+        "kintree_table": kintree,
+        "posedirs": posedirs,
+        "J_names": [f"J_{i}" for i in range(J)],
+    }
+    return data
+
+
+def run():
+    clean_scene()
+    data = build_synthetic_data()
+    J = len(data["J"])
+    joint_names = data["J_names"]
+
+    obj = create_mesh_from_pkl(data, base_name="TEST")
+    armature = create_armature_and_weights(data, obj, base_name="TEST")
+    assert armature is not None, "armature build failed"
+
+    # Known model-frame rotations for joints 1..J-1
+    rng = np.random.default_rng(1)
+    R_model = [rodrigues(rng.normal(size=3), rng.uniform(-0.8, 0.8)) for _ in range(J - 1)]
+
+    # Set each non-root bone's matrix_basis so its model-frame rotation == R_model.
+    bpy.context.view_layer.objects.active = armature
+    bpy.ops.object.mode_set(mode="POSE")
+    for k, name in enumerate(joint_names[1:]):
+        pb = armature.pose.bones.get(name)
+        B4 = pb.bone.matrix_local.to_3x3().to_4x4()  # rest orientation (bone-local -> model)
+        Rm4 = Matrix(np.eye(4))
+        for r in range(3):
+            for c in range(3):
+                Rm4[r][c] = float(R_model[k][r, c])
+        pb.matrix_basis = B4.inverted() @ Rm4 @ B4  # inverse of B @ basis @ B^T
+    bpy.ops.object.mode_set(mode="OBJECT")
+
+    # Reference offset (independent of the add-on)
+    ref = reference_offset(data["posedirs"], R_model)
+
+    # Run the fixed add-on function
+    apply_pose_correctives(obj, data["posedirs"], data["v_template"], joint_names)
+
+    measured = np.array([np.array(v.co) for v in obj.data.vertices]) - data["v_template"]
+    err = np.abs(measured - ref).max()
+    print("\n================ posedirs in-Blender check ================")
+    print(f"  vertices: {measured.shape[0]}   joints: {J}")
+    print(f"  max abs error (add-on vs smal_torch reference): {err:.3e}")
+
+    # Idempotency: run again, result must be identical
+    apply_pose_correctives(obj, data["posedirs"], data["v_template"], joint_names)
+    measured2 = np.array([np.array(v.co) for v in obj.data.vertices]) - data["v_template"]
+    err_idem = np.abs(measured2 - measured).max()
+    print(f"  idempotency (re-apply delta):                   {err_idem:.3e}")
+
+    ok = err < 1e-6 and err_idem < 1e-9
+    print("  RESULT:", "PASS ✅" if ok else "FAIL ❌")
+    print("===========================================================\n")
+    return ok
+
+
+if __name__ == "__main__":
+    run()

--- a/diagnostics/posedirs_validation.py
+++ b/diagnostics/posedirs_validation.py
@@ -1,0 +1,229 @@
+"""Headless validation for the Blender add-on pose-corrective (posedirs) fix.
+
+Issue #24: the add-on's ``apply_pose_correctives`` must reproduce the SMPL/SMAL
+LBS pose-blend-shape term implemented in ``smal_model/smal_torch.py``:
+
+    pose_feature = flatten( R_local[j] - I  for j in 1..J-1 )   # model frame
+    v_offset     = reshape( pose_feature @ posedirs_mat , [V,3] )
+    v_posed      = v_shaped + v_offset                          # BEFORE skinning
+
+The reference builds ``posedirs_mat`` as ``reshape(posedirs,[-1,P]).T`` of shape
+``(P, V*3)`` where ``P = (J-1)*9`` and ``posedirs`` has native shape ``(V,3,P)``.
+
+This script runs entirely in NumPy (no Blender) and demonstrates:
+
+  1. The offset math (reshape + matmul) already matches the reference.
+  2. The OLD add-on is WRONG because it feeds ``bone.matrix_basis`` (expressed in
+     the bone-LOCAL rest frame ``B``) straight into ``pose_feature``. The armature
+     builder gives every bone the SAME non-identity rest orientation
+     (``tail = head + [0,0,0.1]``), so ``B != I`` and the pose rotation is in the
+     wrong basis.
+  3. The FIX -- conjugating each pose rotation back into the model frame via the
+     bone's own rest matrix, ``R_model = B @ matrix_basis @ B.T`` -- reproduces
+     the reference exactly, for constant AND per-bone rest orientations.
+  4. Iterating bones in kintree/joint-index order (not ``pose.bones`` collection
+     order) is required; a permuted order diverges.
+
+Run:  python diagnostics/posedirs_validation.py
+"""
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def rodrigues(axis, angle):
+    """Axis-angle -> 3x3 rotation matrix (model frame)."""
+    axis = np.asarray(axis, dtype=np.float64)
+    axis = axis / (np.linalg.norm(axis) + 1e-12)
+    x, y, z = axis
+    K = np.array([[0, -z, y], [z, 0, -x], [-y, x, 0]], dtype=np.float64)
+    return np.eye(3) + np.sin(angle) * K + (1 - np.cos(angle)) * (K @ K)
+
+
+def random_orthonormal(rng):
+    """A random proper rotation (used as a synthetic bone rest orientation B)."""
+    A = rng.normal(size=(3, 3))
+    Q, _ = np.linalg.qr(A)
+    if np.linalg.det(Q) < 0:
+        Q[:, 0] = -Q[:, 0]
+    return Q
+
+
+# --------------------------------------------------------------------------- #
+# Reference: smal_torch.py posedirs application (offset only, pre-skinning)
+# --------------------------------------------------------------------------- #
+def reference_offset(posedirs_native, R_local_model):
+    """posedirs_native: (V,3,P);  R_local_model: (J-1,3,3) in the MODEL frame."""
+    V, _, P = posedirs_native.shape
+    posedirs_mat = np.reshape(posedirs_native, [-1, P]).T
+    pose_feature = np.concatenate([(R - np.eye(3)).flatten() for R in R_local_model])
+    assert pose_feature.shape[0] == P, (pose_feature.shape, P)
+    v_offset = np.reshape(pose_feature @ posedirs_mat, [V, 3])
+    return v_offset
+
+
+# --------------------------------------------------------------------------- #
+# Add-on math (as written in smil_importer/model_build.py) -- offset only
+# --------------------------------------------------------------------------- #
+def addon_offset(posedirs_native, pose_feature):
+    """Reproduces the add-on's reshape+matmul verbatim, given its pose_feature."""
+    V, _, P = posedirs_native.shape
+    posedirs_reshaped = np.reshape(posedirs_native, [-1, P])  # (V*3, P)
+    v_offset = np.reshape(np.matmul(pose_feature, posedirs_reshaped.T), [-1, 3])
+    return v_offset
+
+
+# --------------------------------------------------------------------------- #
+# Test
+# --------------------------------------------------------------------------- #
+def main():
+    rng = np.random.default_rng(0)
+    V, J = 40, 6  # tiny synthetic model
+    P = (J - 1) * 9
+    posedirs = rng.normal(size=(V, 3, P)) * 0.01
+
+    R_local_model = np.stack([rodrigues(rng.normal(size=3), rng.uniform(-1.0, 1.0)) for _ in range(J - 1)])
+
+    ref = reference_offset(posedirs, R_local_model)
+
+    # Sanity: reshape/matmul is equivalent when fed the SAME rotations.
+    pf_same = np.concatenate([(R - np.eye(3)).flatten() for R in R_local_model])
+    off_same = addon_offset(posedirs, pf_same)
+    err_math = np.abs(off_same - ref).max()
+
+    # Blender emulation: matrix_basis = B.T @ R_model @ B (bone-local storage).
+    B_const = random_orthonormal(rng)
+    B_list_const = [B_const] * (J - 1)
+    B_list_var = [random_orthonormal(rng) for _ in range(J - 1)]
+
+    for label, B_list in [("constant B (current rig)", B_list_const), ("per-bone B (general rig)", B_list_var)]:
+        matrix_basis = [B.T @ R @ B for B, R in zip(B_list, R_local_model)]
+
+        pf_old = np.concatenate([(Mb - np.eye(3)).flatten() for Mb in matrix_basis])
+        off_old = addon_offset(posedirs, pf_old)
+        err_old = np.abs(off_old - ref).max()
+
+        R_recovered = [B @ Mb @ B.T for B, Mb in zip(B_list, matrix_basis)]
+        pf_fix = np.concatenate([(R - np.eye(3)).flatten() for R in R_recovered])
+        off_fix = addon_offset(posedirs, pf_fix)
+        err_fix = np.abs(off_fix - ref).max()
+
+        print(f"[{label}]")
+        print(f"    OLD add-on max abs err vs reference : {err_old:.3e}   <- BUG (nonzero)")
+        print(f"    FIXED     max abs err vs reference : {err_fix:.3e}   <- OK")
+
+    # Bone-ordering check.
+    perm = rng.permutation(J - 1)
+    R_perm = R_local_model[perm]
+    pf_perm = np.concatenate([(R - np.eye(3)).flatten() for R in R_perm])
+    off_perm = addon_offset(posedirs, pf_perm)
+    err_perm = np.abs(off_perm - ref).max()
+
+    print("\n[bone ordering]")
+    print(f"    permuted joint order max abs err   : {err_perm:.3e}   <- must iterate in kintree order")
+
+    print("\n[reshape/matmul identity]")
+    print(f"    add-on vs reference (same rots)    : {err_math:.3e}   <- reshape math already correct")
+
+    assert err_math < 1e-9, "reshape/matmul should already match the reference"
+    Mb = [B_const.T @ R @ B_const for R in R_local_model]
+    Rr = [B_const @ m @ B_const.T for m in Mb]
+    pf = np.concatenate([(R - np.eye(3)).flatten() for R in Rr])
+    assert np.abs(addon_offset(posedirs, pf) - ref).max() < 1e-9, "fix must match reference"
+    print("\nAll assertions passed: the B-conjugation fix reproduces smal_torch exactly.")
+
+    mirror_end_to_end_test()
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end mirror: run the *exact* logic of the rewritten
+# smil_importer/model_build.py::apply_pose_correctives with mock Blender objects
+# (no bpy), including joint-name ordering, and confirm it matches the reference.
+# --------------------------------------------------------------------------- #
+class _MockMatrix:
+    def __init__(self, m):
+        self.m = np.asarray(m, dtype=np.float64)
+
+    def to_3x3(self):
+        return self.m[:3, :3]
+
+    def to_quaternion(self):
+        return _MockQuat(self.m[:3, :3])
+
+
+class _MockQuat:
+    def __init__(self, r):
+        self.r = r
+
+    def to_matrix(self):
+        return self.r
+
+
+class _MockBoneData:
+    def __init__(self, B):
+        self.matrix_local = _MockMatrix(B)
+
+
+class _MockPoseBone:
+    def __init__(self, B, matrix_basis):
+        self.bone = _MockBoneData(B)
+        self.matrix_basis = _MockMatrix(matrix_basis)
+
+
+def _addon_pose_feature(pose_bones):
+    """Verbatim copy of the pose_feature loop in the rewritten function."""
+    pose_feature = []
+    for bone in pose_bones:
+        M_basis = np.array(bone.matrix_basis.to_quaternion().to_matrix())
+        B = np.array(bone.bone.matrix_local.to_3x3())
+        R_model = B @ M_basis @ B.T
+        pose_feature.extend((R_model - np.eye(3)).flatten())
+    return np.array(pose_feature)
+
+
+def mirror_end_to_end_test():
+    rng = np.random.default_rng(7)
+    V, J = 30, 5
+    P = (J - 1) * 9
+    posedirs = rng.normal(size=(V, 3, P)) * 0.02
+    base_vertices = rng.normal(size=(V, 3))
+
+    R_local_model = np.stack([rodrigues(rng.normal(size=3), rng.uniform(-1, 1)) for _ in range(J - 1)])
+    ref_offset = reference_offset(posedirs, R_local_model)
+    ref_final = base_vertices + ref_offset
+
+    # Register bones under names J_1..J_{J-1} in a SHUFFLED dict to prove the
+    # joint-name lookup restores the correct kintree order.
+    joint_names = [f"J_{i}" for i in range(J)]  # J_0 is the root, skipped
+    bones_by_name = {}
+    for j in range(1, J):
+        B = random_orthonormal(rng)
+        Mb = B.T @ R_local_model[j - 1] @ B
+        bones_by_name[joint_names[j]] = _MockPoseBone(B, Mb)
+    shuffled = list(bones_by_name.items())
+    rng.shuffle(shuffled)
+    bones_by_name = dict(shuffled)  # collection order != joint order
+
+    pose_bones = [bones_by_name[name] for name in joint_names[1:]]
+    pose_feature = _addon_pose_feature(pose_bones)
+
+    posedirs_reshaped = np.reshape(posedirs, [-1, P])
+    offsets = np.reshape(np.matmul(pose_feature, posedirs_reshaped.T), [-1, 3])
+    final = np.asarray(base_vertices) + offsets
+
+    err = np.abs(final - ref_final).max()
+    print("\n[end-to-end mirror of rewritten apply_pose_correctives]")
+    print(f"    final rest verts max abs err vs reference : {err:.3e}")
+    assert err < 1e-9, "rewritten function logic must match the reference"
+
+    final2 = np.asarray(base_vertices) + np.reshape(np.matmul(pose_feature, posedirs_reshaped.T), [-1, 3])
+    assert np.abs(final2 - final).max() < 1e-12
+    print("    idempotent re-application                 : OK")
+    print("    joint-name ordering restores kintree order: OK")
+    print("\nEnd-to-end mirror passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

## Problem
The add-on's `apply_pose_correctives` fed each pose bone's `matrix_basis` — the
rotation expressed in the **bone-local** rest frame — straight into the SMPL/SMAL
pose-blend-shape (`posedirs`) term. But `posedirs` expect the joint rotation in the
**model frame**. Since the armature builder gives every bone the same non-identity
rest orientation (`tail = head + [0,0,0.1]`), the bone-local frame `B ≠ I`, so the
correctives were computed in the wrong basis and produced incorrect posed geometry.
Bones were also iterated in `pose.bones` collection order instead of the
kintree/joint-index order the `posedirs` basis was built in.

## Fix
- Conjugate each pose rotation into the model frame before building `pose_feature`:
  `R_model = B @ matrix_basis @ Bᵀ` (B = bone rest matrix).
- Iterate bones in kintree/joint-index order, resolved via `J_names` (falling back
  to the `J_{i}` names the importer assigns) rather than collection order.
- `operators.py` now passes the resolved joint ordering into `apply_pose_correctives`.

## Validation
Two diagnostics under `diagnostics/`:
- `posedirs_validation.py` — headless NumPy reproduction of the `smal_torch.py`
  reference. Shows the old code is wrong, the conjugation fix matches the reference
  exactly for constant and per-bone rest orientations, and that joint order matters.
- `blender_posedirs_check.py` — in-Blender end-to-end check: applies known
  model-frame rotations, runs the fixed corrective, recovers the offset from rest
  vertices, and compares against the NumPy reference.

Closes #24.